### PR TITLE
Use "ghcr.io/k1low/tbls" instead of "k1low/tbls"

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ tbls doc postgres://dbuser:dbpass@hostname:5432/dbname
 Using docker image.
 
 ```console
-$ docker run --rm -v $PWD:/work k1low/tbls doc postgres://dbuser:dbpass@hostname:5432/dbname
+$ docker run --rm -v $PWD:/work ghcr.io/k1low/tbls doc postgres://dbuser:dbpass@hostname:5432/dbname
 ```
 
 ## Install


### PR DESCRIPTION
## About

- Modify `README.md`.
- Currently, the primary container registry is `ghcr.io`, maybe.
