### PR TITLE
fix: Allow mssql driver to work with version older than 2017

### DIFF
--- a/drivers/mssql/mssql.go
+++ b/drivers/mssql/mssql.go
@@ -557,3 +557,4 @@ func convertSystemNamed(name string, isSytemNamed bool) string {
 	}
 	return name
 }
+


### PR DESCRIPTION
Changes the SQL statements to remove the STRING_AGG statement.
This change should still work with versions of MSSQL > 2017.

Fixes: #306

Signed-off-by: Todd Davis <tjdavis3@gmail.com>