### PR TITLE
Express tbls.yml comments override schema comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,6 +875,8 @@ lintExclude:
 
 For example, you can add comment about VIEW TABLE or SQLite tables/columns.
 
+> **Notice:** Comments defined in `.tbls.yml` will override existing comments in the schema.
+
 ```yaml
 # .tbls.yml
 comments:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -145,6 +145,10 @@ func TestMergeAditionalData(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if want := "users comment by tbls"; users.Comment != want {
+		t.Errorf("got %v\nwant %v", users.Comment, want)
+	}
+
 	posts, err := s.FindTableByName("posts")
 	if err != nil {
 		t.Fatal(err)

--- a/testdata/config_test_tbls.yml
+++ b/testdata/config_test_tbls.yml
@@ -18,6 +18,7 @@ relations:
 comments:
   -
     table: users
+    tableComment: users comment by tbls
     indexComments:
       user_index: user index
     constraintComments:


### PR DESCRIPTION
Currently, the behavior where comments in `tbls.yml` override schema comments is not explicitly documented or tested.

So I added documentation to the README, and modified the test for the overriding case.