### PR TITLE
Fix linux arm64 release build

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install packages
         run: |
           sudo apt-get update
-          sudo apt-get install sqlite3
+          sudo apt-get install sqlite3 gcc-aarch64-linux-gnu
 
       - name: Install aws-cli
         uses: isbang/setup-awscli@v0.1.0


### PR DESCRIPTION
The Linux arm64 arch build requires installing an additional OS package `gcc-aarch64-linux-gnu`. I have altered the CI test (dry-run) config file to install this package in the PR #510, but I forgot to also update the CI config file for real (non-dry-run) releases.

This PR resolves the [error](https://github.com/k1LoW/tbls/actions/runs/6386314568/job/17332776671) during the last release build for Linux caused by this omission.

> cgo: C compiler "aarch64-linux-gnu-gcc" not found: exec: "aarch64-linux-gnu-gcc": executable file not found in $PATH