### PR TITLE
Fix some minor typos

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,7 +40,7 @@ import (
 // adjust is a flag on whethre to adjust the notation width of the table
 var adjust bool
 
-// force is a flag on whether to force genarate
+// force is a flag on whether to force generate
 var force bool
 
 // sort is a flag on whether to sort tables, columns, and more

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,7 +37,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// adjust is a flag on whethre to adjust the notation width of the table
+// adjust is a flag on whether to adjust the notation width of the table
 var adjust bool
 
 // force is a flag on whether to force generate

--- a/config/config.go
+++ b/config/config.go
@@ -862,7 +862,7 @@ func detectCardinality(s *schema.Schema) error {
 
 		// parent
 		if r.ParentCardinality == schema.UnknownCardinality {
-			// whether the child colums are nullable or not.
+			// whether the child columns are nullable or not.
 			nullable := true
 			for _, c := range r.Columns {
 				if !c.Nullable {

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -223,7 +223,7 @@ func (s *Schema) FindTableByName(name string) (*Table, error) {
 	return nil, errors.Errorf("not found table '%s'", name)
 }
 
-// FindRelation find relation by columns and parent colums
+// FindRelation find relation by columns and parent columns
 func (s *Schema) FindRelation(cs, pcs []*Column) (*Relation, error) {
 L:
 	for _, r := range s.Relations {


### PR DESCRIPTION
I don't mean to be nit-picky, but this is a suggestion to correct some minor typos.

- `colums`  → `columns`
- `genarate` → `generate`
- `whethre` → `whether`