### PR TITLE
touch up grammar, punctuation, and Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Build Status](https://github.com/k1LoW/tbls/workflows/build/badge.svg)](https://github.com/k1LoW/tbls/actions) [![GitHub release](https://img.shields.io/github/release/k1LoW/tbls.svg)](https://github.com/k1LoW/tbls/releases) [![Go Report Card](https://goreportcard.com/badge/github.com/k1LoW/tbls)](https://goreportcard.com/report/github.com/k1LoW/tbls) ![Coverage](https://raw.githubusercontent.com/k1LoW/octocovs/main/badges/k1LoW/tbls/coverage.svg) ![Code to Test Ratio](https://raw.githubusercontent.com/k1LoW/octocovs/main/badges/k1LoW/tbls/ratio.svg) ![Test Execution Time](https://raw.githubusercontent.com/k1LoW/octocovs/main/badges/k1LoW/tbls/time.svg)
 
-`tbls` ( is pronounced /ˈteɪbl̩z/. ) is a CI-Friendly tool for document a database, written in Go.
+`tbls` (pronounced /ˈteɪbl̩z/) is a CI-Friendly tool to document a database, written in Go.
 
 Key features of `tbls` are:
 
@@ -21,7 +21,7 @@ Key features of `tbls` are:
   - [Install](#install)
   - [Getting Started](#getting-started)
     - [Document a database](#document-a-database)
-    - [Diff database and ( document or database )](#diff-database-and--document-or-database-)
+    - [Diff database and (document or database)](#diff-database-and--document-or-database-)
     - [Lint a database](#lint-a-database)
     - [Measure document coverage](#measure-document-coverage)
     - [Continuous Integration](#continuous-integration)
@@ -53,7 +53,7 @@ Key features of `tbls` are:
 
 Document a database with one command.
 
-``` console
+```console
 $ tbls doc postgres://dbuser:dbpass@hostname:5432/dbname
 ```
 
@@ -67,7 +67,7 @@ $ docker run --rm -v $PWD:/work -w /work ghcr.io/k1low/tbls doc postgres://dbuse
 
 **deb:**
 
-``` console
+```console
 $ export TBLS_VERSION=X.X.X
 $ curl -o tbls.deb -L https://github.com/k1LoW/tbls/releases/download/v$TBLS_VERSION/tbls_$TBLS_VERSION-1_amd64.deb
 $ dpkg -i tbls.deb
@@ -75,7 +75,7 @@ $ dpkg -i tbls.deb
 
 **RPM:**
 
-``` console
+```console
 $ export TBLS_VERSION=X.X.X
 $ yum install https://github.com/k1LoW/tbls/releases/download/v$TBLS_VERSION/tbls_$TBLS_VERSION-1_amd64.rpm
 ```
@@ -139,15 +139,15 @@ jobs:
         run: tbls doc
 ```
 
-**:octocat: GitHub Actions for tbls is [here](https://github.com/k1LoW/setup-tbls).**
+**:octocat: A GitHub Action for tbls is [here](https://github.com/k1LoW/setup-tbls).**
 
 **Temporary:**
 
-``` console
+```console
 $ source <(curl https://raw.githubusercontent.com/k1LoW/tbls/main/use)
 ```
 
-``` console
+```console
 $ curl -sL https://raw.githubusercontent.com/k1LoW/tbls/main/use > /tmp/use-tbls.tmp && . /tmp/use-tbls.tmp
 ```
 
@@ -155,9 +155,9 @@ $ curl -sL https://raw.githubusercontent.com/k1LoW/tbls/main/use > /tmp/use-tbls
 
 ### Document a database
 
-Add `.tbls.yml` ( or `tbls.yml` ) file to your repository.
+Add `.tbls.yml` (or `tbls.yml`) file to your repository.
 
-``` yaml
+```yaml
 # .tbls.yml
 
 # DSN (Database Source Name) to connect database
@@ -172,13 +172,13 @@ docPath: doc/schema
 
 Run `tbls doc` to analyzes the database and generate document in GitHub Friendly Markdown format.
 
-``` console
+```console
 $ tbls doc
 ```
 
 Commit `.tbls.yml` and the document.
 
-``` console
+```console
 $ git add .tbls.yml doc/schema
 $ git commit -m 'Add database document'
 $ git push origin main
@@ -190,11 +190,11 @@ View the document on GitHub.
 
 ![sample](img/doc.png)
 
-### Diff database and ( document or database )
+### Diff database and (document or database)
 
 Update database schema.
 
-``` console
+```console
 $ psql -U dbuser -d dbname -h hostname -p 5432 -c 'ALTER TABLE users ADD COLUMN phone_number varchar(15);'
 Password for user dbuser:
 ALTER TABLE
@@ -202,7 +202,7 @@ ALTER TABLE
 
 `tbls diff` shows the difference between database schema and generated document.
 
-``` diff
+```diff
 $ tbls diff
 diff postgres://dbuser:*****@hostname:5432/dbname doc/schema/README.md
 --- postgres://dbuser:*****@hostname:5432/dbname
@@ -231,7 +231,7 @@ diff postgres://dbuser:*****@hostname:5432/dbname doc/schema/users.md
 
 And, `tbls diff` support for diff checking between database and other database
 
-``` console
+```console
 $ tbls diff postgres://dbuser:*****@local:5432/dbname postgres://dbuser:*****@production:5432/dbname
 ```
 
@@ -257,7 +257,7 @@ $ tbls doc --rm-dist
 
 Add linting rule to `.tbls.yml` following
 
-``` yaml
+```yaml
 # .tbls.yml
 lint:
   requireColumnComment:
@@ -273,7 +273,7 @@ lint:
 
 Run `tbls lint` to check the database according to `lint:` rules
 
-``` console
+```console
 $ tbls lint
 users.username: column comment required.
 users.password: column comment required.
@@ -292,9 +292,9 @@ comments: too many columns. [11/10]
 
 ### Measure document coverage
 
-`tbls coverage` measure and show document coverage ( description, comments ).
+`tbls coverage` measure and show document coverage (description, comments).
 
-``` console
+```console
 $ tbls coverage
 Table                       Coverage
 All tables                  16.1%
@@ -327,7 +327,7 @@ Continuous integration using tbls.
 
 **Example: Travis CI**
 
-``` yaml
+```yaml
 # .travis.yml
 language: go
 
@@ -348,7 +348,7 @@ script:
 
 `name:` is used to specify the database name of the document.
 
-``` yaml
+```yaml
 # .tbls.yml
 name: mydatabase
 ```
@@ -357,7 +357,7 @@ name: mydatabase
 
 `desc:` is used to specify the database description.
 
-``` yaml
+```yaml
 # .tbls.yml
 desc: This is My Database
 ```
@@ -368,7 +368,7 @@ desc: This is My Database
 
 **label database:**
 
-``` yaml
+```yaml
 # .tbls.yml
 labels:
   - cmdb
@@ -377,7 +377,7 @@ labels:
 
 **label tables:**
 
-``` yaml
+```yaml
 # .tbls.yml
 comments:
   -
@@ -389,7 +389,7 @@ comments:
 
 **label columns:**
 
-``` yaml
+```yaml
 # .tbls.yml
 comments:
   -
@@ -404,7 +404,7 @@ comments:
 
 `dsn:` (Data Source Name) is used to connect to database.
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: my://dbuser:dbpass@hostname:3306/dbname
 ```
@@ -415,30 +415,30 @@ tbls supports the following databases/datasources.
 
 **PostgreSQL:**
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: postgres://dbuser:dbpass@hostname:5432/dbname
 ```
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: pg://dbuser:dbpass@hostname:5432/dbname
 ```
 
 When you want to disable SSL mode, add "?sslmode=disable"
 For example:
-``` yaml
+```yaml
 dsn: pg://dbuser:dbpass@hostname:5432/dbname?sslmode=disable
 ```
 
 **MySQL:**
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: mysql://dbuser:dbpass@hostname:3306/dbname
 ```
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: my://dbuser:dbpass@hostname:3306/dbname
 ```
@@ -446,42 +446,42 @@ dsn: my://dbuser:dbpass@hostname:3306/dbname
 When you want to hide AUTO_INCREMENT clause on the table definitions,
 add "?hide_auto_increment".
 For example:
-``` yaml
+```yaml
 dsn: my://dbuser:dbpass@hostname:3306/dbname?hide_auto_increment
 ```
 
 **MariaDB:**
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: mariadb://dbuser:dbpass@hostname:3306/dbname
 ```
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: maria://dbuser:dbpass@hostname:3306/dbname
 ```
 
 **SQLite:**
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: sqlite:///path/to/dbname.db
 ```
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: sq:///path/to/dbname.db
 ```
 
 **BigQuery:**
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: bigquery://project-id/dataset-id?creds=/path/to/google_application_credentials.json
 ```
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: bq://project-id/dataset-id?creds=/path/to/google_application_credentials.json
 ```
@@ -504,7 +504,7 @@ Also, you can use impersonate service account using environment variables below.
 
 **Cloud Spanner:**
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: spanner://project-id/instance-id/dbname?creds=/path/to/google_application_credentials.json
 ```
@@ -524,41 +524,41 @@ Also, you can use impersonate service account using environment variables below.
 
 **Amazon Redshift:**
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: redshift://dbuser:dbpass@hostname:5432/dbname
 ```
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: rs://dbuser:dbpass@hostname:5432/dbname
 ```
 
 **Microsoft SQL Server:**
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: mssql://DbUser:SQLServer-DbPassw0rd@hostname:1433/testdb
 ```
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: sqlserver://DbUser:SQLServer-DbPassw0rd@hostname:1433/testdb
 ```
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: ms://DbUser:SQLServer-DbPassw0rd@localhost:1433/testdb
 ```
 
 **Amazon DynamoDB:**
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: dynamodb://us-west-2
 ```
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: dynamo://ap-northeast-1?aws_access_key_id=XXXXXxxxxxxxXXXXXXX&aws_secret_access_key=XXXXXxxxxxxxXXXXXXX
 ```
@@ -571,7 +571,7 @@ To set AWS credentials, you can use
 
 **Snowflake (Experimental):**
 
-``` yaml
+```yaml
 ---
 # .tbls.yml
 dsn: snowflake://user:password@myaccount/mydb/myschema
@@ -581,26 +581,26 @@ See also: https://pkg.go.dev/github.com/snowflakedb/gosnowflake
 
 **MongoDB:**
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: mongodb://mongoadmin:secret@localhost:27017/test
 ```
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: mongodb://mongoadmin:secret@localhost:27017/test?sampleSize=20
 ```
 
 If a field has multiple types, the `multipleFieldType` query can be used to list all the types.
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: mongodb://mongoadmin:secret@localhost:27017/test?sampleSize=20&multipleFieldType=true
 ```
 
 **ClickHouse:**
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: clickhouse://dbuser:dbpass@hostname:9000/dbname
 ```
@@ -611,7 +611,7 @@ See also: https://pkg.go.dev/github.com/ClickHouse/clickhouse-go
 
 The JSON file output by the `tbls out -t json` command can be read as a datasource.
 
-``` yaml
+```yaml
 ---
 # .tbls.yml
 dsn: json://path/to/testdb.json
@@ -619,13 +619,13 @@ dsn: json://path/to/testdb.json
 
 **HTTP:**
 
-``` yaml
+```yaml
 ---
 # .tbls.yml
 dsn: https://hostname/path/to/testdb.json
 ```
 
-``` yaml
+```yaml
 ---
 # .tbls.yml
 dsn:
@@ -636,7 +636,7 @@ dsn:
 
 **GitHub:**
 
-``` yaml
+```yaml
 ---
 # .tbls.yml
 dsn: github://k1LoW/tbls/sample/mysql/schema.json
@@ -646,7 +646,7 @@ dsn: github://k1LoW/tbls/sample/mysql/schema.json
 
 `tbls doc` generates document in the directory specified by `docPath:`.
 
-``` yaml
+```yaml
 # .tbls.yml
 # Default is `dbdoc`
 docPath: doc/schema
@@ -656,7 +656,7 @@ docPath: doc/schema
 
 `format:` is used to change the document format.
 
-``` yaml
+```yaml
 # .tbls.yml
 format:
   # Adjust the column width of Markdown format table
@@ -682,7 +682,7 @@ format:
 
 `tbls doc` generate ER diagram images at the same time.
 
-``` yaml
+```yaml
 # .tbls.yml
 er:
   # Skip generation of ER diagram
@@ -707,7 +707,7 @@ er:
   # Default is 1
   distance: 2
   # ER diagram (png/jpg) font (font name, font file, font path or keyword)
-  # Default is "" ( system default )
+  # Default is "" (system default)
   font: M+
 ```
 
@@ -718,7 +718,7 @@ See the [Personalized Templates](#personalized-templates) section below.
 
 `tbls lint` work as linter for database.
 
-``` yaml
+```yaml
 # .tbls.yml
 lint:
   # require table comment
@@ -818,7 +818,7 @@ lint:
     enabled: true
     exclude:
       - comments.user_id
-  # checks if labels are in BigQuery style ( https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements )
+  # checks if labels are in BigQuery style (https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements)
   labelStyleBigQuery:
     enabled: true
     exclude:
@@ -836,7 +836,7 @@ lint:
 
 `include:` and `exclude:` are used to filter target tables from `tbls *`.
 
-``` yaml
+```yaml
 # .tbls.yml
 include:
   - some_prefix_*
@@ -847,7 +847,7 @@ exclude:
 
 `lintExclude:` is used to exclude tables from `tbls lint`.
 
-``` yaml
+```yaml
 # .tbls.yml
 lintExclude:
   - CamelizeTable
@@ -858,7 +858,7 @@ lintExclude:
 1. Add tables from include
 2. Remove tables from exclude
     - Check for include/exclude overlaps
-    - If include is more specific than exclude (i.e. `schema.MyTable` > `schema.*` or `schema.MyT*` > `schema.*` ), include the table(s). If include is equally or less specific than exclude, exclude wins.
+    - If include is more specific than exclude (i.e. `schema.MyTable` > `schema.*` or `schema.MyT*` > `schema.*`), include the table(s). If include is equally or less specific than exclude, exclude wins.
 3. Result
 
 ### Comments
@@ -867,7 +867,7 @@ lintExclude:
 
 For example, you can add comment about VIEW TABLE or SQLite tables/columns.
 
-``` yaml
+```yaml
 # .tbls.yml
 comments:
   -
@@ -910,7 +910,7 @@ comments:
 
 You can create ER diagrams with relations without having foreign key constraints.
 
-``` yaml
+```yaml
 relations:
   -
     table: logs
@@ -952,7 +952,7 @@ relations:
 
 If you want to override an existing relation, set the `override:` to `true`.
 
-``` yaml
+```yaml
 relations:
   -
     table: posts
@@ -971,7 +971,7 @@ relations:
 
 `detectVirtualRelations:` if enabled, automatically detect relations from table and column names.
 
-``` yaml
+```yaml
 detectVirtualRelations:
   enabled: true
   strategy: default
@@ -991,7 +991,7 @@ detectVirtualRelations:
 
 `dict:` is used to replace title/table header of database document
 
-``` yaml
+```yaml
 # .tbls.yml
 ---
 dict:
@@ -1044,7 +1044,7 @@ requiredVersion: '>= 1.42, < 2'
 
 All configuration values can be set by expanding the environment variables.
 
-``` yaml
+```yaml
 # .tbls.yml
 dsn: my://${MYSQL_USER}:${MYSQL_PASSWORD}@hostname:3306/${MYSQL_DATABASE}
 ```
@@ -1053,7 +1053,7 @@ dsn: my://${MYSQL_USER}:${MYSQL_PASSWORD}@hostname:3306/${MYSQL_DATABASE}
 Viewpoints of your database schema based on concerns of your domain and add description to them.
 You can also define groups of tables within viewpoints.
 
-``` yaml
+```yaml
 # .tbls.yml
 
 viewpoints:
@@ -1090,75 +1090,75 @@ viewpoints:
 
 **Markdown:**
 
-``` console
+```console
 $ tbls out -t md -o schema.md
 ```
 
 **DOT:**
 
-``` console
+```console
 $ tbls out -t dot -o schema.dot
 ```
 
 **PlantUML:**
 
-``` console
+```console
 $ tbls out -t plantuml -o schema.puml
 ```
 
 **Mermaid:**
 
-``` console
+```console
 $ tbls out -t mermaid -o schema.mmd
 ```
 
 **Image (svg, png, jpg):**
 
-``` console
+```console
 $ tbls out -t svg --table users --distance 2 -o users.svg
 ```
 
 **JSON:**
 
-``` console
+```console
 $ tbls out -t json -o schema.json
 ```
 
 > **Tips:** `tbls doc` can load `schema.json` as DSN.
 >
-> ``` console
+> ```console
 > $ tbls doc json:///path/to/schema.json
 > ```
 
 **YAML:**
 
-``` console
+```console
 $ tbls out -t yaml -o schema.yaml
 ```
 
 **Excel:**
 
-``` console
+```console
 $ tbls out -t xlsx -o schema.xlsx
 ```
 
 **.tbls.yml:**
 
-``` console
+```console
 $ tbls out -t config -o .tbls.new.yml
 ```
 
 ## Command arguments
 
-tbls subcommands ( `doc`,`diff`, etc) accepts arguments and options
+tbls subcommands (`doc`,`diff`, etc) accepts arguments and options
 
-``` console
+```console
 $ tbls doc my://root:mypass@localhost:3306/testdb doc/schema
 ```
 
 You can check available arguments and options using `tbls help [COMMAND]`.
 
-``` console
+```console
 $ tbls help doc
 'tbls doc' analyzes a database and generate document in GitHub Friendly Markdown format.
 
@@ -1180,7 +1180,7 @@ Flags:
 
 ## Output Schema data
 
-`tbls doc` also output schema data ( `schema.json` ) to same directory as the generated schema document.
+`tbls doc` also output schema data (`schema.json`) to same directory as the generated schema document.
 
 To disable output of schema data, set `disableOutputSchema:` to `true` in `.tbls.yml` file.
 
@@ -1188,6 +1188,6 @@ To disable output of schema data, set `disableOutputSchema:` to `true` in `.tbls
 
 tbls accepts environment variables `TBLS_DSN` and `TBLS_DOC_PATH`
 
-``` console
+```console
 $ env TBLS_DSN=my://root:mypass@localhost:3306/testdb TBLS_DOC_PATH=doc/schema tbls doc
 ```


### PR DESCRIPTION
I haven't gone through the whole README, but I found a number of things that could be improved. 

Although "for" was sometimes used like this in archaic forms of English (Middle English?  Early Modern?) it is not used in current Modern English (and I think it was always "for to" back when it _was_ used—I don't remember).

In regard to code fences, it does appear that GitHub allows the language identifier to have a space before it (and after the 3 backticks) but their guide shows it without a space, and I'm not sure whether other Markdown parsers would allow that space (which I've never seen before).  If you really like the space I can modify the PR to add them back, but I think it's much safer to do without them.

https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#syntax-highlighting