### PR TITLE
[BREAKING]Set path of temporary generated schema.json (instead of JSON string) to TBLS_SCHEMA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ test_spanner:
 test_ext_subcommand: build
 	@echo hello | env PATH="./testdata/bin:${PATH}" ./tbls echo | grep 'STDIN=hello' > /dev/null
 	@env PATH="./testdata/bin:${PATH}" ./tbls echo -c ./testdata/ext_subcommand_tbls.yml | grep 'TBLS_DSN=pg://postgres:pgpass@localhost:55432/testdb?sslmode=disable' > /dev/null
-	@env PATH="./testdata/bin:${PATH}" ./tbls echo -c ./testdata/ext_subcommand_tbls.yml | grep 'TBLS_SCHEMA={' > /dev/null
+	@env PATH="./testdata/bin:${PATH}" ./tbls echo -c ./testdata/ext_subcommand_tbls.yml | grep 'TBLS_SCHEMA=/' > /dev/null
 	@env PATH="./testdata/bin:${PATH}" ./tbls echo -c ./testdata/ext_subcommand_tbls.yml | grep 'TBLS_CONFIG_PATH=' | grep 'testdata/ext_subcommand_tbls.yml' > /dev/null
 	@env PATH="./testdata/bin:${PATH}" TBLS_DSN=pg://postgres:pgpass@localhost:55432/testdb?sslmode=disable ./tbls echo | grep 'TBLS_DSN=pg://postgres:pgpass@localhost:55432/testdb?sslmode=disable' > /dev/null
 	@echo hello | env PATH="./testdata/bin:${PATH}" ./tbls echo -c ./testdata/ext_subcommand_tbls.yml | grep 'STDIN=hello' > /dev/null

--- a/datasource/datasource.go
+++ b/datasource/datasource.go
@@ -155,7 +155,7 @@ func AnalyzeJSONString(str string) (*schema.Schema, error) {
 func AnalyzeJSONStringOrFile(strOrPath string) (s *schema.Schema, err error) {
 	s = &schema.Schema{}
 	var buf io.Reader
-	if strOrPath[0:] == "{" {
+	if strings.HasPrefix(strOrPath, "{") {
 		buf = bytes.NewBufferString(strOrPath)
 	} else {
 		buf, err = os.Open(filepath.Clean(strOrPath))

--- a/datasource/datasource.go
+++ b/datasource/datasource.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -144,10 +146,23 @@ func AnalyzeJSON(urlstr string) (*schema.Schema, error) {
 	return s, nil
 }
 
-// AnalyzeJSONString analyze JSON string
+// Deprecated
 func AnalyzeJSONString(str string) (*schema.Schema, error) {
-	s := &schema.Schema{}
-	buf := bytes.NewBufferString(str)
+	return AnalyzeJSONStringOrFile(str)
+}
+
+// AnalyzeJSONStringOrFile analyze JSON string or JSON file
+func AnalyzeJSONStringOrFile(strOrPath string) (s *schema.Schema, err error) {
+	s = &schema.Schema{}
+	var buf io.Reader
+	if strOrPath[0:] == "{" {
+		buf = bytes.NewBufferString(strOrPath)
+	} else {
+		buf, err = os.Open(filepath.Clean(strOrPath))
+		if err != nil {
+			return s, errors.WithStack(err)
+		}
+	}
 	dec := json.NewDecoder(buf)
 	if err := dec.Decode(s); err != nil {
 		return s, errors.WithStack(err)


### PR DESCRIPTION
`ARG_MAX` limit was sometimes exceeded when large database schema was set as an environment variable