### PR TITLE
Add a NamingStrategy to map Post.user_id → User.user_id style detected relation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -723,6 +723,7 @@ func mergeDetectedRelations(s *schema.Schema, strategy *NamingStrategy) {
 	var (
 		err          error
 		parentColumn *schema.Column
+		parentTable  *schema.Table
 	)
 
 	for _, t := range s.Tables {
@@ -733,9 +734,16 @@ func mergeDetectedRelations(s *schema.Schema, strategy *NamingStrategy) {
 				Table:   t,
 			}
 
-			if relation.ParentTable, err = s.FindTableByName(strategy.ParentTableName(c.Name)); err != nil {
+			if parentTable, err = s.FindTableByName(strategy.ParentTableName(c.Name)); err != nil {
 				continue
 			}
+
+			if parentTable == t {
+				continue
+			}
+
+			relation.ParentTable = parentTable
+
 			if parentColumn, err = relation.ParentTable.FindColumnByName(strategy.ParentColumnName(c.Name)); err != nil {
 				continue
 			}

--- a/config/naming.go
+++ b/config/naming.go
@@ -36,6 +36,18 @@ func SelectNamingStrategy(name string) (*NamingStrategy, error) {
 			ParentColumn: singularTableParentColumnNamer,
 		}, nil
 
+	case "identical":
+		return &NamingStrategy{
+			ParentTable:  defaultParentTableNamer,
+			ParentColumn: identicalParentColumnNamer,
+		}, nil
+
+	case "identicalSingularTableName":
+		return &NamingStrategy{
+			ParentTable:  singularTableParentTableNamer,
+			ParentColumn: identicalParentColumnNamer,
+		}, nil
+
 	default:
 		return nil, fmt.Errorf("Naming strategy does not exist. strategy: %s\n", name)
 	}
@@ -75,4 +87,8 @@ func singularTableParentTableNamer(name string) string {
 
 func singularTableParentColumnNamer(name string) string {
 	return "id"
+}
+
+func identicalParentColumnNamer(name string) string {
+	return name
 }

--- a/config/naming_test.go
+++ b/config/naming_test.go
@@ -36,3 +36,21 @@ func TestSingularTableParentColumnNamer(t *testing.T) {
 		}
 	}
 }
+
+func TestIdenticalParentColumnNamer(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		// normal
+		{"user_id", "user_id"},
+	}
+
+	for _, tt := range tests {
+		got := identicalParentColumnNamer(tt.name)
+
+		if got != tt.want {
+			t.Errorf("name %v\ngot %v\nwant %v", tt.name, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
I encountered a niche case where primary keys are named `tablename_id`, and wanted tbls to be able to detect the relation.

This PR adds:
* `identical` and `identicalSingularTableName` NamingStrategy which detects `user_id` → `user_id` relations
* checks to prevent making relation to the table itself

My concern about this is that other NamingStrategy's can be introduced and the combination will blow up. If that's the case, separating the NamingStrategy config into two parts and letting ParentTableNamer and ParentColumnNamer be specified separately might be good maybe??