### PR TITLE
Fix the command line argument for goreleaser release command

### DIFF
--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: --config .goreleaser/linux.yml --rm-clean
+          args: --config .goreleaser/linux.yml --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This PR is another (and hopefully last) attempt of mine to fix the non-dry-run build of Linux releases.

This fix addresses the run error in the latest `linux-release` job of the tagpr CI workflow by making the argument name compatible with the latest version, not the older version referenced by the stale homebrew in the macos-latest CI container image, of `goreleaser`.

>  ⨯ command failed                                   error=unknown flag: --rm-clean

https://github.com/k1LoW/tbls/actions/runs/6386764561/job/17333991521