### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ $ tbls doc postgres://dbuser:dbpass@hostname:5432/dbname
 Using docker image.
 
 ```console
-$ docker run --rm -v $PWD:/work ghcr.io/k1low/tbls doc postgres://dbuser:dbpass@hostname:5432/dbname
+$ docker run --rm -v $PWD:/work -w /work ghcr.io/k1low/tbls doc postgres://dbuser:dbpass@hostname:5432/dbname
 ```
 
 ## Install


### PR DESCRIPTION
# Issue

After following `README > Quick Start` > `using docker image`, command will run successfully but output nothing to local.

## How to reproduce

```
$ docker run --rm -v $PWD:/work ghcr.io/k1low/tbls doc postgres://dbuser:dbpass@hostname:5432/dbname
```

# Cause of issue

Docker `WORKDIR` has been removed. https://github.com/k1LoW/tbls/commit/4c37754bfd781f88ed5045d7f90c50020572806d  
So we should overwrite `WORKDIR` with `-w` option.