### PR TITLE
fix: Skip enum fetching for Redshift compatibility in postgres driver

### DIFF
--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -502,6 +502,11 @@ func (p *Postgres) getFunctionsByQuery(query string) ([]*schema.Function, error)
 func (p *Postgres) getEnums() ([]*schema.Enum, error) {
 	enums := []*schema.Enum{}
 
+	// Amazon RedShift does not support enum
+	if p.rsMode {
+		return enums, nil
+	}
+
 	enumsResult, err := p.db.Query(`SELECT n.nspname, t.typname AS enum_name, ARRAY_AGG(e.enumlabel) AS enum_values
 											FROM pg_type t, pg_enum e, pg_catalog.pg_namespace n
 											WHERE t.typcategory = 'E'


### PR DESCRIPTION
Amazon Redshift does not support PostgreSQL enum types:  
https://docs.aws.amazon.com/redshift/latest/dg/c_unsupported-postgresql-datatypes.html

When running `tbls` against Redshift, the enum type query causes an error.  
> ERROR: relation "pg_enum" does not exist

This PR skips fetching enum types when the driver is Redshift, allowing documentation generation to proceed without failure.