### PR TITLE
Fix errcheck related to type assertion

### DIFF
--- a/cmdutil/when.go
+++ b/cmdutil/when.go
@@ -1,6 +1,7 @@
 package cmdutil
 
 import (
+	"fmt"
 	"os"
 	"strings"
 
@@ -46,8 +47,10 @@ func IsAllowedToExecute(when string) (bool, error) {
 	}
 	if got, err := expr.Run(program, whenEnv); err != nil {
 		return false, errors.WithStack(err)
+	} else if got, ok := got.(bool); !ok {
+		return false, fmt.Errorf("expected bool, but got %T", got)
 	} else {
-		return got.(bool), nil
+		return got, nil
 	}
 }
 

--- a/cmdutil/when_test.go
+++ b/cmdutil/when_test.go
@@ -113,15 +113,27 @@ func TestIsAllowedToExecute(t *testing.T) {
 			want:          false,
 			errorContains: "unknown name NoneSuchVariable",
 		},
+		{
+			name:          "Expression produces an integer",
+			envset:        map[string]string{},
+			when:          "123",
+			want:          false,
+			errorContains: "expected bool, but got int",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			NewWhenEnv = func() *WhenEnv { return &WhenEnv{Env: tt.envset} }
 			got, err := IsAllowedToExecute(tt.when)
+
 			if err != nil {
 				if tt.errorContains != nil {
-					if !strings.Contains(err.Error(), tt.errorContains.(string)) {
-						t.Errorf("Error %v does not contain %s", err, tt.errorContains)
+					if errStr, ok := tt.errorContains.(string); ok {
+						if !strings.Contains(err.Error(), errStr) {
+							t.Errorf("Error %v does not contain %s", err, errStr)
+						}
+					} else {
+						t.Errorf("errorContains should be a string, but got %T", tt.errorContains)
 					}
 				} else {
 					t.Error(err)
@@ -129,9 +141,11 @@ func TestIsAllowedToExecute(t *testing.T) {
 			} else if tt.errorContains != nil {
 				t.Errorf("Expected an error containing %v", tt.errorContains)
 			}
+
 			if got != tt.want {
 				t.Errorf("got %v\nwant %v", got, tt.want)
 			}
 		})
 	}
+
 }

--- a/cmdutil/when_test.go
+++ b/cmdutil/when_test.go
@@ -125,7 +125,6 @@ func TestIsAllowedToExecute(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			NewWhenEnv = func() *WhenEnv { return &WhenEnv{Env: tt.envset} }
 			got, err := IsAllowedToExecute(tt.when)
-
 			if err != nil {
 				if tt.errorContains != nil {
 					if errStr, ok := tt.errorContains.(string); ok {
@@ -141,11 +140,9 @@ func TestIsAllowedToExecute(t *testing.T) {
 			} else if tt.errorContains != nil {
 				t.Errorf("Expected an error containing %v", tt.errorContains)
 			}
-
 			if got != tt.want {
 				t.Errorf("got %v\nwant %v", got, tt.want)
 			}
 		})
 	}
-
 }

--- a/config/yaml.go
+++ b/config/yaml.go
@@ -72,7 +72,9 @@ func (f *Format) UnmarshalYAML(data []byte) error {
 	case []interface{}:
 		values := []string{}
 		for _, vv := range v {
-			values = append(values, vv.(string))
+			if str, ok := vv.(string); ok {
+				values = append(values, str)
+			}
 		}
 		f.HideColumnsWithoutValues = values
 	}

--- a/dict/dict.go
+++ b/dict/dict.go
@@ -18,7 +18,9 @@ func New() Dict {
 
 func (d *Dict) Lookup(k string) string {
 	if v, ok := d.s.Load(k); ok {
-		return v.(string)
+		if str, ok := v.(string); ok {
+			return str
+		}
 	}
 	return k
 }


### PR DESCRIPTION
# Description
I noticed that errcheck was returning an error by running `make lint`.
It seems to be caused by missing return value checks in a type assertion.

```sh
Error return value is not checked (errcheck)
```

# Steps to Reproduce
```sh
make lint
```

# What I Did
I addressed the root cause of the errcheck issue by adding conditional branching to the type assertion.

I decided to keep the function signature the same.

Although ignoring the error could be an option to avoid redundant error handling, I decided to handle it properly rather than ignoring it carelessly.

# What I confirmed
- The error disappeared with `make lint`
- The test cases for the changed parts passed

# Others
This is my first PR to tbls.
I often use tbls because they are easy to use and useful.
Thanks for tbls. :D