### PR TITLE
Work with redshift

### DIFF
--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -25,7 +25,7 @@ INNER JOIN pg_namespace ns ON cls.relnamespace = ns.oid
 INNER JOIN (SELECT table_name, table_type
 FROM information_schema.tables
 WHERE table_schema != 'pg_catalog' AND table_schema != 'information_schema'
-AND table_catalog = $1) tbl ON pg_class.relname = tbl.table_name
+AND table_catalog = $1) tbl ON cls.relname = tbl.table_name
 ORDER BY oid`, s.Name)
 	defer tableRows.Close()
 	if err != nil {


### PR DESCRIPTION
#26 

Amazon Redshift can't use "'table_name'.regclass::oid".
Use "pg_catalog.pg_class" table, instead of it.

Test result of "TestAnalyzeView".

```
=== RUN   TestAnalyzeView
--- PASS: TestAnalyzeView (0.13s)
PASS
coverage: 85.8% of statements
ok      github.com/watarukura/tbls/drivers/postgres     0.145s  coverage: 85.8% of statements
```