### PR TITLE
Update GoReleaser configurations

### DIFF
--- a/.goreleaser/darwin.yml
+++ b/.goreleaser/darwin.yml
@@ -24,7 +24,8 @@ archives:
   name_template: '{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
   format_overrides:
     - goos: darwin
-      format: zip
+      formats:
+        - zip
   files:
     - LICENSE
     - CREDITS
@@ -33,7 +34,7 @@ archives:
 checksum:
   name_template: 'checksums-darwin.txt'
 snapshot:
-  name_template: "{{ .Version }}-next"
+  version_template: "{{ .Version }}-next"
 changelog:
   sort: asc
   filters:

--- a/.goreleaser/linux.yml
+++ b/.goreleaser/linux.yml
@@ -55,7 +55,7 @@ nfpms:
   -
     id: tbls-nfpms
     file_name_template: "{{ .ProjectName }}_{{ .Version }}-1_{{ .Arch }}"
-    ids:
+    builds:
     - tbls-linux
     homepage: https://github.com/k1LoW/tbls
     maintainer: Ken'ichiro Oyama <k1lowxb@gmail.com>

--- a/.goreleaser/linux.yml
+++ b/.goreleaser/linux.yml
@@ -44,7 +44,7 @@ archives:
 checksum:
   name_template: 'checksums-linux.txt'
 snapshot:
-  name_template: "{{ .Version }}-next"
+  version_template: "{{ .Version }}-next"
 changelog:
   sort: asc
   filters:
@@ -55,7 +55,7 @@ nfpms:
   -
     id: tbls-nfpms
     file_name_template: "{{ .ProjectName }}_{{ .Version }}-1_{{ .Arch }}"
-    builds:
+    ids:
     - tbls-linux
     homepage: https://github.com/k1LoW/tbls
     maintainer: Ken'ichiro Oyama <k1lowxb@gmail.com>

--- a/.goreleaser/windows.yml
+++ b/.goreleaser/windows.yml
@@ -27,7 +27,8 @@ archives:
   name_template: '{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
   format_overrides:
     - goos: windows
-      format: zip
+      formats:
+        - zip
   files:
     - LICENSE
     - CREDITS
@@ -36,7 +37,7 @@ archives:
 checksum:
   name_template: 'checksums-windows.txt'
 snapshot:
-  name_template: "{{ .Version }}-next"
+  version_template: "{{ .Version }}-next"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
## PR Summary
This small PR updates the GoReleaser configuration to resolve the following warnings, which you can find in the [CI logs](https://github.com/k1LoW/tbls/actions/runs/16004079719/job/45146264309#step:6:26): 
```
DEPRECATED: snapshot.name_template should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info
DEPRECATED: archives.format_overrides.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
```