### PR TITLE
feat: [MongoDB] Support multiple type field

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,13 @@ dsn: mongodb://mongoadmin:secret@localhost:27017/test
 dsn: mongodb://mongoadmin:secret@localhost:27017/test?sampleSize=20
 ```
 
+If a field has multiple types, the `multipleFieldType` query can be used to list all the types.
+
+``` yaml
+# .tbls.yml
+dsn: mongodb://mongoadmin:secret@localhost:27017/test?sampleSize=20&multipleFieldType=true
+```
+
 **JSON:**
 
 The JSON file output by the `tbls out -t json` command can be read as a datasource.

--- a/datasource/mongo.go
+++ b/datasource/mongo.go
@@ -14,7 +14,10 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 )
 
-const defaultSampleSize = 1000
+const (
+	defaultSampleSize        = 1000
+	defaultMultipleFieldType = false
+)
 
 // AnalyzeMongodb analyze `mongodb://`
 func AnalyzeMongodb(urlstr string) (*schema.Schema, error) {
@@ -50,7 +53,11 @@ func AnalyzeMongodb(urlstr string) (*schema.Schema, error) {
 	if err != nil {
 		sampleSize = defaultSampleSize
 	}
-	driver, err := mongodb.New(ctx, client, dbName, sampleSize)
+	multipleFieldType, err := strconv.ParseBool(values.Get("multipleFieldType"))
+	if err != nil {
+		multipleFieldType = defaultMultipleFieldType
+	}
+	driver, err := mongodb.New(ctx, client, dbName, sampleSize, multipleFieldType)
 	if err != nil {
 		return s, err
 	}

--- a/drivers/mongodb/mongodb_test.go
+++ b/drivers/mongodb/mongodb_test.go
@@ -55,3 +55,57 @@ func TestAnalyze(t *testing.T) {
 		t.Errorf("got not empty string.")
 	}
 }
+
+func Test_addColumnType(t *testing.T) {
+	columns := []*schema.Column{
+		{
+			Name: "username",
+			Type: "string",
+		},
+		{
+			Name: "age",
+			Type: "int",
+		}
+	}
+
+	tests := []struct {
+		name string
+		list []*schema.Column
+		columnName string
+		valueType string
+		want []*schema.Column
+	}{
+		{
+			name: "Existing types are not added"
+			list: columns,
+			columnName: "username",
+			valueType: "string",
+			want: columns,
+		},
+		{
+			name: "New types are added with comma separation"
+			list: columns,
+			columnName: "age",
+			valueType: "string",
+			want: []*schema.Column{
+				{
+					Name: "username",
+					Type: "string",
+				},
+				{
+					Name: "age",
+					Type: "int,string",
+				}
+			}
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := addColumnType(test.list, test.columnName, test.valueType)
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("got %v\nwant %v", got, test.want)
+			}
+		})
+	}
+}

