### PR TITLE
Skip getting functions because Amazon RedShift does not support `pg_get_funciton_arguments()`

### DIFF
--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -421,6 +421,10 @@ func (p *Postgres) getFunctions() ([]*schema.Function, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	if p.rsMode {
+		// Amazon RedShift does not support pg_get_function_arguments
+		return functions, nil
+	}
 	if storedProcedureSupported {
 		functions, err = p.getFunctionsByQuery(queryFunctions)
 		if err != nil {


### PR DESCRIPTION
ref: #370