### PR TITLE
Fix extra `-e` displayed on temporary installation.

### DIFF
--- a/use
+++ b/use
@@ -47,4 +47,4 @@ then
   unzip -qo "$TBLS_ARCHIVE" -d "$TBLS_TMPDIR"
 fi
 export PATH=${TBLS_TMPDIR}:$PATH
-echo -e '\e[36mYou can use `tbls` command in this session.\e[m'
+printf '\e[36mYou can use `tbls` command in this session.\e[m\n'


### PR DESCRIPTION
Fixed ``-e You can use `tbls` command in this session.`` is displayed after temporary installation finished.
(extra `-e` is displayed.)

How to reproduction.
```bash
wget -O tbls "https://raw.githubusercontent.com/k1LoW/tbls/main/use"
chmod u+x ./tbls
./tbls
```

`-e` option of `echo` is not POSIX, so the option is not recognized when shebang is `#!bin/sh`.

Thank you for updating this nice tool.