--- a/drivers/mongodb/mongodb_test.go
+++ b/drivers/mongodb/mongodb_test.go
@@ -5,6 +5,7 @@ package mongodb
 import (
 	"context"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -38,7 +39,7 @@ func TestAnalyze(t *testing.T) {
 	s := &schema.Schema{
 		Name: "MongoDB local `docker-mongo-sample-datasets`",
 	}
-	driver, err := New(ctx, client, dbName, 10)
+	driver, err := New(ctx, client, dbName, 10, false)
 	if err != nil {
 		t.Errorf("%v", err)
 	}
@@ -69,24 +70,24 @@ func Test_addColumnType(t *testing.T) {
 	}
 
 	tests := []struct {
-		name string
-		list []*schema.Column
+		name       string
+		list       []*schema.Column
 		columnName string
-		valueType string
-		want []*schema.Column
+		valueType  string
+		want       []*schema.Column
 	}{
 		{
-			name: "Existing types are not added"
-			list: columns,
+			name:       "Existing types are not added",
+			list:       columns,
 			columnName: "username",
-			valueType: "string",
-			want: columns,
+			valueType:  "string",
+			want:       columns,
 		},
 		{
-			name: "New types are added with comma separation"
-			list: columns,
+			name:       "New types are added with comma separation",
+			list:       columns,
 			columnName: "age",
-			valueType: "string",
+			valueType:  "string",
 			want: []*schema.Column{
 				{
 					Name: "username",
@@ -95,8 +96,8 @@ func Test_addColumnType(t *testing.T) {
 				{
 					Name: "age",
 					Type: "int,string",
-				}
-			}
+				},
+			},
 		},
 	}
 

--- a/drivers/mongodb/mongodb_test.go
+++ b/drivers/mongodb/mongodb_test.go
@@ -65,7 +65,7 @@ func Test_addColumnType(t *testing.T) {
 		{
 			Name: "age",
 			Type: "int",
-		}
+		},
 	}
 
 	tests := []struct {


### PR DESCRIPTION
## Issue Context / why we need it

MongoDB is schema-less, so field may have different types. When dealing with such databases, the `$sample` stage may produce different results with each execution.

For example:

```shell
$ cat init/init.js
db.createCollection('tblstest');
db.tblstest.insertMany(
  [
    { name: 'test1', age: 1 },
    { name: 'test2', age: 2 },
    { name: 'test3', age: 3 },
    { name: 'test4', age: 4 },
    { name: 'test5', age: null },
    { name: 'test6', age: null },
    { name: 'test7', age: null },
    { name: 'test8', age: null },
    { name: 'test9', age: 9 },
    { name: 'test10', age: 10 },
  ]
)

$ docker run --rm -it -p 27017:27017 -v $PWD/init:/docker-entrypoint-initdb.d mongo:7.0.3

$ cat .tbls.yml
dsn: mongodb://localhost:27017/test?sampleSize=10
docPath: ./docs/schemas/mongodb
er:
  skip: true

# Repeat multiple times...
$ tbls doc --rm-dist
...

$ git diff
diff --git a/docs/schemas/mongodb/test.tblstest.md b/docs/schemas/mongodb/test.tblstest.md
index d5987f7..881552b 100644
--- a/docs/schemas/mongodb/test.tblstest.md
+++ b/docs/schemas/mongodb/test.tblstest.md
@@ -9,7 +9,7 @@ Count of documents is 10
 | Name | Type | Default | Nullable | Occurrences | Percents | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | ----------- | -------- | -------- | ------- | ------- |
 | _id | objectId |  | false | 5 | 100.0 |  |  |  |
-| age | int32 |  | false | 5 | 100.0 |  |  |  |
+| age | <nil> |  | false | 5 | 100.0 |  |  |  |
 | name | string |  | false | 5 | 100.0 |  |  |  |
```

I think it's bothersome to have differences with each execution, so it would be preferable to either suppress this or output all types of the aggregated documents.

## What this PR does

From the documents selected in the `$sample` stage, all types of the fields will be enumerated with commas separated.  
This can be enabled with the `multipleFieldType` query.

For example:

```shell
$ cat .tbls.yml
dsn: mongodb://localhost:27019/test?sampleSize=10&multipleFieldType=true
docPath: ./docs/schemas/mongodb
er:
  skip: true

$ tbls doc --rm-dist
$ git diff
diff --git a/docs/schemas/mongodb/test.tblstest.md b/docs/schemas/mongodb/test.tblstest.md
index d5987f7..9e30dda 100644
--- a/docs/schemas/mongodb/test.tblstest.md
+++ b/docs/schemas/mongodb/test.tblstest.md
@@ -8,9 +8,9 @@ Count of documents is 10

 | Name | Type | Default | Nullable | Occurrences | Percents | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | ----------- | -------- | -------- | ------- | ------- |
-| _id | objectId |  | false | 5 | 100.0 |  |  |  |
-| age | int32 |  | false | 5 | 100.0 |  |  |  |
-| name | string |  | false | 5 | 100.0 |  |  |  |
+| _id | objectId |  | false | 10 | 100.0 |  |  |  |
+| age | <nil>,int32 |  | false | 10 | 100.0 |  |  |  | # 👈 
+| name | string |  | false | 10 | 100.0 |  |  |  |

```

As one solution, I've implemented this feature, but holding the types in a comma-separated format might be something we need to discuss. I would like to hear your opinion.









