### PR TITLE
fix: use len() for relation check in detectShowColumnsForER to support include filter

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -602,7 +602,7 @@ func (c *Config) detectShowColumnsForER(s *schema.Schema) error {
 
 	for _, t := range s.Tables {
 		for _, cc := range t.Columns {
-			if c.ER.ShowColumnTypes.Related && (cc.ChildRelations != nil || cc.ParentRelations != nil) {
+			if c.ER.ShowColumnTypes.Related && (len(cc.ChildRelations) > 0 || len(cc.ParentRelations) > 0) {
 				// related
 				cc.HideForER = false
 			} else if c.ER.ShowColumnTypes.Primary && cc.PK {


### PR DESCRIPTION
ref: https://github.com/k1LoW/tbls/issues/685

When using the `include` option in .tbls.yml to filter tables, the er.showColumnTypes.related/primary setting did not work as expected: columns other than PK and FK were not hidden in the ER diagram output. This is because the previous implementation checked only for nil on ChildRelations and ParentRelations, but after filtering, these fields become empty slices (`[]`) rather than `nil`.

By changing the check to use [len(cc.ChildRelations) > 0 || len(cc.ParentRelations) > 0](https://potential-space-robot-4455p994h7j6v.github.dev/), the logic now correctly detects related columns even when the include filter is used. This ensures that only PK and FK columns are shown in the ER diagram as intended, regardless of the use of include.