### PR TITLE
Fix duplicate output when multiple schemas have the same named table

### DIFF
--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -38,7 +38,7 @@ INNER JOIN pg_namespace ns ON cls.relnamespace = ns.oid
 INNER JOIN (SELECT table_name, table_type, table_schema
 FROM information_schema.tables
 WHERE table_schema != 'pg_catalog' AND table_schema != 'information_schema'
-AND table_catalog = $1) tbl ON cls.relname = tbl.table_name
+AND table_catalog = $1) tbl ON cls.relname = tbl.table_name AND ns.nspname = tbl.table_schema
 ORDER BY oid`, s.Name)
 	defer tableRows.Close()
 	if err != nil {


### PR DESCRIPTION
I fixed a bug that two same named tables in diffrent schemas are listed multiple times in the output Markdown file.

### Version

* tbls 1.18.0
* PostgreSQL 10.10
* macOS 10.14.6

### Steps to reproduce

1. Run PostgreSQL server
    ```shell
    $ cd $GOPATH/src/github.com/k1LoW/tbls
    $ docker-compose up postgres
    ```
1. Create a testdata initialization SQL file.
    ```sql
    $ vi init.sql
    CREATE SCHEMA schema1;
    CREATE SCHEMA schema2;
    -------------------------------------------------
    SET search_path TO schema1;
    CREATE TABLE users (
      id serial PRIMARY KEY,
      username varchar (50) UNIQUE NOT NULL CHECK(char_length(username) > 4),
      password varchar (50) NOT NULL,
      email varchar (355) UNIQUE NOT NULL
    );
    -------------------------------------------------
    SET search_path TO schema2;
    CREATE TABLE users (
      id serial PRIMARY KEY,
      username varchar (50) UNIQUE NOT NULL CHECK(char_length(username) > 4),
      password varchar (50) NOT NULL,
      email varchar (355) UNIQUE NOT NULL
    );
    ```
1. Execute init.sql via psql command
    ```shell
    $ psql -h localhost -p 55432 -U postgres testdb
    localhost postgres@testdb=# \i init.sql
    ```
1. Execute tbls
    ```shell
    $ tbls doc -f pg://postgres:pgpass@localhost:55432/testdb?sslmode=disable result
    $ less result/README.md
    ```

### Expected behaviour (This PR)

```
# testdb

## Tables

| Name | Columns | Comment | Type |
| ---- | ------- | ------- | ---- |
| [schema1.users](schema1.users.md) | 4 | Users table | BASE TABLE |
| [schema2.users](schema2.users.md) | 4 | Users table | BASE TABLE |

...
```

### Actual behaviour (Current master branch)

```
# testdb

## Tables

| Name | Columns | Comment | Type |
| ---- | ------- | ------- | ---- |
| [schema1.users](schema1.users.md) | 4 | Users table | BASE TABLE |
| [schema2.users](schema2.users.md) | 4 | Users table | BASE TABLE |
| [schema1.users](schema1.users.md) | 4 | Users table | BASE TABLE |
| [schema2.users](schema2.users.md) | 4 | Users table | BASE TABLE |

...
```

### Implementation note

Current

```sql
localhost postgres@testdb=# SELECT cls.oid, relnamespace, ns.nspname, relname, tbl.table_schema FROM pg_class cls
INNER JOIN pg_namespace ns on cls.relnamespace = ns.oid
INNER JOIN (SELECT table_name, table_type, table_schema FROM information_schema.tables
    WHERE table_schema != 'pg_catalog' AND table_schema != 'information_schema') tbl
    ON cls.relname = tbl.table_name;
  oid  | relnamespace | nspname | relname | table_schema
-------+--------------+---------+---------+--------------
 16404 |        16388 | schema2 | users   | schema1    # <-- schema mismatch
 16391 |        16387 | schema1 | users   | schema1
 16404 |        16388 | schema2 | users   | schema2
 16391 |        16387 | schema1 | users   | schema2    # <-- schema mismatch
(4 rows)
```

Fixed

```sql
localhost postgres@testdb=# SELECT cls.oid, relnamespace, ns.nspname, relname, tbl.table_schema FROM pg_class cls
INNER JOIN pg_namespace ns on cls.relnamespace = ns.oid
INNER JOIN (SELECT table_name, table_type, table_schema FROM information_schema.tables
    WHERE table_schema != 'pg_catalog' AND table_schema != 'information_schema') tbl
    ON cls.relname = tbl.table_name AND ns.nspname = tbl.table_schema;
  oid  | relnamespace | nspname | relname | table_schema                                                     │tax error at or near ")" at character 151
-------+--------------+---------+---------+--------------                                                    │postgres_1  | 2019-08-15 06:53:09.719 UTC [118] STATEMENT: 
 16391 |        16387 | schema1 | users   | schema1                                                          │ SELECT table_name, table_type, table_schema
 16404 |        16388 | schema2 | users   | schema2                                                          │postgres_1  |   FROM information_schema.tables
(2 rows)
```
