### PR TITLE
Fix schema filter logic to prevent duplicated counts of tables

### DIFF
--- a/schema/filter.go
+++ b/schema/filter.go
@@ -81,6 +81,8 @@ func (s *Schema) SepareteTablesThatAreIncludedOrNot(opt *FilterOption) (_ []*Tab
 		for _, tt := range ts {
 			if !lo.ContainsBy(includes, func(t *Table) bool {
 				return tt.Name == t.Name
+			}) && !lo.ContainsBy(includes2, func(t *Table) bool {
+				return tt.Name == t.Name
 			}) {
 				includes2 = append(includes2, tt)
 			}


### PR DESCRIPTION
When I tested the schema filter function with a Distance of 3 in a very small schema for the development, I noticed the following error often occurs in filter.go:

> Failed to load schema: failed to filter schema: failed to separate tables. expected: 10, actual: 16

By checking the function, I found a bug in the aggregation logic of the filter function, which caused duplicate tables to be counted in `includes2`, so I had fix it.