### PR TITLE
Address lint errors

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -550,47 +550,6 @@ func (c *Config) mergeDictFromSchema(s *schema.Schema) {
 	}
 }
 
-func excludeTableFromSchema(name string, s *schema.Schema) error {
-	// Tables
-	tables := []*schema.Table{}
-	for _, t := range s.Tables {
-		if t.Name != name {
-			tables = append(tables, t)
-		}
-		for _, c := range t.Columns {
-			// ChildRelations
-			childRelations := []*schema.Relation{}
-			for _, r := range c.ChildRelations {
-				if r.Table.Name != name && r.ParentTable.Name != name {
-					childRelations = append(childRelations, r)
-				}
-			}
-			c.ChildRelations = childRelations
-
-			// ParentRelations
-			parentRelations := []*schema.Relation{}
-			for _, r := range c.ParentRelations {
-				if r.Table.Name != name && r.ParentTable.Name != name {
-					parentRelations = append(parentRelations, r)
-				}
-			}
-			c.ParentRelations = parentRelations
-		}
-	}
-	s.Tables = tables
-
-	// Relations
-	relations := []*schema.Relation{}
-	for _, r := range s.Relations {
-		if r.Table.Name != name && r.ParentTable.Name != name {
-			relations = append(relations, r)
-		}
-	}
-	s.Relations = relations
-
-	return nil
-}
-
 // MaskedDSN return DSN mask password
 func (c *Config) MaskedDSN() (string, error) {
 	u, err := url.Parse(c.DSN.URL)
@@ -903,17 +862,6 @@ func detectPKFK(s *schema.Schema) error {
 		}
 	}
 	return nil
-}
-
-func matchLabels(il []string, l schema.Labels) bool {
-	for _, ll := range l {
-		for _, ill := range il {
-			if wildcard.MatchSimple(ill, ll.Name) {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func match(s []string, e string) bool {

--- a/drivers/mongodb/mongodb.go
+++ b/drivers/mongodb/mongodb.go
@@ -95,7 +95,8 @@ func (d *Mongodb) listFields(collection *mongo.Collection) ([]*schema.Column, er
 			return columns, err
 		}
 		total += 1
-		for key, value := range result.Map() {
+		for _, entry := range result {
+			key, value := entry.Key, entry.Value
 			var valueType string
 			switch value.(type) {
 			case string:

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -499,6 +499,9 @@ WHERE t.table_schema = ?
 	})
 	for _, r := range relations {
 		strColumns, strParentTable, strParentColumns, err := parseFK(r.Def)
+		if err != nil {
+			return err
+		}
 		for _, c := range strColumns {
 			column, err := r.Table.FindColumnByName(c)
 			if err != nil {

--- a/drivers/sqlite/sqlite.go
+++ b/drivers/sqlite/sqlite.go
@@ -366,6 +366,9 @@ SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND tbl_name = ?;
 	// Relations
 	for _, r := range relations {
 		strColumns, strParentTable, strParentColumns, err := parseFK(r.Def)
+		if err != nil {
+			return err
+		}
 		for _, c := range strColumns {
 			column, err := r.Table.FindColumnByName(c)
 			if err != nil {


### PR DESCRIPTION
- Remove unused config functions (these were moved to `filter.go` in 1bed38d)
- Use entries of mongodb bson.D result directly instead of using the deprecated Map method.
- Don't ignore err results from utility functions.

I really like being able to rely on `make lint` being clean, seeing errors there, even if not in my own PR changes, makes me itch. 😅 

Specifically, these lint issues have been addressed:

```
golangci-lint run ./...
drivers/mysql/mysql.go:501:49: ineffectual assignment to err (ineffassign)
                strColumns, strParentTable, strParentColumns, err := parseFK(r.Def)
                                                              ^
drivers/mongodb/mongodb.go:98:27: SA1019: result.Map is deprecated: Converting directly from a D to an M will not be supported in Go Driver 2.0. Instead, users should marshal the D to BSON using bson.Marshal and unmarshal it to M using bson.Unmarshal. (staticcheck)
                for key, value := range result.Map() {
                                        ^
drivers/sqlite/sqlite.go:368:49: ineffectual assignment to err (ineffassign)
                strColumns, strParentTable, strParentColumns, err := parseFK(r.Def)
                                                              ^
config/config.go:553:6: func `excludeTableFromSchema` is unused (unused)
func excludeTableFromSchema(name string, s *schema.Schema) error {
     ^
config/config.go:908:6: func `matchLabels` is unused (unused)
func matchLabels(il []string, l schema.Labels) bool {
     ^
```