### PR TITLE
Fix: apply showColumnTypes to ER diagram in Viewpoint pages (mermaid)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -461,6 +461,9 @@ func (c *Config) ModifySchema(s *schema.Schema) error {
 		}); err != nil {
 			return err
 		}
+		if err := c.detectShowColumnsForER(cs); err != nil {
+			return err
+		}
 		groups := []*schema.ViewpointGroup{}
 		tables := lo.Map(cs.Tables, func(t *schema.Table, _ int) string {
 			return t.Name


### PR DESCRIPTION
ref: #685 

This pull request fixes an issue where the 'showColumnTypes' setting was not applied to ER diagrams on Viewpoint pages (especially for mermaid format).

## Reason for change

Previously, the showColumnTypes logic was only applied to the main schema and not to the schema objects generated for each Viewpoint. As a result, ER diagrams on Viewpoint pages always displayed all columns, regardless of the showColumnTypes setting.

With this change, the showColumnTypes logic is also applied to each Viewpoint schema, ensuring consistent column visibility in ER diagrams across all documentation pages.