### PR TITLE
nit: Fix typo

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -466,7 +466,7 @@ func (c *Config) ModifySchema(s *schema.Schema) error {
 			return t.Name
 		})
 		for _, g := range v.Groups {
-			gt, _, err := cs.SepareteTablesThatAreIncludedOrNot(&schema.FilterOption{
+			gt, _, err := cs.SeparateTablesThatAreIncludedOrNot(&schema.FilterOption{
 				Include:       g.Tables,
 				IncludeLabels: g.Labels,
 			})

--- a/output/dot/dot.go
+++ b/output/dot/dot.go
@@ -93,7 +93,7 @@ func (d *Dot) OutputViewpoint(wr io.Writer, v *schema.Viewpoint) error {
 	groups := []map[string]interface{}{}
 	nogroup := v.Schema.Tables
 	for i, g := range v.Groups {
-		tables, _, err := v.Schema.SepareteTablesThatAreIncludedOrNot(&schema.FilterOption{
+		tables, _, err := v.Schema.SeparateTablesThatAreIncludedOrNot(&schema.FilterOption{
 			Include:       g.Tables,
 			IncludeLabels: g.Labels,
 		})

--- a/output/md/md.go
+++ b/output/md/md.go
@@ -760,7 +760,7 @@ func (m *Md) makeViewpointTemplateData(v *schema.Viewpoint) (map[string]interfac
 	groups := []map[string]interface{}{}
 	nogroup := v.Schema.Tables
 	for _, g := range v.Groups {
-		tables, _, err := v.Schema.SepareteTablesThatAreIncludedOrNot(&schema.FilterOption{
+		tables, _, err := v.Schema.SeparateTablesThatAreIncludedOrNot(&schema.FilterOption{
 			Include:       g.Tables,
 			IncludeLabels: g.Labels,
 		})

--- a/schema/filter.go
+++ b/schema/filter.go
@@ -20,7 +20,7 @@ func (s *Schema) Filter(opt *FilterOption) (err error) {
 	defer func() {
 		err = errors.WithStack(err)
 	}()
-	_, excludes, err := s.SepareteTablesThatAreIncludedOrNot(opt)
+	_, excludes, err := s.SeparateTablesThatAreIncludedOrNot(opt)
 	if err != nil {
 		return err
 	}
@@ -34,7 +34,7 @@ func (s *Schema) Filter(opt *FilterOption) (err error) {
 	return nil
 }
 
-func (s *Schema) SepareteTablesThatAreIncludedOrNot(opt *FilterOption) (_ []*Table, _ []*Table, err error) {
+func (s *Schema) SeparateTablesThatAreIncludedOrNot(opt *FilterOption) (_ []*Table, _ []*Table, err error) {
 	defer func() {
 		err = errors.WithStack(err)
 	}()


### PR DESCRIPTION
First thank you so much for this library 🙇 

Very very minor nit but wanted to address it just in case 🙏 

`SepareteTablesThatAreIncludedOrNot` -> `SeparateTablesThatAreIncludedOrNot`