### PR TITLE
Support the case where name in index_info is NULL.

### DIFF
--- a/drivers/sqlite/sqlite.go
+++ b/drivers/sqlite/sqlite.go
@@ -248,7 +248,7 @@ WHERE name != 'sqlite_sequence' AND (type = 'table' OR type = 'view');`)
 			var (
 				colRank            string
 				colRankWithinTable string
-				col                string
+				col                sql.NullString
 				cols               []string
 			)
 			row, err := l.db.Query(fmt.Sprintf("PRAGMA index_info(`%s`)", indexName))
@@ -264,7 +264,9 @@ WHERE name != 'sqlite_sequence' AND (type = 'table' OR type = 'view');`)
 				if err != nil {
 					return errors.WithStack(err)
 				}
-				cols = append(cols, col)
+				if col.Valid {
+					cols = append(cols, col.String)
+				}
 			}
 
 			switch indexCreatedBy {


### PR DESCRIPTION
Fix https://github.com/k1LoW/tbls/issues/578 ( @tcanabrava Thank you!! )
ref: https://www.sqlite.org/pragma.html#pragma_index_info

> 3. The name of the column being indexed. This columns is NULL if the column is the rowid or an expression.