### PR TITLE
Add baseUrl flag for links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ testdb.sqlite3
 .tbls.yml
 *client_secrets.json*
 .DS_Store
+.idea

--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -198,7 +198,7 @@ func init() {
 	docCmd.Flags().BoolVarP(&withoutER, "without-er", "", false, "no generate ER diagrams")
 	docCmd.Flags().BoolVarP(&adjust, "adjust-table", "j", false, "adjust column width of table")
 	docCmd.Flags().StringVarP(&when, "when", "", "", "command execute condition")
-	docCmd.Flags().StringVarP(&baseUrl, "baseUrl", "b", "", "base url for links")
+	docCmd.Flags().StringVarP(&baseUrl, "base-url", "b", "", "base url for links")
 	if err := docCmd.MarkZshCompPositionalArgumentFile(2); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)

--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -162,6 +162,7 @@ func loadDocArgs(args []string) ([]config.Option, error) {
 	if withoutER {
 		options = append(options, config.ERSkip(withoutER))
 	}
+	options = append(options, config.BaseUrl(baseUrl))
 	if len(args) == 2 {
 		options = append(options, config.DSNURL(args[0]))
 		options = append(options, config.DocPath(args[1]))
@@ -197,6 +198,7 @@ func init() {
 	docCmd.Flags().BoolVarP(&withoutER, "without-er", "", false, "no generate ER diagrams")
 	docCmd.Flags().BoolVarP(&adjust, "adjust-table", "j", false, "adjust column width of table")
 	docCmd.Flags().StringVarP(&when, "when", "", "", "command execute condition")
+	docCmd.Flags().StringVarP(&baseUrl, "baseUrl", "b", "", "base url for links")
 	if err := docCmd.MarkZshCompPositionalArgumentFile(2); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,6 +56,8 @@ var erFormat string
 // when is a option that command execute condition
 var when string
 
+var baseUrl string
+
 const rootUsageTemplate = `Usage:{{if .Runnable}}{{if ne .UseLine "tbls [flags]" }}
   {{.UseLine}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
   {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}

--- a/config/config.go
+++ b/config/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	MergedDict  dict.Dict            `yaml:"-"`
 	Path        string               `yaml:"-"`
 	root        string               `yaml:"-"`
+	BaseUrl     string               `yaml:"baseUrl,omitempty"`
 }
 
 type DSN struct {
@@ -150,6 +151,16 @@ func ERFormat(erFormat string) Option {
 func Distance(distance int) Option {
 	return func(c *Config) error {
 		c.ER.Distance = &distance
+		return nil
+	}
+}
+
+// BaseUrl return Option set Config.BaseUrl
+func BaseUrl(baseUrl string) Option {
+	return func(c *Config) error {
+		if baseUrl != "" {
+			c.BaseUrl = baseUrl
+		}
 		return nil
 	}
 }

--- a/output/md/md.go
+++ b/output/md/md.go
@@ -45,6 +45,7 @@ func (m *Md) OutputSchema(wr io.Writer, s *schema.Schema) error {
 	templateData := m.makeSchemaTemplateData(s, m.config.Format.Adjust)
 	templateData["er"] = m.er
 	templateData["erFormat"] = m.config.ER.Format
+	templateData["baseUrl"] = m.config.BaseUrl
 	err = tmpl.Execute(wr, templateData)
 	if err != nil {
 		return errors.WithStack(err)
@@ -62,6 +63,7 @@ func (m *Md) OutputTable(wr io.Writer, t *schema.Table) error {
 	templateData := m.makeTableTemplateData(t, m.config.Format.Adjust)
 	templateData["er"] = m.er
 	templateData["erFormat"] = m.config.ER.Format
+	templateData["baseUrl"] = m.config.BaseUrl
 
 	err = tmpl.Execute(wr, templateData)
 	if err != nil {
@@ -263,7 +265,7 @@ func (m *Md) makeSchemaTemplateData(s *schema.Schema, adjust bool) map[string]in
 	}
 	for _, t := range s.Tables {
 		data := []string{
-			fmt.Sprintf("[%s](%s.md)", t.Name, t.Name),
+			fmt.Sprintf("[%s](%s%s.md)", t.Name, m.config.BaseUrl, t.Name),
 			fmt.Sprintf("%d", len(t.Columns)),
 			t.Comment,
 			t.Type,
@@ -305,7 +307,7 @@ func (m *Md) makeTableTemplateData(t *schema.Table, adjust bool) map[string]inte
 			if _, ok := cEncountered[r.Table.Name]; ok {
 				continue
 			}
-			childRelations = append(childRelations, fmt.Sprintf("[%s](%s.md)", r.Table.Name, r.Table.Name))
+			childRelations = append(childRelations, fmt.Sprintf("[%s](%s%s.md)", r.Table.Name, m.config.BaseUrl, r.Table.Name))
 			cEncountered[r.Table.Name] = true
 		}
 		parentRelations := []string{}
@@ -314,7 +316,7 @@ func (m *Md) makeTableTemplateData(t *schema.Table, adjust bool) map[string]inte
 			if _, ok := pEncountered[r.ParentTable.Name]; ok {
 				continue
 			}
-			parentRelations = append(parentRelations, fmt.Sprintf("[%s](%s.md)", r.ParentTable.Name, r.ParentTable.Name))
+			parentRelations = append(parentRelations, fmt.Sprintf("[%s](%s%s.md)", r.ParentTable.Name, m.config.BaseUrl, r.ParentTable.Name))
 			pEncountered[r.ParentTable.Name] = true
 		}
 		data := []string{

--- a/output/md/templates/index.md.tmpl
+++ b/output/md/templates/index.md.tmpl
@@ -21,7 +21,7 @@
 
 ## {{ "Relations" | lookup }}
 
-![er](schema.{{ .erFormat }})
+![er]({{ .baseUrl }}schema.{{ .erFormat }})
 {{- end }}
 
 ---

--- a/output/md/templates/table.md.tmpl
+++ b/output/md/templates/table.md.tmpl
@@ -53,7 +53,7 @@
 {{- if .er -}}
 ## {{ "Relations" | lookup }}
 
-![er]({{ .Table.Name }}.{{ .erFormat }})
+![er]({{ .baseUrl }}{{ .Table.Name }}.{{ .erFormat }})
 
 {{ end -}}
 ---


### PR DESCRIPTION
Hello!

I want to publish our .md files to code hosting service of aliyun, but links are not correct, because lacking of base url.
So I add a flag baseUrl to support this feature.

Usage:
`tbls doc -b xxx/schema/`

the `xxx/schema/` will be added to prefix of all links in .md files. For example: `![er](xxx/schema/schema.png)`.
So the er picture will show.
