### PR TITLE
[WIP] Support for custom template paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1038,9 +1038,23 @@ templates:
   md:
     index: 'templates/index.md.tmpl'
     table: 'templates/table.md.tmpl'
+    enum: 'templates/enum.md.tmpl'
 ```
 
 A good starting point to design your own template is to modify a copy the default ones for [Dot](output/dot/templates), [PlantUML](output/plantuml/templates) and [markdown](output/md/templates).
+
+**Custom Output Paths:** You can also customize where files are generated using `outputPaths`:
+
+```yaml
+outputPaths:
+  md:
+    index: "docs/database-overview.md"
+    table: "tables/{{.Name}}.md"
+    viewpoint: "views/{{.Name}}.md" 
+    enum: "types/{{.Name}}.md" # Disabled by default.
+```
+
+Set a path to empty string (`""`) to disable generation for that file type. Template variables like `{{.Name}}` and `{{.Index}}` are supported for dynamic naming.
 
 ### Required Version
 

--- a/config/templates.go
+++ b/config/templates.go
@@ -9,6 +9,21 @@ type Templates struct {
 	Mermaid Mermaid `yaml:"mermaid,omitempty"`
 }
 
+// OutputPaths holds the configurations for customizing output file paths.
+type OutputPaths struct {
+	MD OutputPathsMD `yaml:"md,omitempty"`
+}
+
+// OutputPathsMD holds the output file path patterns for markdown files.
+// Each field supports template variables to customize file naming and organization.
+// nil = use default, empty string = disable generation, non-empty = custom path
+type OutputPathsMD struct {
+	Index     *string `yaml:"index,omitempty"`     // README.md path
+	Table     *string `yaml:"table,omitempty"`     // Table file path pattern (supports {{.Name}})
+	Viewpoint *string `yaml:"viewpoint,omitempty"` // Viewpoint file path pattern (supports {{.Name}}, {{.Index}})
+	Enum      *string `yaml:"enum,omitempty"`      // Enum file path pattern (supports {{.Name}})
+}
+
 // MD holds the paths to the markdown template files.
 // If populated the files are used to override the default ones.
 type MD struct {

--- a/output/md/md.go
+++ b/output/md/md.go
@@ -887,31 +887,10 @@ func (m *Md) makeViewpointTemplateData(v *schema.Viewpoint) (map[string]interfac
 }
 
 func (m *Md) makeEnumTemplateData(e *schema.Enum) map[string]interface{} {
-	adjust := m.config.Format.Adjust
-
-	// Values table data
-	valuesData := [][]string{}
-	valuesHeader := []string{m.config.MergedDict.Lookup("Value")}
-	valuesHeaderLine := []string{"-----"}
-	valuesData = append(valuesData, valuesHeader, valuesHeaderLine)
-
-	for _, value := range e.Values {
-		valuesData = append(valuesData, []string{value})
-	}
-
-	if adjust {
-		return map[string]interface{}{
-			"Enum":   e,
-			"Name":   e.Name,
-			"Values": adjustTable(valuesData),
-		}
-	}
-
 	return map[string]interface{}{
-		"Enum":   e,
-		"Name":   e.Name,
-		"Values": valuesData,
-	}
+			"Name":   e.Name,
+			"Values": e.Values,
+		}
 }
 
 func (m *Md) adjustColumnHeader(columnsHeader *[]string, columnsHeaderLine *[]string, hasColumn bool, name string) {


### PR DESCRIPTION
This PR adds 4 features:

- Output path templating for the markdown output files
- Output path templating for graphviz output files
- Support for an `Enum` template in markdown
- Support to skip file generation by setting the output path to the empty string

This code with the help of Claude 4.0