### PR TITLE
Fix #188 'near "." Syntax Error'

### DIFF
--- a/drivers/sqlite/sqlite.go
+++ b/drivers/sqlite/sqlite.go
@@ -246,7 +246,7 @@ WHERE name != 'sqlite_sequence' AND (type = 'table' OR type = 'view');`)
 				col                string
 				cols               []string
 			)
-			row, err := l.db.Query(fmt.Sprintf("PRAGMA index_info(%s)", indexName))
+			row, err := l.db.Query(fmt.Sprintf("PRAGMA index_info(`%s`)", indexName))
 			if err != nil {
 				return errors.WithStack(err)
 			}


### PR DESCRIPTION
missed quotes at  "PRAGMA index_info" query led to incorrect processing some index names. 