### PR TITLE
Remove array_remove() for supporting PostgreSQL 9.2

### DIFF
--- a/datasource/datasource_test.go
+++ b/datasource/datasource_test.go
@@ -68,7 +68,7 @@ func TestAnalyzeTables(t *testing.T) {
 		want := tt.tableCount
 		got := len(schema.Tables)
 		if got != want {
-			t.Errorf("got %v\nwant %v", got, want)
+			t.Errorf("%v: got %v\nwant %v", tt.dsn, got, want)
 		}
 	}
 }


### PR DESCRIPTION
Fix #251 

Remove array_remove for supporting PostgreSQL 9.2.