### PR TITLE
Add existing virtual relation strategies to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -977,27 +977,15 @@ detectVirtualRelations:
   strategy: default
 ```
 
-**`default` strategy:**
+##### Supported strategies
 
-``` yaml
-detectVirtualRelations:
-  enabled: true
-  strategy: default
-```
+| strategy name                | relation from        | relation to     |
+| :--                          | :--                  | :--             |
+| `default`                    | `some_table.user_id` | `users.id`      |
+| `singularTableName`          | `some_table.user_id` | `user.id`       |
+| `identical`                  | `some_table.user_id` | `users.user_id` |
+| `identicalSingularTableName` | `some_table.user_id` | `user.user_id`  |
 
-- some_table.user_id -> users.id
-- some_table.post_id -> posts.id
-
-**`singularTableName` strategy:**
-
-``` yaml
-detectVirtualRelations:
-  enabled: true
-  strategy: singularTableName
-```
-
-- some_table.user_id -> user.id
-- some_table.post_id -> post.id
 
 ### Dictionary
 


### PR DESCRIPTION
## About

I found undocumented strategies: `identical`, `identicalSingularTableName`

https://github.com/k1LoW/tbls/blob/76d30f8358993e7111e98afce77fee5f49b79065/config/naming.go#L24-L49

I just wanted to use an `identiacal` strategy.