### PR TITLE
#478: replace STRING_AGG to allow older MSSQL versions

### DIFF
--- a/drivers/mssql/mssql.go
+++ b/drivers/mssql/mssql.go
@@ -163,14 +163,18 @@ SELECT
   i.is_unique,
   i.is_primary_key,
   i.is_unique_constraint,
-  STRING_AGG(COL_NAME(ic.object_id, ic.column_id), ', ') WITHIN GROUP ( ORDER BY ic.key_ordinal ),
+  STUFF(
+    (SELECT ', ' + COL_NAME(ic.object_id, ic.column_id)
+      FROM sys.index_columns AS ic
+      WHERE i.object_id = ic.object_id AND i.index_id = ic.index_id
+      ORDER BY ic.key_ordinal
+      FOR XML PATH('')
+    ), 1, 2, '') AS index_columns,
   c.is_system_named
 FROM sys.key_constraints AS c
 LEFT JOIN sys.indexes AS i ON i.object_id = c.parent_object_id AND i.index_id = c.unique_index_id
-INNER JOIN sys.index_columns AS ic
-ON i.object_id = ic.object_id AND i.index_id = ic.index_id
 WHERE i.object_id = object_id(@p1)
-GROUP BY c.name, i.index_id, i.type_desc, i.is_unique, i.is_primary_key, i.is_unique_constraint, c.is_system_named
+GROUP BY c.name, i.index_id, i.type_desc, i.is_unique, i.is_primary_key, i.is_unique_constraint, c.is_system_named, i.object_id
 ORDER BY i.index_id
 `, fmt.Sprintf("%s.%s", tableSchema, tableName))
 		if err != nil {
@@ -225,15 +229,24 @@ SELECT
   OBJECT_NAME(f.parent_object_id) AS table_name,
   OBJECT_NAME(f.referenced_object_id) AS parent_table_name,
   OBJECT_SCHEMA_NAME(f.referenced_object_id) AS parent_schema_name,
-  STRING_AGG(COL_NAME(fc.parent_object_id, fc.parent_column_id), ', ') AS column_names,
-  STRING_AGG(COL_NAME(fc.referenced_object_id, fc.referenced_column_id), ', ') AS parent_column_names,
+  STUFF(
+    (SELECT ', ' + COL_NAME(fc.parent_object_id, fc.parent_column_id)
+      FROM sys.foreign_key_columns AS fc
+      WHERE f.object_id = fc.constraint_object_id
+      FOR XML PATH('')
+    ), 1, 2, '') AS column_names,
+  STUFF(
+    (SELECT ', ' + COL_NAME(fc.referenced_object_id, fc.referenced_column_id)
+      FROM sys.foreign_key_columns AS fc
+      WHERE f.object_id = fc.constraint_object_id
+      FOR XML PATH('')
+    ), 1, 2, '') AS parent_column_names,
   update_referential_action_desc,
   delete_referential_action_desc,
   f.is_system_named
 FROM sys.foreign_keys AS f
-LEFT JOIN sys.foreign_key_columns AS fc ON f.object_id = fc.constraint_object_id
 WHERE f.parent_object_id = object_id(@p1)
-GROUP BY f.name, f.parent_object_id, f.referenced_object_id, delete_referential_action_desc, update_referential_action_desc, f.is_system_named
+GROUP BY f.name, f.parent_object_id, f.referenced_object_id, delete_referential_action_desc, update_referential_action_desc, f.is_system_named, f.object_id
 `, fmt.Sprintf("%s.%s", tableSchema, tableName))
 		if err != nil {
 			return errors.WithStack(err)
@@ -349,15 +362,19 @@ SELECT
   i.is_unique,
   i.is_primary_key,
   i.is_unique_constraint,
-  STRING_AGG(COL_NAME(ic.object_id, ic.column_id), ', ') WITHIN GROUP ( ORDER BY ic.key_ordinal ),
+  STUFF(
+    (SELECT ', ' + COL_NAME(ic.object_id, ic.column_id)
+      FROM sys.index_columns AS ic
+      WHERE i.object_id = ic.object_id AND i.index_id = ic.index_id
+	  ORDER BY ic.key_ordinal
+      FOR XML PATH('')
+    ), 1, 2, '') AS column_names,
   c.is_system_named
 FROM sys.indexes AS i
-INNER JOIN sys.index_columns AS ic
-ON i.object_id = ic.object_id AND i.index_id = ic.index_id
 LEFT JOIN sys.key_constraints AS c
 ON i.object_id = c.parent_object_id AND i.index_id = c.unique_index_id
 WHERE i.object_id = object_id(@p1)
-GROUP BY i.name, i.index_id, i.type_desc, i.is_unique, i.is_primary_key, i.is_unique_constraint, c.is_system_named
+GROUP BY i.name, i.index_id, i.type_desc, i.is_unique, i.is_primary_key, i.is_unique_constraint, c.is_system_named, i.object_id
 ORDER BY i.index_id
 `, fmt.Sprintf("%s.%s", tableSchema, tableName))
 		if err != nil {

--- a/drivers/mssql/mssql.go
+++ b/drivers/mssql/mssql.go
@@ -247,6 +247,7 @@ SELECT
 FROM sys.foreign_keys AS f
 WHERE f.parent_object_id = object_id(@p1)
 GROUP BY f.name, f.parent_object_id, f.referenced_object_id, delete_referential_action_desc, update_referential_action_desc, f.is_system_named, f.object_id
+ORDER BY f.name
 `, fmt.Sprintf("%s.%s", tableSchema, tableName))
 		if err != nil {
 			return errors.WithStack(err)

--- a/drivers/mssql/mssql.go
+++ b/drivers/mssql/mssql.go
@@ -372,8 +372,9 @@ SELECT
   c.is_system_named
 FROM sys.indexes AS i
 LEFT JOIN sys.key_constraints AS c
-ON i.object_id = c.parent_object_id AND i.index_id = c.unique_index_id
+  ON i.object_id = c.parent_object_id AND i.index_id = c.unique_index_id
 WHERE i.object_id = object_id(@p1)
+  AND EXISTS (SELECT 1 FROM sys.index_columns AS ic0 WHERE ic0.index_id = i.index_id)
 GROUP BY i.name, i.index_id, i.type_desc, i.is_unique, i.is_primary_key, i.is_unique_constraint, c.is_system_named, i.object_id
 ORDER BY i.index_id
 `, fmt.Sprintf("%s.%s", tableSchema, tableName))

--- a/drivers/mssql/mssql.go
+++ b/drivers/mssql/mssql.go
@@ -172,7 +172,7 @@ SELECT
     ), 1, 2, '') AS index_columns,
   c.is_system_named
 FROM sys.key_constraints AS c
-LEFT JOIN sys.indexes AS i ON i.object_id = c.parent_object_id AND i.index_id = c.unique_index_id
+INNER JOIN sys.indexes AS i ON i.object_id = c.parent_object_id AND i.index_id = c.unique_index_id
 WHERE i.object_id = object_id(@p1)
 GROUP BY c.name, i.index_id, i.type_desc, i.is_unique, i.is_primary_key, i.is_unique_constraint, c.is_system_named, i.object_id
 ORDER BY i.index_id


### PR DESCRIPTION
#478: Replaced `STRING_AGG` (appeared in MSSQL 2017) with old-fashioned string aggregation
