### PR TITLE
Fix basename issue and simplify code

### DIFF
--- a/internal/zsh_completions.go
+++ b/internal/zsh_completions.go
@@ -54,7 +54,7 @@ function {{$cmdPath}} {
     commands=({{range .Commands}}{{if not .Hidden}}
       "{{.Name}}:{{.Short}}"{{end}}{{end}}
     )
-    subcommands=( ${(@f)"$(print -l ${^path}/*(-*N) | grep tbls- | xargs basename | sort | uniq | sed -e 's/^tbls-\(.*\)$/\1:tbls-\1/')"} ) 
+    subcommands=( ${(@f)"$(print -l ${^path}/tbls-*(-*N:t) | sort -u | sed -e 's/^tbls-\(.*\)$/\1:tbls-\1/')"} )
     commands+=($subcommands)    
     _describe "command" commands
     ;;


### PR DESCRIPTION
`basename` command cannot take multiple arguments in POSIX specification.
Coreutils version has `--multiple` option however it is not portable.
So use zsh `:t` modifier instead. You can also avoid this issue by using `xargs -n1` however it makes slow.

Following error occurs if user installs multiple tbls sub-commands

```
 basename: extra operand ‘/home/shohei/bin/tbls-foo’
```

### Reference about `:t` modifier

- http://zsh.sourceforge.net/Doc/Release/Expansion.html#Modifiers

> t [ digits ]
> Remove all leading pathname components, leaving the final component (tail). This works like ‘basename’. Any trailing slashes are first removed.

