### PR TITLE
add Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Document a database with one command.
 $ tbls doc postgres://dbuser:dbpass@hostname:5432/dbname
 ```
 
+Using docker image.
+
+```console
+$ docker run --rm -v $PWD:/work k1low/tbls doc postgres://dbuser:dbpass@hostname:5432/dbname
+```
+
 ## Install
 
 **homebrew tap:**
@@ -64,6 +70,12 @@ Download binary from [releases page](https://github.com/k1LoW/tbls/releases)
 
 ```console
 $ go get github.com/k1LoW/tbls
+```
+
+**docker:**
+
+```console
+$ docker pull k1low/tbls:latest
 ```
 
 ## Getting Started

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:latest
+
+ENTRYPOINT ["tbls"]
+WORKDIR /work
+VOLUME ["/work"]
+
+ENV TBLS_VERSION=v1.18.1
+RUN set -x \
+        && wget https://github.com/k1LoW/tbls/releases/download/${TBLS_VERSION}/tbls_${TBLS_VERSION}_linux_amd64.tar.gz \
+        && tar xzf tbls_${TBLS_VERSION}_linux_amd64.tar.gz \
+        && mv tbls /usr/local/bin/ \
+        && rm tbls_${TBLS_VERSION}_linux_amd64.tar.gz


### PR DESCRIPTION
Thank you for making cool tool for DB.
I think this tool is useful with docker, so I wrote simple Dockerfile.

with README.md updated, but it should work after docker hub configuration.
( Why the tag `k1low/tbls` is lowercase that is because from docker's restriction `invalid reference format: repository name must be lowercase`.)

You can use in `docker-compose.yml` too like this.

```yml
version: '3.7'
services:
  tbls:
    # from docker hub
    # image: k1low/tbls

    # from current docker/Dockerfile
    build: ./docker

    depends_on:
      - db_service
    volumes:
      - .:/work
    command: "doc postgres://dbuser:dbpass@db_service:5432/dbname"
```
