### PR TITLE
Support external database driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ TBLS ?= ./tbls
 
 default: test
 
-ci: depsdev build db test testdoc testdoc_hide_auto_increment test_too_many_tables test_json test_ext_subcommand test_jsonschema doc
+ci: depsdev build db test testdoc testdoc_hide_auto_increment test_too_many_tables test_json test_ext_subcommand test_ext_driver test_jsonschema doc
 
 ci_windows: depsdev build db_sqlite testdoc_sqlite
 
@@ -146,6 +146,9 @@ test_ext_subcommand: build
 	env PATH="${PWD}/testdata/bin:${PATH}" $(TBLS) echo -c ./testdata/ext_subcommand_tbls.yml | grep 'TBLS_CONFIG_PATH=' | grep 'testdata/ext_subcommand_tbls.yml' > /dev/null
 	env PATH="${PWD}/testdata/bin:${PATH}" TBLS_DSN=pg://postgres:pgpass@localhost:55432/testdb?sslmode=disable $(TBLS) echo | grep 'TBLS_DSN=pg://postgres:pgpass@localhost:55432/testdb?sslmode=disable' > /dev/null
 	echo hello | env PATH="${PWD}/testdata/bin:${PATH}" $(TBLS) echo -c ./testdata/ext_subcommand_tbls.yml | grep 'STDIN=hello' > /dev/null
+
+test_ext_driver: build
+	env PATH="${PWD}/testdata/bin:${PATH}" $(TBLS) ls --dsn foodb://bar | grep 'users' > /dev/null
 
 test_jsonschema:
 	cd scripts/jsonschema && go run main.go | diff -u ../../spec/tbls.schema.json_schema.json -

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,6 +29,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cli/safeexec"
 	"github.com/k1LoW/errors"
 	"github.com/k1LoW/tbls/cmdutil"
 	"github.com/k1LoW/tbls/config"
@@ -127,7 +128,7 @@ var rootCmd = &cobra.Command{
 
 		envs := os.Environ()
 		subCmd := args[0]
-		path, err := exec.LookPath(version.Name + "-" + subCmd)
+		bin, err := safeexec.LookPath(version.Name + "-" + subCmd)
 		if err != nil {
 			if strings.HasPrefix(subCmd, "-") {
 				cmd.PrintErrf("Error: unknown flag: '%s'\n", subCmd)
@@ -168,7 +169,7 @@ var rootCmd = &cobra.Command{
 			envs = append(envs, fmt.Sprintf("TBLS_SCHEMA=%s", tmpfile.Name()))
 		}
 
-		c := exec.Command(path, args...) // #nosec
+		c := exec.Command(bin, args...) // #nosec
 		c.Env = envs
 		c.Stdout = os.Stdout
 		c.Stdin = os.Stdin
@@ -251,6 +252,10 @@ func getExtSubCmds(prefix string) ([]string, error) {
 				continue
 			}
 			if !strings.HasPrefix(e.Name(), fmt.Sprintf("%s-", prefix)) {
+				continue
+			}
+			// Exclude external driver
+			if strings.HasPrefix(e.Name(), fmt.Sprintf("%s-driver-", prefix)) {
 				continue
 			}
 			fi, err := e.Info()

--- a/testdata/bin/tbls-driver-foodb
+++ b/testdata/bin/tbls-driver-foodb
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+dir=$(cd $(dirname $0); pwd)
+
+cat ${dir}/../test_schema.json


### PR DESCRIPTION
If the executable `tbls-driver-foodb` is on the PATH, tbls will recognize the `foodb://` scheme.