### PR TITLE
Fix the order of table columns including columnLabels

### DIFF
--- a/output/md/md.go
+++ b/output/md/md.go
@@ -551,14 +551,14 @@ func (m *Md) makeTableTemplateData(t *schema.Table) map[string]interface{} {
 		if t.HasColumnWithExtraDef() {
 			data = append(data, mdEscRep.Replace(c.ExtraDef))
 		}
-		if t.HasColumnWithLabels() {
-			data = append(data, output.LabelJoin(c.Labels))
-		}
 		data = append(data,
 			strings.Join(childRelations, " "),
 			strings.Join(parentRelations, " "),
 			c.Comment,
 		)
+		if t.HasColumnWithLabels() {
+			data = append(data, output.LabelJoin(c.Labels))
+		}
 		columnsData = append(columnsData, data)
 	}
 

--- a/sample/sqlite/users.md
+++ b/sample/sqlite/users.md
@@ -22,10 +22,10 @@ CREATE TABLE users (
 
 | Name | Type | Default | Nullable | Children | Parents | Comment | Labels |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- | ------ |
-| id | INTEGER |  | true |  | [user_options](user_options.md) [posts](posts.md) [comments](comments.md) [comment_stars](comment_stars.md) [logs](logs.md) |  |  |
+| id | INTEGER |  | true | [user_options](user_options.md) [posts](posts.md) [comments](comments.md) [comment_stars](comment_stars.md) [logs](logs.md) |  |  |  |
 | username | TEXT |  | false |  |  |  |  |
-| password | TEXT |  | false | `secure` `encrypted` |  |  |  |
-| email | TEXT |  | false | `secure` |  |  |  |
+| password | TEXT |  | false |  |  |  | `secure` `encrypted` |
+| email | TEXT |  | false |  |  |  | `secure` |
 | created | NUMERIC |  | false |  |  |  |  |
 | updated | NUMERIC |  | true |  |  |  |  |
 


### PR DESCRIPTION
Follow up of #328.

Labels introduced by `columnLabels` are placed at the wrong column (the `Children` column) in the output documents. This PR fixes the order of those columns.