### PR TITLE
Add an arm64 architecture variant of the Linux build

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install sqlite3
+          sudo apt-get install sqlite3 gcc-aarch64-linux-gnu
 
       - name: Install aws-cli
         uses: isbang/setup-awscli@v0.1.0

--- a/.goreleaser/linux.yml
+++ b/.goreleaser/linux.yml
@@ -21,6 +21,7 @@ builds:
     - linux
   goarch:
     - amd64
+    - arm64
 archives:
 -
   id: tbls-archive

--- a/.goreleaser/linux.yml
+++ b/.goreleaser/linux.yml
@@ -4,7 +4,7 @@ before:
     - go mod tidy
 builds:
 -
-  id: tbls-linux-amd64
+  id: tbls-linux
   flags:
     - -a
     - -tags
@@ -21,26 +21,13 @@ builds:
     - linux
   goarch:
     - amd64
--
-  id: tbls-linux-arm64
-  flags:
-    - -a
-    - -tags
-    - netgo
-    - -installsuffix
-    - netgo
-  ldflags:
-    - -s -w -X github.com/k1LoW/tbls.version={{.Version}} -X github.com/k1LoW/tbls.commit={{.FullCommit}} -X github.com/k1LoW/tbls.date={{.Date}} -X github.com/k1LoW/tbls/version.Version={{.Version}}
-    - -linkmode external
-    - -extldflags '-static'
-  env:
-    - CGO_ENABLED=1
-    - CC=aarch64-linux-gnu-gcc
-    - CXX=aarch64-linux-gnu-g++
-  goos:
-    - linux
-  goarch:
     - arm64
+  overrides:
+    - goos: linux
+      goarch: arm64
+      env:
+        - CC=aarch64-linux-gnu-gcc
+        - CXX=aarch64-linux-gnu-g++
 archives:
 -
   id: tbls-archive

--- a/.goreleaser/linux.yml
+++ b/.goreleaser/linux.yml
@@ -4,7 +4,7 @@ before:
     - go mod tidy
 builds:
 -
-  id: tbls-linux
+  id: tbls-linux-amd64
   flags:
     - -a
     - -tags
@@ -21,6 +21,25 @@ builds:
     - linux
   goarch:
     - amd64
+-
+  id: tbls-linux-arm64
+  flags:
+    - -a
+    - -tags
+    - netgo
+    - -installsuffix
+    - netgo
+  ldflags:
+    - -s -w -X github.com/k1LoW/tbls.version={{.Version}} -X github.com/k1LoW/tbls.commit={{.FullCommit}} -X github.com/k1LoW/tbls.date={{.Date}} -X github.com/k1LoW/tbls/version.Version={{.Version}}
+    - -linkmode external
+    - -extldflags '-static'
+  env:
+    - CGO_ENABLED=1
+    - CC=aarch64-linux-gnu-gcc
+    - CXX=aarch64-linux-gnu-g++
+  goos:
+    - linux
+  goarch:
     - arm64
 archives:
 -


### PR DESCRIPTION
This PR adds an arm64 CPU architecture variant of the Linux build as a release target in addition to the existing amd64 (x86_64) Linux build.

Currently, unlike [`tbls-build`](https://github.com/k1LoW/homebrew-tap/blob/9d4fbacd69cfdc4fd3cd780f45c9e6de92d4ddeb/tbls-build.rb#L17-L26), the release builds of the `tbls` program for macOS are available for both the amd64 and arm64 architectures to support both Intel CPU and Apple CPU, but the release builds for Linux OSes are only available for the amd64 architecture.

There are a couple of use cases where the arm64 arch Linux release of the `tbls` program is valuable:

- Installing `tbls` in a Linux OS container on an Apple CPU macOS machines without resorting to compatibility mode (enabling emulation of the linux/amd64 platform), which could hurt performance and development productivity.
- ~~Installing `tbls` on Raspberry Pi devices, which are powered by ARM processors.~~ This is armhf arch, not arm64.
- Installing `tbls` in workloads (e.g., self-hosted CI/CD pipelines) running on virtual machines and cloud container platforms powered by the [AWS Graviton CPU](https://aws.amazon.com/ec2/graviton/), which is based on the ARM CPU architecture.