### PR TITLE
feat:refer viewpoints from tables

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+run: 
+  timeout: 5m
 linters:
   fast: false
   enable:
@@ -7,7 +9,7 @@ linters-settings:
   errcheck:
     check-type-assertions: true
   staticcheck:
-    go: 1.16
+    go: "1.21"
   misspell:
     locale: US
     ignore-words: []

--- a/output/md/md.go
+++ b/output/md/md.go
@@ -538,6 +538,7 @@ func (m *Md) makeTableTemplateData(t *schema.Table) map[string]interface{} {
 	number := m.config.Format.Number
 	adjust := m.config.Format.Adjust
 	hideColumns := m.config.Format.HideColumnsWithoutValues
+	showOnlyFirstParagraph := m.config.Format.ShowOnlyFirstParagraph
 
 	// Columns
 	columnsData := [][]string{}
@@ -603,9 +604,13 @@ func (m *Md) makeTableTemplateData(t *schema.Table) map[string]interface{} {
 	}
 
 	for _, v := range t.Viewpoints {
+		desc := v.Desc
+		if showOnlyFirstParagraph {
+			desc = output.ShowOnlyFirstParagraph(desc)
+		}
 		data := []string{
 			fmt.Sprintf("[%s](viewpoint-%d.md)", v.Name, v.Index),
-			v.Desc,
+			desc,
 		}
 
 		viewpointsData = append(viewpointsData, data)

--- a/output/md/md_test.go
+++ b/output/md/md_test.go
@@ -3,6 +3,7 @@ package md
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/k1LoW/tbls/config"
@@ -62,6 +63,11 @@ func TestOutput(t *testing.T) {
 				t.Fatal(err)
 			}
 			tb.Name = tt.tableBName
+			for _, v := range s.Viewpoints {
+				if vti := slices.Index(v.Tables, "b"); vti != -1 {
+					v.Tables[vti] = tt.tableBName
+				}
+			}
 			c, err := config.New()
 			if err != nil {
 				t.Error(err)

--- a/output/md/templates/table.md.tmpl
+++ b/output/md/templates/table.md.tmpl
@@ -34,7 +34,14 @@
 |{{ range $d := $l }} {{ $d | nl2br }} |{{ end }}
 {{- end }}
 
-{{ $len := len .Constraints }}{{ if ne $len 2 -}}
+{{ $len := len .Viewpoints }}{{ if ne $len 2 -}}
+## {{ "Viewpoints" | lookup }}
+{{ range $l := .Viewpoints }}
+|{{ range $d := $l }} {{ $d | nl2br }} |{{ end }}
+{{- end }}
+
+{{ end -}}
+{{ $len := len .Constraints -}}{{ if ne $len 2 -}}
 ## {{ "Constraints" | lookup }}
 {{ range $l := .Constraints }}
 |{{ range $d := $l }} {{ $d | nl2br }} |{{ end }}

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -11,6 +11,54 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+func TestSetViewpointsToTables(t *testing.T) {
+	viewpointAName := "va"
+	viewpointBName := "vb"
+
+	tests := []struct {
+		viewpointATables     []string
+		viewpointBTables     []string
+		wantTableAViewpoints []*TableViewpoint
+	}{
+		{[]string{"a"}, []string{"b"}, []*TableViewpoint{{Name: viewpointAName}}},
+		{[]string{"a", "b"}, []string{"a"}, []*TableViewpoint{{
+			Index: 0,
+			Name:  viewpointAName,
+		}, {
+			Index: 1,
+			Name:  viewpointBName,
+		}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%v", tt.viewpointATables), func(t *testing.T) {
+			fmt.Println(tt.viewpointATables)
+			s := newTestSchema(t)
+			s.Viewpoints = []*Viewpoint{
+				{
+					Name:   viewpointAName,
+					Tables: tt.viewpointATables,
+				},
+				{
+					Name:   viewpointBName,
+					Tables: tt.viewpointBTables,
+				},
+			}
+			result, err := s.SetViewpointsToTables()
+			if err != nil {
+				t.Error(err)
+			}
+			gotTable, _ := result.FindTableByName("a")
+			got := gotTable.Viewpoints
+			want := tt.wantTableAViewpoints
+
+			if diff := cmp.Diff(got, want, nil); diff != "" {
+				t.Errorf("%s", diff)
+			}
+		})
+	}
+}
+
 func TestNormalizeTableName(t *testing.T) {
 	tests := []struct {
 		s    *Schema
@@ -212,11 +260,11 @@ func TestSchema_Sort(t *testing.T) {
 		},
 		Functions: []*Function{
 			&Function{
-				Name:   "b",
+				Name:      "b",
 				Arguments: "arg b",
 			},
 			&Function{
-				Name:   "b",
+				Name:      "b",
 				Arguments: "arg a",
 			},
 		},

--- a/testdata/md_template_test_a.md.golden
+++ b/testdata/md_template_test_a.md.golden
@@ -19,6 +19,13 @@ THIS IS TABLE A
 | a | INTEGER |  | false | [b](b.md) |  | COLUMN A |
 | a2 | TEXT |  | false |  |  | column a2 |
 
+## Viewpoints
+
+| Name | Definition |
+| ---- | ---------- |
+| [table a b](viewpoint-0.md) | select table a and b |
+| [table a label red](viewpoint-3.md) | select table a and label red<br><br>- table a<br>- label red |
+
 ## Constraints
 
 | Name | Type | Definition | Comment |

--- a/testdata/md_test_a.md.first_para.golden
+++ b/testdata/md_test_a.md.first_para.golden
@@ -20,7 +20,7 @@ TABLE A
 | Name | Definition |
 | ---- | ---------- |
 | [table a b](viewpoint-0.md) | select table a and b |
-| [table a label red](viewpoint-3.md) | select table a and label red<br><br>- table a<br>- label red |
+| [table a label red](viewpoint-3.md) | select table a and label red |
 
 ## Constraints
 

--- a/testdata/md_test_a.md.first_para.golden
+++ b/testdata/md_test_a.md.first_para.golden
@@ -15,6 +15,13 @@ TABLE A
 | a | INTEGER |  | false | [b](b.md) |  | COLUMN A |
 | a2 | TEXT |  | false |  |  | column a2 |
 
+## Viewpoints
+
+| Name | Definition |
+| ---- | ---------- |
+| [table a b](viewpoint-0.md) | select table a and b |
+| [table a label red](viewpoint-3.md) | select table a and label red<br><br>- table a<br>- label red |
+
 ## Constraints
 
 | Name | Type | Definition | Comment |

--- a/testdata/md_test_a.md.golden
+++ b/testdata/md_test_a.md.golden
@@ -15,6 +15,13 @@ TABLE A
 | a | INTEGER |  | false | [b](b.md) |  | COLUMN A |
 | a2 | TEXT |  | false |  |  | column a2 |
 
+## Viewpoints
+
+| Name | Definition |
+| ---- | ---------- |
+| [table a b](viewpoint-0.md) | select table a and b |
+| [table a label red](viewpoint-3.md) | select table a and label red<br><br>- table a<br>- label red |
+
 ## Constraints
 
 | Name | Type | Definition | Comment |

--- a/testdata/md_test_a.md.mermaid.golden
+++ b/testdata/md_test_a.md.mermaid.golden
@@ -15,6 +15,13 @@ TABLE A
 | a | INTEGER |  | false | [b](b.md) |  | COLUMN A |
 | a2 | TEXT |  | false |  |  | column a2 |
 
+## Viewpoints
+
+| Name | Definition |
+| ---- | ---------- |
+| [table a b](viewpoint-0.md) | select table a and b |
+| [table a label red](viewpoint-3.md) | select table a and label red<br><br>- table a<br>- label red |
+
 ## Constraints
 
 | Name | Type | Definition | Comment |

--- a/testdata/templates/table.md.tmpl
+++ b/testdata/templates/table.md.tmpl
@@ -31,7 +31,14 @@
 |{{ range $d := $l }} {{ $d | nl2br }} |{{ end }}
 {{- end }}
 
-{{ $len := len .Constraints }}{{ if ne $len 2 -}}
+{{ $len := len .Viewpoints }}{{ if ne $len 2 -}}
+## {{ "Viewpoints" | lookup }}
+{{ range $l := .Viewpoints }}
+|{{ range $d := $l }} {{ $d | nl2br }} |{{ end }}
+{{- end }}
+
+{{ end -}}
+{{ $len := len .Constraints -}}{{ if ne $len 2 -}}
 ## {{ "Constraints" | lookup }}
 {{ range $l := .Constraints }}
 |{{ range $d := $l }} {{ $d | nl2br }} |{{ end }}


### PR DESCRIPTION
fix: #526 
based on discussion in https://github.com/k1LoW/tbls/pull/530.


To render link to viewpoints from the markdown, the OutputTable function has to know the index of the viewpoints, which was not included in Viewpoint type.

So I added TableViewpoint type like below.
```go
struct TableViewpoint {
    Index Int
    Name String
    Desc String
}
```