### PR TITLE
Fixed position of a comment in the `use` script

### DIFF
--- a/use
+++ b/use
@@ -33,7 +33,8 @@ download() {
     echo "Unable to get tbls version." >&2
     exit 1
   }
-  curl `if [ -f "$TBLS_ARCHIVE" ]; then echo -z "$TBLS_ARCHIVE"; fi` \ # Skip downloading if the newest file was downloaded before
+  # Skip downloading if the newest file was downloaded before
+  curl `if [ -f "$TBLS_ARCHIVE" ]; then echo -z "$TBLS_ARCHIVE"; fi` \
     -s -L -o "$TBLS_ARCHIVE" \
     "${TBLS_RELEASES_URL}/download/${TBLS_VERSION}/tbls_${TBLS_VERSION}_${TBLS_GOOS}_${TBLS_ARCH}.${TBLS_EXT}"
 }


### PR DESCRIPTION
Following errors were caused due to a comment after `\`. I've fixed it.

```
curl: (3) URL using bad/illegal format or missing URL
curl: (6) Could not resolve host: Skip
curl: (6) Could not resolve host: downloading
curl: (6) Could not resolve host: if
curl: (6) Could not resolve host: the
curl: (6) Could not resolve host: newest
curl: (6) Could not resolve host: file
curl: (6) Could not resolve host: was
curl: (6) Could not resolve host: downloaded
curl: (6) Could not resolve host: before
```