### PR TITLE
Bulk get schema info for MySQL

### DIFF
--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -99,6 +99,159 @@ func (m *Mysql) Analyze(s *schema.Schema) error {
 		}
 	}
 
+	// bulk get indexes
+	indexRows, err := m.db.Query(`
+SELECT
+s.table_name,
+(CASE WHEN s.index_name='PRIMARY' AND s.non_unique=0 THEN 'PRIMARY KEY'
+      WHEN s.index_name!='PRIMARY' AND s.non_unique=0 THEN 'UNIQUE KEY'
+      WHEN s.non_unique=1 THEN 'KEY'
+      ELSE null
+  END) AS key_type,
+s.index_name, GROUP_CONCAT(s.column_name ORDER BY s.seq_in_index SEPARATOR ', '), s.index_type
+FROM information_schema.statistics AS s
+LEFT JOIN information_schema.columns AS c ON s.table_schema = c.table_schema AND s.table_name = c.table_name AND s.column_name = c.column_name
+WHERE s.table_name = c.table_name
+AND s.table_schema = ?
+GROUP BY s.table_name, key_type, s.table_name, s.index_name, s.index_type`, s.Name)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer indexRows.Close()
+
+	tableIndexes := map[string][]*schema.Index{}
+	for indexRows.Next() {
+		var (
+			tableName       string
+			indexKeyType    string
+			indexName       string
+			indexColumnName string
+			indexType       string
+			indexDef        string
+		)
+		err = indexRows.Scan(&tableName, &indexKeyType, &indexName, &indexColumnName, &indexType)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		if indexKeyType == "PRIMARY KEY" {
+			indexDef = fmt.Sprintf("%s (%s) USING %s", indexKeyType, indexColumnName, indexType)
+		} else {
+			indexDef = fmt.Sprintf("%s %s (%s) USING %s", indexKeyType, indexName, indexColumnName, indexType)
+		}
+
+		index := &schema.Index{
+			Name:    indexName,
+			Def:     indexDef,
+			Table:   &tableName,
+			Columns: strings.Split(indexColumnName, ", "),
+		}
+		tableIndexes[tableName] = append(tableIndexes[tableName], index)
+	}
+
+	// bulk get triggers
+	triggerRows, err := m.db.Query(`
+SELECT
+  event_object_table,
+  trigger_name,
+  action_timing,
+  event_manipulation,
+  event_object_table,
+  action_orientation,
+  action_statement
+FROM information_schema.triggers
+WHERE event_object_schema = ?
+`, s.Name)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer triggerRows.Close()
+	tableTriggers := map[string][]*schema.Trigger{}
+	for triggerRows.Next() {
+		var (
+			tableName                string
+			triggerName              string
+			triggerActionTiming      string
+			triggerEventManipulation string
+			triggerEventObjectTable  string
+			triggerActionOrientation string
+			triggerActionStatement   string
+			triggerDef               string
+		)
+		err = triggerRows.Scan(&tableName, &triggerName, &triggerActionTiming, &triggerEventManipulation, &triggerEventObjectTable, &triggerActionOrientation, &triggerActionStatement)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		triggerDef = fmt.Sprintf("CREATE TRIGGER %s %s %s ON %s\nFOR EACH %s\n%s", triggerName, triggerActionTiming, triggerEventManipulation, triggerEventObjectTable, triggerActionOrientation, triggerActionStatement)
+		trigger := &schema.Trigger{
+			Name: triggerName,
+			Def:  triggerDef,
+		}
+		tableTriggers[tableName] = append(tableTriggers[tableName], trigger)
+	}
+
+	// bulk get columns and comments
+	columnStmt := `
+SELECT table_name, column_name, column_default, is_nullable, column_type, column_comment, extra, generation_expression
+FROM information_schema.columns
+WHERE table_schema = ? ORDER BY table_name, ordinal_position`
+	if !supportGeneratedColumn {
+		columnStmt = `
+SELECT table_name, column_name, column_default, is_nullable, column_type, column_comment, extra
+FROM information_schema.columns
+WHERE table_schema = ? ORDER BY table_name, ordinal_position`
+	}
+	columnRows, err := m.db.Query(columnStmt, s.Name)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer columnRows.Close()
+	tableColumns := map[string][]*schema.Column{}
+	for columnRows.Next() {
+		var (
+			tableName      string
+			columnName     string
+			columnDefault  sql.NullString
+			isNullable     string
+			columnType     string
+			columnComment  sql.NullString
+			extra          sql.NullString
+			generationExpr sql.NullString
+		)
+		if supportGeneratedColumn {
+			err = columnRows.Scan(&tableName, &columnName, &columnDefault, &isNullable, &columnType, &columnComment, &extra, &generationExpr)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+		} else {
+			err = columnRows.Scan(&tableName, &columnName, &columnDefault, &isNullable, &columnType, &columnComment, &extra)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+		}
+		extraDef := extra.String
+		if generationExpr.String != "" {
+			switch extraDef {
+			case "VIRTUAL GENERATED":
+				extraDef = fmt.Sprintf("GENERATED ALWAYS AS %s VIRTUAL", generationExpr.String)
+			case "STORED GENERATED":
+				extraDef = fmt.Sprintf("GENERATED ALWAYS AS %s STORED", generationExpr.String)
+			default:
+				extraDef = fmt.Sprintf("%s:%s", extraDef, generationExpr.String)
+			}
+		}
+		column := &schema.Column{
+			Name:     columnName,
+			Type:     columnType,
+			Nullable: convertColumnNullable(isNullable),
+			Default:  columnDefault,
+			Comment:  columnComment.String,
+			ExtraDef: extraDef,
+		}
+
+		tableColumns[tableName] = append(tableColumns[tableName], column)
+	}
+
 	// tables and comments
 	tableRows, err := m.db.Query(m.queryForTables(), s.Name)
 	if err != nil {
@@ -108,6 +261,7 @@ func (m *Mysql) Analyze(s *schema.Schema) error {
 
 	relations := []*schema.Relation{}
 
+	tableMap := map[string]*schema.Table{}
 	tables := []*schema.Table{}
 	for tableRows.Next() {
 		var (
@@ -175,58 +329,22 @@ AND table_name = ?;
 		}
 
 		// indexes
-		indexRows, err := m.db.Query(`
+		table.Indexes = tableIndexes[table.Name]
+
+		// triggers
+		table.Triggers = tableTriggers[table.Name]
+
+		// columns and comments
+		table.Columns = tableColumns[table.Name]
+
+		tables = append(tables, table)
+		tableMap[table.Name] = table
+	}
+
+	// bulk get constraints
+	constraintRows, err := m.db.Query(`
 SELECT
-(CASE WHEN s.index_name='PRIMARY' AND s.non_unique=0 THEN 'PRIMARY KEY'
-      WHEN s.index_name!='PRIMARY' AND s.non_unique=0 THEN 'UNIQUE KEY'
-      WHEN s.non_unique=1 THEN 'KEY'
-      ELSE null
-  END) AS key_type,
-s.index_name, GROUP_CONCAT(s.column_name ORDER BY s.seq_in_index SEPARATOR ', '), s.index_type
-FROM information_schema.statistics AS s
-LEFT JOIN information_schema.columns AS c ON s.table_schema = c.table_schema AND s.table_name = c.table_name AND s.column_name = c.column_name
-WHERE s.table_name = c.table_name
-AND s.table_schema = ?
-AND s.table_name = ?
-GROUP BY key_type, s.table_name, s.index_name, s.index_type`, s.Name, tableName)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-		defer indexRows.Close()
-
-		indexes := []*schema.Index{}
-		for indexRows.Next() {
-			var (
-				indexKeyType    string
-				indexName       string
-				indexColumnName string
-				indexType       string
-				indexDef        string
-			)
-			err = indexRows.Scan(&indexKeyType, &indexName, &indexColumnName, &indexType)
-			if err != nil {
-				return errors.WithStack(err)
-			}
-
-			if indexKeyType == "PRIMARY KEY" {
-				indexDef = fmt.Sprintf("%s (%s) USING %s", indexKeyType, indexColumnName, indexType)
-			} else {
-				indexDef = fmt.Sprintf("%s %s (%s) USING %s", indexKeyType, indexName, indexColumnName, indexType)
-			}
-
-			index := &schema.Index{
-				Name:    indexName,
-				Def:     indexDef,
-				Table:   &table.Name,
-				Columns: strings.Split(indexColumnName, ", "),
-			}
-			indexes = append(indexes, index)
-		}
-		table.Indexes = indexes
-
-		// constraints
-		constraintRows, err := m.db.Query(`
-SELECT
+  kcu.table_name,
   kcu.constraint_name,
   sub.costraint_type,
   GROUP_CONCAT(kcu.column_name ORDER BY kcu.ordinal_position, position_in_unique_constraint SEPARATOR ', ') AS column_name,
@@ -251,172 +369,64 @@ INNER JOIN
    END) AS costraint_type
    FROM information_schema.key_column_usage AS kcu
    LEFT JOIN information_schema.columns AS c ON kcu.table_schema = c.table_schema AND kcu.table_name = c.table_name AND kcu.column_name = c.column_name
-   WHERE kcu.table_name = ?
-   AND kcu.ordinal_position = 1
+   WHERE kcu.ordinal_position = 1
   ) AS sub
 ON kcu.constraint_name = sub.constraint_name
   AND kcu.table_schema = sub.table_schema
   AND kcu.table_name = sub.table_name
   AND (kcu.referenced_table_name = sub.referenced_table_name OR (kcu.referenced_table_name IS NULL AND sub.referenced_table_name IS NULL))
 WHERE kcu.table_schema= ?
-  AND kcu.table_name = ?
-GROUP BY kcu.constraint_name, sub.costraint_type, kcu.referenced_table_name`, tableName, s.Name, tableName)
+GROUP BY kcu.table_name, kcu.constraint_name, sub.costraint_type, kcu.referenced_table_name`, s.Name)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer constraintRows.Close()
+
+	for constraintRows.Next() {
+		var (
+			tableName               string
+			constraintName          string
+			constraintType          string
+			constraintColumnName    string
+			constraintRefTableName  sql.NullString
+			constraintRefColumnName sql.NullString
+			constraintDef           string
+		)
+		err = constraintRows.Scan(&tableName, &constraintName, &constraintType, &constraintColumnName, &constraintRefTableName, &constraintRefColumnName)
 		if err != nil {
 			return errors.WithStack(err)
 		}
-		defer constraintRows.Close()
 
-		constraints := []*schema.Constraint{}
-		for constraintRows.Next() {
-			var (
-				constraintName          string
-				constraintType          string
-				constraintColumnName    string
-				constraintRefTableName  sql.NullString
-				constraintRefColumnName sql.NullString
-				constraintDef           string
-			)
-			err = constraintRows.Scan(&constraintName, &constraintType, &constraintColumnName, &constraintRefTableName, &constraintRefColumnName)
-			if err != nil {
-				return errors.WithStack(err)
+		switch constraintType {
+		case "PRIMARY KEY":
+			constraintDef = fmt.Sprintf("PRIMARY KEY (%s)", constraintColumnName)
+		case "UNIQUE":
+			constraintDef = fmt.Sprintf("UNIQUE KEY %s (%s)", constraintName, constraintColumnName)
+		case "FOREIGN KEY":
+			constraintType = schema.TypeFK
+			constraintDef = fmt.Sprintf("FOREIGN KEY (%s) REFERENCES %s (%s)", constraintColumnName, constraintRefTableName.String, constraintRefColumnName.String)
+			relation := &schema.Relation{
+				Table: tableMap[tableName],
+				Def:   constraintDef,
 			}
-			switch constraintType {
-			case "PRIMARY KEY":
-				constraintDef = fmt.Sprintf("PRIMARY KEY (%s)", constraintColumnName)
-			case "UNIQUE":
-				constraintDef = fmt.Sprintf("UNIQUE KEY %s (%s)", constraintName, constraintColumnName)
-			case "FOREIGN KEY":
-				constraintType = schema.TypeFK
-				constraintDef = fmt.Sprintf("FOREIGN KEY (%s) REFERENCES %s (%s)", constraintColumnName, constraintRefTableName.String, constraintRefColumnName.String)
-				relation := &schema.Relation{
-					Table: table,
-					Def:   constraintDef,
-				}
-				relations = append(relations, relation)
-			case "UNKNOWN":
-				constraintDef = fmt.Sprintf("UNKNOWN CONSTRAINT (%s) (%s) (%s)", constraintColumnName, constraintRefTableName.String, constraintRefColumnName.String)
-			}
-
-			constraint := &schema.Constraint{
-				Name:    constraintName,
-				Type:    constraintType,
-				Def:     constraintDef,
-				Table:   &table.Name,
-				Columns: strings.Split(constraintColumnName, ", "),
-			}
-			if constraintRefTableName.String != "" {
-				constraint.ReferencedTable = &constraintRefTableName.String
-				constraint.ReferencedColumns = strings.Split(constraintRefColumnName.String, ", ")
-			}
-
-			constraints = append(constraints, constraint)
+			relations = append(relations, relation)
+		case "UNKNOWN":
+			constraintDef = fmt.Sprintf("UNKNOWN CONSTRAINT (%s) (%s) (%s)", constraintColumnName, constraintRefTableName.String, constraintRefColumnName.String)
 		}
-		table.Constraints = constraints
 
-		// triggers
-		triggerRows, err := m.db.Query(`
-SELECT
-  trigger_name,
-  action_timing,
-  event_manipulation,
-  event_object_table,
-  action_orientation,
-  action_statement
-FROM information_schema.triggers
-WHERE event_object_schema = ?
-AND event_object_table = ?
-`, s.Name, tableName)
-		if err != nil {
-			return errors.WithStack(err)
+		constraint := &schema.Constraint{
+			Name:    constraintName,
+			Type:    constraintType,
+			Def:     constraintDef,
+			Table:   &tableName,
+			Columns: strings.Split(constraintColumnName, ", "),
 		}
-		defer triggerRows.Close()
-		triggers := []*schema.Trigger{}
-		for triggerRows.Next() {
-			var (
-				triggerName              string
-				triggerActionTiming      string
-				triggerEventManipulation string
-				triggerEventObjectTable  string
-				triggerActionOrientation string
-				triggerActionStatement   string
-				triggerDef               string
-			)
-			err = triggerRows.Scan(&triggerName, &triggerActionTiming, &triggerEventManipulation, &triggerEventObjectTable, &triggerActionOrientation, &triggerActionStatement)
-			if err != nil {
-				return errors.WithStack(err)
-			}
-			triggerDef = fmt.Sprintf("CREATE TRIGGER %s %s %s ON %s\nFOR EACH %s\n%s", triggerName, triggerActionTiming, triggerEventManipulation, triggerEventObjectTable, triggerActionOrientation, triggerActionStatement)
-			trigger := &schema.Trigger{
-				Name: triggerName,
-				Def:  triggerDef,
-			}
-			triggers = append(triggers, trigger)
+		if constraintRefTableName.String != "" {
+			constraint.ReferencedTable = &constraintRefTableName.String
+			constraint.ReferencedColumns = strings.Split(constraintRefColumnName.String, ", ")
 		}
-		table.Triggers = triggers
 
-		// columns and comments
-		columnStmt := `
-SELECT column_name, column_default, is_nullable, column_type, column_comment, extra, generation_expression
-FROM information_schema.columns
-WHERE table_schema = ? AND table_name = ? ORDER BY ordinal_position`
-		if !supportGeneratedColumn {
-			columnStmt = `
-SELECT column_name, column_default, is_nullable, column_type, column_comment, extra
-FROM information_schema.columns
-WHERE table_schema = ? AND table_name = ? ORDER BY ordinal_position`
-		}
-		columnRows, err := m.db.Query(columnStmt, s.Name, tableName)
-		if err != nil {
-			return errors.WithStack(err)
-		}
-		defer columnRows.Close()
-		columns := []*schema.Column{}
-		for columnRows.Next() {
-			var (
-				columnName     string
-				columnDefault  sql.NullString
-				isNullable     string
-				columnType     string
-				columnComment  sql.NullString
-				extra          sql.NullString
-				generationExpr sql.NullString
-			)
-			if supportGeneratedColumn {
-				err = columnRows.Scan(&columnName, &columnDefault, &isNullable, &columnType, &columnComment, &extra, &generationExpr)
-				if err != nil {
-					return errors.WithStack(err)
-				}
-			} else {
-				err = columnRows.Scan(&columnName, &columnDefault, &isNullable, &columnType, &columnComment, &extra)
-				if err != nil {
-					return errors.WithStack(err)
-				}
-			}
-			extraDef := extra.String
-			if generationExpr.String != "" {
-				switch extraDef {
-				case "VIRTUAL GENERATED":
-					extraDef = fmt.Sprintf("GENERATED ALWAYS AS %s VIRTUAL", generationExpr.String)
-				case "STORED GENERATED":
-					extraDef = fmt.Sprintf("GENERATED ALWAYS AS %s STORED", generationExpr.String)
-				default:
-					extraDef = fmt.Sprintf("%s:%s", extraDef, generationExpr.String)
-				}
-			}
-			column := &schema.Column{
-				Name:     columnName,
-				Type:     columnType,
-				Nullable: convertColumnNullable(isNullable),
-				Default:  columnDefault,
-				Comment:  columnComment.String,
-				ExtraDef: extraDef,
-			}
-
-			columns = append(columns, column)
-		}
-		table.Columns = columns
-
-		tables = append(tables, table)
+		tableMap[tableName].Constraints = append(tableMap[tableName].Constraints, constraint)
 	}
 
 	functions, err := m.getFunctions()


### PR DESCRIPTION
# About

In databases with a large number of tables, it took a long time to execute the process, so I improved it.

# Description

The queries to retrieve schema information were issued for each table, resulting in a large overhead and time consuming query processing.

Therefore, we reduced the number of queries by retrieving schema information in batches whenever possible.

## FYI

Result of time in my environment. (over 1,000 tables)

before: about 90min
after: about 3min