### PR TITLE
Add PostgreSQL SSL mode in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,6 @@ Using docker image.
 $ docker run --rm -v $PWD:/work k1low/tbls doc postgres://dbuser:dbpass@hostname:5432/dbname
 ```
 
-In SSL mode, add "?sslmode=disable"
-For example:
-```console
-$ docker run --rm -v $PWD:/work k1low/tbls doc postgres://dbuser:dbpass@hostname:5432/dbname?sslmode=disable
-```
-
 ## Install
 
 **deb:**
@@ -383,6 +377,12 @@ dsn: postgres://dbuser:dbpass@hostname:5432/dbname
 ``` yaml
 # .tbls.yml
 dsn: pg://dbuser:dbpass@hostname:5432/dbname
+```
+
+In SSL mode, add "?sslmode=disable"
+For example:
+``` yaml
+dsn: pg://dbuser:dbpass@hostname:5432/dbname?sslmode=disable
 ```
 
 **MySQL:**

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Using docker image.
 $ docker run --rm -v $PWD:/work k1low/tbls doc postgres://dbuser:dbpass@hostname:5432/dbname
 ```
 
+In SSL mode, add "?sslmode=disable"
+For example:
+```console
+$ docker run --rm -v $PWD:/work k1low/tbls doc postgres://dbuser:dbpass@hostname:5432/dbname?sslmode=disable
+```
+
 ## Install
 
 **deb:**

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ dsn: postgres://dbuser:dbpass@hostname:5432/dbname
 dsn: pg://dbuser:dbpass@hostname:5432/dbname
 ```
 
-In SSL mode, add "?sslmode=disable"
+When you want to disable SSL mode, add "?sslmode=disable"
 For example:
 ``` yaml
 dsn: pg://dbuser:dbpass@hostname:5432/dbname?sslmode=disable


### PR DESCRIPTION
In README, there is no statement about PostgreSQL in SSL mode.
So, I would like to suggest to add it.

Refer to:
https://github.com/k1LoW/tbls/issues/300