### PR TITLE
feat(postgres): Ensure ordering of index columns is always stable

### DIFF
--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -698,7 +698,7 @@ ORDER BY idx.indexrelid`
 SELECT
   cls.relname AS indexname,
   pg_get_indexdef(idx.indexrelid) AS indexdef,
-  ARRAY_AGG(attr.attname),
+  ARRAY_AGG(attr.attname ORDER BY attr.attnum ASC),
   descr.description AS comment
 FROM pg_index AS idx
 INNER JOIN pg_class AS cls ON idx.indexrelid = cls.oid


### PR DESCRIPTION
Hello 👋

First of all, thanks for the great work on this project!

I use `tbls` with Postgres in the CI pipeline of some services I work on in my daily job and I noticed that the order of the columns in multi-column indexes is not always stable. In particular, it can change across different Postgres versions because the [query](https://github.com/k1LoW/tbls/blob/main/drivers/postgres/postgres.go#L701) used to analyze the schema does not specify an order for the column names.

This PR adds an `ORDER BY attr.attnum ASC` clause to such query so that the column names are always returned in the same order for multi-column indexes. This order _should_ match the actual definition of the index (even if I'm not 100% sure, as the official [docs](https://www.postgresql.org/docs/current/catalog-pg-attribute.html) are not super clear about it 😅).

Thanks!