### PR TITLE
Handling empty env vars in strict mode

### DIFF
--- a/use
+++ b/use
@@ -18,7 +18,7 @@ fi
 TBLS_ARCHIVE="/tmp/tbls.${TBLS_EXT}"
 
 TBLS_RELEASES_URL="https://github.com/k1LoW/tbls/releases"
-test -z "$TBLS_TMPDIR" && TBLS_TMPDIR="$(mktemp -d)"
+test -z "${TBLS_TMPDIR:-}" && TBLS_TMPDIR="$(mktemp -d)"
 
 last_version() {
   curl -sL -o /dev/null -w %{url_effective} "$TBLS_RELEASES_URL/latest" |
@@ -28,8 +28,8 @@ last_version() {
 }
 
 download() {
-  test -z "$TBLS_VERSION" && TBLS_VERSION="$(last_version)"
-  test -z "$TBLS_VERSION" && {
+  test -z "${TBLS_VERSION:-}" && TBLS_VERSION="$(last_version)"
+  test -z "${TBLS_VERSION:-}" && {
     echo "Unable to get tbls version." >&2
     exit 1
   }


### PR DESCRIPTION
We use `set -o nounset` and this is causing the quick install script to fail:

```
/tmp/use-tbls.tmp: line 21: TBLS_TMPDIR: unbound variable
```

Solution: https://stackoverflow.com/a/11264114/3073656