### PR TITLE
Fix 'no such file or directory error' when --rm-dist and no directory

### DIFF
--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -78,13 +78,15 @@ var docCmd = &cobra.Command{
 		}
 
 		if rmDist && c.DocPath != "" {
-			docs, err := ioutil.ReadDir(c.DocPath)
-			if err != nil {
-				return errors.WithStack(err)
-			}
-			for _, f := range docs {
-				if err := os.RemoveAll(filepath.Join(c.DocPath, f.Name())); err != nil {
+			if _, err := os.Lstat(c.DocPath); err == nil {
+				docs, err := ioutil.ReadDir(c.DocPath)
+				if err != nil {
 					return errors.WithStack(err)
+				}
+				for _, f := range docs {
+					if err := os.RemoveAll(filepath.Join(c.DocPath, f.Name())); err != nil {
+						return errors.WithStack(err)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
```console
$ rm -rf sample/mysql
$ ./tbls doc my://root:mypass@localhost:33308/testdb -c testdata/test_tbls.yml -f sample/mysql --rm-dist
open sample/mysql: no such file or directory
```