### PR TITLE
Fix unclosed fenced code block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -922,6 +922,7 @@ relations:
     parentCardinality: one or more
     override: true
     def: posts->users
+```
 
 #### Automatically detect relations
 


### PR DESCRIPTION
"Automatically detect relations" is a very nice feature, but it's not Heading, so I can't link to it.