### PR TITLE
test: use windows-2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        platform: [windows-2019, windows-latest]
+        platform: [windows-2022, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Use LF

--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -81,7 +81,7 @@ jobs:
   windows-release-test:
     strategy:
       matrix:
-        os: [windows-2019, windows-latest]
+        os: [windows-2022, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Use LF

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -111,7 +111,7 @@ jobs:
   windows-assets:
     needs: tagpr
     if: needs.tagpr.outputs.tagpr-tag != ''
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Use LF
         run: |


### PR DESCRIPTION
This pull request updates the CI workflows to use a newer Windows environment (`windows-2022`) for improved compatibility and support. The changes affect multiple workflow files.

### Workflow updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL89-R89): Updated the `platform` matrix to replace `windows-2019` with `windows-2022` for the Test job.
* [`.github/workflows/release-test.yml`](diffhunk://#diff-cfb5fad94da0d964cbd2b402415839cc0c8e79a9ce5ae58586f5c8becb0d938dL84-R84): Updated the `os` matrix to replace `windows-2019` with `windows-2022` for the `windows-release-test` job.
* [`.github/workflows/tagpr.yml`](diffhunk://#diff-ffc7eb13f2d4fb8a7c238f2f81c30c7b932ba8582616312295a6b4c15a6ad83eL114-R114): Changed the `runs-on` environment from `windows-2019` to `windows-2022` for the `windows-assets` job.