### PR TITLE
Issue #439: Allow JSON schema output indentation to be configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage.out
 *client_secrets.json*
 .DS_Store
 .idea
+vendor

--- a/README.md
+++ b/README.md
@@ -620,6 +620,9 @@ format:
   hideColumnsWithoutValues: true
   # It can be boolean or array
   # hideColumnsWithoutValues: ["Parents", "Children"]
+  # Format JSON schema as a single line.
+  # Default is false
+  inlineJSON: true
 ```
 
 ### ER diagram

--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -168,7 +168,7 @@ func withSchemaFile(s *schema.Schema, c *config.Config) (e error) {
 		_ = sf.Close()
 	}()
 	fmt.Printf("%s\n", c.SchemaFilePath())
-	j := json.New(true)
+	j := json.New(c.Format.InlineJSON)
 	if err := j.OutputSchema(sf, s); err != nil {
 		return err
 	}

--- a/cmd/out.go
+++ b/cmd/out.go
@@ -87,7 +87,7 @@ var outCmd = &cobra.Command{
 
 		switch format {
 		case "json":
-			o = json.New(false)
+			o = json.New(c.Format.InlineJSON)
 		case "yaml":
 			o = new(yaml.YAML)
 		case "dot":

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -156,7 +156,7 @@ var rootCmd = &cobra.Command{
 
 			envs = append(envs, fmt.Sprintf("TBLS_DSN=%s", cfg.DSN.URL))
 			envs = append(envs, fmt.Sprintf("TBLS_CONFIG_PATH=%s", cfg.Path))
-			o := json.New(true)
+			o := json.New(cfg.Format.InlineJSON)
 			tmpfile, err := os.CreateTemp("", "TBLS_SCHEMA")
 			if err != nil {
 				return err

--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,7 @@ type Format struct {
 	Number                   bool     `yaml:"number,omitempty"`
 	ShowOnlyFirstParagraph   bool     `yaml:"showOnlyFirstParagraph,omitempty"`
 	HideColumnsWithoutValues []string `yaml:"hideColumnsWithoutValues,omitempty"`
+	InlineJSON               bool     `yaml:"inlineJSON,omitempty"`
 }
 
 // ER is er setting

--- a/config/yaml.go
+++ b/config/yaml.go
@@ -36,12 +36,14 @@ func (f Format) MarshalYAML() ([]byte, error) {
 			Sort                     bool `yaml:"sort,omitempty"`
 			Number                   bool `yaml:"number,omitempty"`
 			ShowOnlyFirstParagraph   bool `yaml:"showOnlyFirstParagraph,omitempty"`
+			InlineJSON               bool `yaml:"inlineJSON,omitempty"`
 			HideColumnsWithoutValues bool `yaml:"hideColumnsWithoutValues,omitempty"`
 		}{
 			Adjust:                   f.Adjust,
 			Sort:                     f.Sort,
 			Number:                   f.Number,
 			ShowOnlyFirstParagraph:   f.ShowOnlyFirstParagraph,
+			InlineJSON:               f.InlineJSON,
 			HideColumnsWithoutValues: false,
 		}
 		return yaml.Marshal(s)
@@ -56,6 +58,7 @@ func (f *Format) UnmarshalYAML(data []byte) error {
 		Number                   bool        `yaml:"number,omitempty"`
 		ShowOnlyFirstParagraph   bool        `yaml:"showOnlyFirstParagraph,omitempty"`
 		HideColumnsWithoutValues interface{} `yaml:"hideColumnsWithoutValues,omitempty"`
+		InlineJSON               bool        `yaml:"inlineJSON,omitempty"`
 	}{}
 	if err := yaml.Unmarshal(data, &s); err != nil {
 		return err
@@ -64,6 +67,7 @@ func (f *Format) UnmarshalYAML(data []byte) error {
 	f.Sort = s.Sort
 	f.Number = s.Number
 	f.ShowOnlyFirstParagraph = s.ShowOnlyFirstParagraph
+	f.InlineJSON = s.InlineJSON
 	switch v := s.HideColumnsWithoutValues.(type) {
 	case bool:
 		if v {


### PR DESCRIPTION
 - Add `inlineJSON` boolean configuration field to the `Format` struct. Include this field in the YAML marshal / unmarshal functions.
 - Update the uses of `json.New()` to use the value from the configuration.
 - Update `README` to contain the new configuration field.