### PR TITLE
Added options for curl to skip downloading of tbls if the newest file exists

### DIFF
--- a/use
+++ b/use
@@ -33,8 +33,7 @@ download() {
     echo "Unable to get tbls version." >&2
     exit 1
   }
-  rm -f "$TBLS_ARCHIVE"
-  curl -s -L -o "$TBLS_ARCHIVE" \
+  curl -z "$TBLS_ARCHIVE" -s -L -o "$TBLS_ARCHIVE" \
     "${TBLS_RELEASES_URL}/download/${TBLS_VERSION}/tbls_${TBLS_VERSION}_${TBLS_GOOS}_${TBLS_ARCH}.${TBLS_EXT}"
 }
 

--- a/use
+++ b/use
@@ -33,7 +33,8 @@ download() {
     echo "Unable to get tbls version." >&2
     exit 1
   }
-  curl -z "$TBLS_ARCHIVE" -s -L -o "$TBLS_ARCHIVE" \
+  curl `if [ -f "$TBLS_ARCHIVE" ]; then echo -z "$TBLS_ARCHIVE"; fi` \ # Skip downloading if the newest file was downloaded before
+    -s -L -o "$TBLS_ARCHIVE" \
     "${TBLS_RELEASES_URL}/download/${TBLS_VERSION}/tbls_${TBLS_VERSION}_${TBLS_GOOS}_${TBLS_ARCH}.${TBLS_EXT}"
 }
 


### PR DESCRIPTION
Added options for curl to skip downloading of tbls if the file exists and a newer file is not available (-z curl option).
It is really useful to speed up CI jobs when otherwise I need to wait every time the downloading completion.
Here is the [documentation](https://curl.se/docs/manpage.html#:~:text=%2Dz%2C%20%2D%2Dtime%2Dcond%20%3Ctime%3E). I have tested, and it works since github returns `last-modified` HTTP header in a response to download the [file ](https://github.com/k1LoW/tbls/releases/download/v1.60.0/tbls_v1.60.0_linux_amd64.tar.gz) (last response after redirection) and this header is used for `-z` option.