### PR TITLE
Change default shell to /bin/sh

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,3 +12,5 @@ RUN set -x \
         && source <(curl -sL https://git.io/use-tbls) \
         && which tbls | xargs -I{} mv {} /usr/local/bin/tbls \
         && apk del bash curl
+
+SHELL ["/bin/sh", "-c"]


### PR DESCRIPTION
This Dockerfile cant't build because of default shell.
```
FROM k1low/tbls

RUN apk add --update --no-cache \
           graphviz \
           ttf-freefont
```

Error message: 
```
 failed to build: OCI runtime create failed: container_linux.go:346: starting container process caused "exec: \"/bin/bash\": stat /bin/bash: no such file or directory": unknown
```