### PR TITLE
feat: change schema.json indentation

### DIFF
--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -122,7 +122,7 @@ func withSchemaFile(s *schema.Schema, c *config.Config) (e error) {
 		_ = sf.Close()
 	}()
 	fmt.Printf("%s\n", c.SchemaFilePath())
-	j := json.New(true)
+	j := json.New(false)
 	if err := j.OutputSchema(sf, s); err != nil {
 		return err
 	}

--- a/sample/adjust/schema.json
+++ b/sample/adjust/schema.json
@@ -1,1 +1,1405 @@
-{"name":"testdb","desc":"Sample PostgreSQL database document.","tables":[{"name":"public.users","type":"BASE TABLE","comment":"Users table","columns":[{"name":"id","type":"integer","nullable":false,"default":"nextval('users_id_seq'::regclass)"},{"name":"username","type":"varchar(50)","nullable":false},{"name":"password","type":"varchar(50)","nullable":false},{"name":"email","type":"varchar(355)","nullable":false,"comment":"ex. user@example.com"},{"name":"created","type":"timestamp without time zone","nullable":false},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"users_pkey","def":"CREATE UNIQUE INDEX users_pkey ON public.users USING btree (id)","table":"public.users","columns":["id"]},{"name":"users_username_key","def":"CREATE UNIQUE INDEX users_username_key ON public.users USING btree (username)","table":"public.users","columns":["username"]},{"name":"users_email_key","def":"CREATE UNIQUE INDEX users_email_key ON public.users USING btree (email)","table":"public.users","columns":["email"]}],"constraints":[{"name":"users_username_check","type":"CHECK","def":"CHECK ((char_length((username)::text) \u003e 4))","table":"public.users","referenced_table":"","columns":["username"]},{"name":"users_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"public.users","referenced_table":"","columns":["id"]},{"name":"users_username_key","type":"UNIQUE","def":"UNIQUE (username)","table":"public.users","referenced_table":"","columns":["username"]},{"name":"users_email_key","type":"UNIQUE","def":"UNIQUE (email)","table":"public.users","referenced_table":"","columns":["email"]}],"triggers":[{"name":"update_users_updated","def":"CREATE TRIGGER update_users_updated AFTER INSERT OR UPDATE ON public.users FOR EACH ROW EXECUTE FUNCTION update_updated()","comment":"Update updated when users insert or update"}]},{"name":"public.user_options","type":"BASE TABLE","comment":"User options table","columns":[{"name":"user_id","type":"integer","nullable":false},{"name":"show_email","type":"boolean","nullable":false,"default":"false"},{"name":"created","type":"timestamp without time zone","nullable":false},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"user_options_pkey","def":"CREATE UNIQUE INDEX user_options_pkey ON public.user_options USING btree (user_id)","table":"public.user_options","columns":["user_id"],"comment":"PRIMARY KEY"}],"constraints":[{"name":"user_options_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE","table":"public.user_options","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"],"comment":"FK"},{"name":"user_options_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (user_id)","table":"public.user_options","referenced_table":"","columns":["user_id"]}]},{"name":"public.posts","type":"BASE TABLE","comment":"Posts table","columns":[{"name":"id","type":"bigint","nullable":false,"default":"nextval('posts_id_seq'::regclass)"},{"name":"user_id","type":"integer","nullable":false},{"name":"title","type":"varchar(255)","nullable":false,"default":"'Untitled'::character varying"},{"name":"body","type":"text","nullable":false,"comment":"post body"},{"name":"post_type","type":"post_types","nullable":false,"comment":"public/private/draft"},{"name":"labels","type":"varchar(50)[]","nullable":true},{"name":"created","type":"timestamp without time zone","nullable":false},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"posts_id_pk","def":"CREATE UNIQUE INDEX posts_id_pk ON public.posts USING btree (id)","table":"public.posts","columns":["id"]},{"name":"posts_user_id_title_key","def":"CREATE UNIQUE INDEX posts_user_id_title_key ON public.posts USING btree (user_id, title)","table":"public.posts","columns":["user_id","title"]},{"name":"posts_user_id_idx","def":"CREATE INDEX posts_user_id_idx ON public.posts USING btree (user_id)","table":"public.posts","columns":["user_id"],"comment":"posts.user_id index"}],"constraints":[{"name":"update_posts_updated","type":"TRIGGER","def":"CREATE CONSTRAINT TRIGGER update_posts_updated AFTER INSERT OR UPDATE ON public.posts NOT DEFERRABLE INITIALLY IMMEDIATE FOR EACH ROW EXECUTE FUNCTION update_updated()","table":"public.posts","referenced_table":"","columns":["tableoid","cmax","xmax","cmin","xmin","ctid","id","user_id","title","body","post_type","labels","created","updated"]},{"name":"posts_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL (user_id)","table":"public.posts","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"],"comment":"posts -\u003e users"},{"name":"posts_id_pk","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"public.posts","referenced_table":"","columns":["id"]},{"name":"posts_user_id_title_key","type":"UNIQUE","def":"UNIQUE (user_id, title)","table":"public.posts","referenced_table":"","columns":["user_id","title"]}],"triggers":[{"name":"update_posts_updated","def":"CREATE CONSTRAINT TRIGGER update_posts_updated AFTER INSERT OR UPDATE ON public.posts NOT DEFERRABLE INITIALLY IMMEDIATE FOR EACH ROW EXECUTE FUNCTION update_updated()","comment":"Update updated when posts update"}]},{"name":"public.comments","type":"BASE TABLE","comment":"Comments\nMulti-line\r\ntable\rcomment","columns":[{"name":"id","type":"bigint","nullable":false,"default":"nextval('comments_id_seq'::regclass)"},{"name":"post_id","type":"bigint","nullable":false},{"name":"user_id","type":"integer","nullable":false},{"name":"comment","type":"text","nullable":false,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"post_id_desc","type":"bigint","nullable":true,"extra_def":"GENERATED ALWAYS AS (post_id * '-1'::integer) STORED"},{"name":"created","type":"timestamp without time zone","nullable":false},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"comments_id_pk","def":"CREATE UNIQUE INDEX comments_id_pk ON public.comments USING btree (id)","table":"public.comments","columns":["id"]},{"name":"comments_post_id_user_id_key","def":"CREATE UNIQUE INDEX comments_post_id_user_id_key ON public.comments USING btree (post_id, user_id)","table":"public.comments","columns":["post_id","user_id"]},{"name":"comments_post_id_user_id_idx","def":"CREATE INDEX comments_post_id_user_id_idx ON public.comments USING btree (post_id, user_id)","table":"public.comments","columns":["post_id","user_id"]}],"constraints":[{"name":"comments_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users(id)","table":"public.comments","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"comments_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (post_id) REFERENCES posts(id)","table":"public.comments","referenced_table":"posts","columns":["post_id"],"referenced_columns":["id"]},{"name":"comments_id_pk","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"public.comments","referenced_table":"","columns":["id"]},{"name":"comments_post_id_user_id_key","type":"UNIQUE","def":"UNIQUE (post_id, user_id)","table":"public.comments","referenced_table":"","columns":["post_id","user_id"]}]},{"name":"public.comment_stars","type":"BASE TABLE","columns":[{"name":"id","type":"uuid","nullable":false,"default":"uuid_generate_v4()"},{"name":"user_id","type":"integer","nullable":false},{"name":"comment_post_id","type":"bigint","nullable":false},{"name":"comment_user_id","type":"integer","nullable":false},{"name":"created","type":"timestamp without time zone","nullable":false},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"comment_stars_user_id_comment_post_id_comment_user_id_key","def":"CREATE UNIQUE INDEX comment_stars_user_id_comment_post_id_comment_user_id_key ON public.comment_stars USING btree (user_id, comment_post_id, comment_user_id)","table":"public.comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"constraints":[{"name":"comment_stars_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_user_id) REFERENCES users(id)","table":"public.comment_stars","referenced_table":"users","columns":["comment_user_id"],"referenced_columns":["id"]},{"name":"comment_stars_user_id_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments(post_id, user_id)","table":"public.comment_stars","referenced_table":"comments","columns":["comment_post_id","comment_post_id","comment_user_id","comment_user_id"],"referenced_columns":["post_id","user_id","post_id","user_id"]},{"name":"comment_stars_user_id_comment_post_id_comment_user_id_key","type":"UNIQUE","def":"UNIQUE (user_id, comment_post_id, comment_user_id)","table":"public.comment_stars","referenced_table":"","columns":["user_id","comment_post_id","comment_user_id"]}]},{"name":"public.logs","type":"BASE TABLE","comment":"audit log table","columns":[{"name":"id","type":"uuid","nullable":false,"default":"uuid_generate_v4()"},{"name":"user_id","type":"integer","nullable":false},{"name":"post_id","type":"bigint","nullable":true},{"name":"comment_id","type":"bigint","nullable":true},{"name":"comment_star_id","type":"uuid","nullable":true},{"name":"payload","type":"text","nullable":true},{"name":"created","type":"timestamp without time zone","nullable":false}]},{"name":"public.post_comments","type":"VIEW","comment":"post and comments View table","columns":[{"name":"id","type":"bigint","nullable":true,"comment":"comments.id"},{"name":"title","type":"varchar(255)","nullable":true,"comment":"posts.title"},{"name":"post_user","type":"varchar(50)","nullable":true,"comment":"posts.users.username"},{"name":"comment","type":"text","nullable":true},{"name":"comment_user","type":"varchar(50)","nullable":true,"comment":"comments.users.username"},{"name":"created","type":"timestamp without time zone","nullable":true,"comment":"comments.created"},{"name":"updated","type":"timestamp without time zone","nullable":true,"comment":"comments.updated"}],"def":"CREATE VIEW post_comments AS (\n SELECT c.id,\n    p.title,\n    u.username AS post_user,\n    c.comment,\n    u2.username AS comment_user,\n    c.created,\n    c.updated\n   FROM (((posts p\n     LEFT JOIN comments c ON ((p.id = c.post_id)))\n     LEFT JOIN users u ON ((u.id = p.user_id)))\n     LEFT JOIN users u2 ON ((u2.id = c.user_id)))\n)","referenced_tables":["public.posts","public.comments","public.users"]},{"name":"public.post_comment_stars","type":"MATERIALIZED VIEW","columns":[{"name":"id","type":"uuid","nullable":true},{"name":"comment_user","type":"varchar(50)","nullable":true},{"name":"comment_star_user","type":"varchar(50)","nullable":true},{"name":"created","type":"timestamp without time zone","nullable":true},{"name":"updated","type":"timestamp without time zone","nullable":true}],"def":"CREATE MATERIALIZED VIEW post_comment_stars AS (\n SELECT cs.id,\n    cu.username AS comment_user,\n    csu.username AS comment_star_user,\n    cs.created,\n    cs.updated\n   FROM (((comments c\n     LEFT JOIN comment_stars cs ON (((cs.comment_post_id = c.id) AND (cs.comment_user_id = c.user_id))))\n     LEFT JOIN users cu ON ((cu.id = cs.comment_user_id)))\n     LEFT JOIN users csu ON ((csu.id = cs.user_id)))\n)","referenced_tables":["public.comments","public.comment_stars","public.users"]},{"name":"public.CamelizeTable","type":"BASE TABLE","columns":[{"name":"id","type":"uuid","nullable":false,"default":"uuid_generate_v4()"},{"name":"created","type":"timestamp without time zone","nullable":false}],"indexes":[{"name":"CamelizeTable_id_key","def":"CREATE UNIQUE INDEX \"CamelizeTable_id_key\" ON public.\"CamelizeTable\" USING btree (id)","table":"public.CamelizeTable","columns":["id"]}],"constraints":[{"name":"CamelizeTable_id_key","type":"UNIQUE","def":"UNIQUE (id)","table":"public.CamelizeTable","referenced_table":"","columns":["id"]}]},{"name":"public.hyphen-table","type":"BASE TABLE","columns":[{"name":"id","type":"uuid","nullable":false,"default":"uuid_generate_v4()"},{"name":"hyphen-column","type":"text","nullable":false},{"name":"CamelizeTableId","type":"uuid","nullable":false},{"name":"created","type":"timestamp without time zone","nullable":false}],"indexes":[{"name":"hyphen-table_hyphen-column_key","def":"CREATE UNIQUE INDEX \"hyphen-table_hyphen-column_key\" ON public.\"hyphen-table\" USING btree (\"hyphen-column\")","table":"public.hyphen-table","columns":["hyphen-column"]}],"constraints":[{"name":"hyphen-table_CamelizeTableId_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (\"CamelizeTableId\") REFERENCES \"CamelizeTable\"(id) ON DELETE CASCADE","table":"public.hyphen-table","referenced_table":"CamelizeTable","columns":["CamelizeTableId"],"referenced_columns":["id"]},{"name":"hyphen-table_hyphen-column_key","type":"UNIQUE","def":"UNIQUE (\"hyphen-column\")","table":"public.hyphen-table","referenced_table":"","columns":["hyphen-column"]}]},{"name":"administrator.blogs","type":"BASE TABLE","comment":"admin blogs","columns":[{"name":"id","type":"integer","nullable":false,"default":"nextval('administrator.blogs_id_seq'::regclass)"},{"name":"user_id","type":"integer","nullable":false},{"name":"name","type":"text","nullable":false},{"name":"description","type":"text","nullable":true},{"name":"created","type":"timestamp without time zone","nullable":false},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"blogs_pkey","def":"CREATE UNIQUE INDEX blogs_pkey ON administrator.blogs USING btree (id)","table":"administrator.blogs","columns":["id"]}],"constraints":[{"name":"blogs_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE","table":"administrator.blogs","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"blogs_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"administrator.blogs","referenced_table":"","columns":["id"]}]},{"name":"backup.blogs","type":"BASE TABLE","columns":[{"name":"id","type":"integer","nullable":false,"default":"nextval('blogs_id_seq'::regclass)"},{"name":"user_id","type":"integer","nullable":false},{"name":"dump","type":"text","nullable":false},{"name":"created","type":"timestamp without time zone","nullable":false},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"blogs_pkey","def":"CREATE UNIQUE INDEX blogs_pkey ON backup.blogs USING btree (id)","table":"backup.blogs","columns":["id"]}],"constraints":[{"name":"blogs_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"backup.blogs","referenced_table":"","columns":["id"]}]},{"name":"backup.blog_options","type":"BASE TABLE","columns":[{"name":"id","type":"integer","nullable":false,"default":"nextval('blog_options_id_seq'::regclass)"},{"name":"blog_id","type":"integer","nullable":false},{"name":"label","type":"text","nullable":true},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"blog_options_pkey","def":"CREATE UNIQUE INDEX blog_options_pkey ON backup.blog_options USING btree (id)","table":"backup.blog_options","columns":["id"]}],"constraints":[{"name":"blog_options_blog_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (blog_id) REFERENCES blogs(id) ON DELETE CASCADE","table":"backup.blog_options","referenced_table":"blogs","columns":["blog_id"],"referenced_columns":["id"]},{"name":"blog_options_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"backup.blog_options","referenced_table":"","columns":["id"]}]},{"name":"time.bar","type":"BASE TABLE","columns":[{"name":"id","type":"integer","nullable":false}],"indexes":[{"name":"bar_pkey","def":"CREATE UNIQUE INDEX bar_pkey ON \"time\".bar USING btree (id)","table":"time.bar","columns":["id"]}],"constraints":[{"name":"bar_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"time.bar","referenced_table":"","columns":["id"]}]},{"name":"time.hyphenated-table","type":"BASE TABLE","columns":[{"name":"id","type":"integer","nullable":false}],"indexes":[{"name":"hyphenated-table_pkey","def":"CREATE UNIQUE INDEX \"hyphenated-table_pkey\" ON \"time\".\"hyphenated-table\" USING btree (id)","table":"time.hyphenated-table","columns":["id"]}],"constraints":[{"name":"hyphenated-table_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"time.hyphenated-table","referenced_table":"","columns":["id"]}]},{"name":"time.referencing","type":"BASE TABLE","columns":[{"name":"id","type":"integer","nullable":false},{"name":"bar_id","type":"integer","nullable":false},{"name":"ht_id","type":"integer","nullable":false}],"indexes":[{"name":"referencing_pkey","def":"CREATE UNIQUE INDEX referencing_pkey ON \"time\".referencing USING btree (id)","table":"time.referencing","columns":["id"]}],"constraints":[{"name":"referencing_bar_id","type":"FOREIGN KEY","def":"FOREIGN KEY (bar_id) REFERENCES \"time\".bar(id)","table":"time.referencing","referenced_table":"bar","columns":["bar_id"],"referenced_columns":["id"]},{"name":"referencing_ht_id","type":"FOREIGN KEY","def":"FOREIGN KEY (ht_id) REFERENCES \"time\".\"hyphenated-table\"(id)","table":"time.referencing","referenced_table":"hyphenated-table","columns":["ht_id"],"referenced_columns":["id"]},{"name":"referencing_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"time.referencing","referenced_table":"","columns":["id"]}]}],"relations":[{"table":"public.user_options","columns":["user_id"],"cardinality":"zero_or_one","parent_table":"public.users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"},{"table":"public.posts","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"public.users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL (user_id)"},{"table":"public.comments","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"public.users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users(id)"},{"table":"public.comments","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"public.posts","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (post_id) REFERENCES posts(id)"},{"table":"public.comment_stars","columns":["comment_user_id"],"cardinality":"zero_or_more","parent_table":"public.users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_user_id) REFERENCES users(id)"},{"table":"public.comment_stars","columns":["comment_post_id","comment_user_id"],"cardinality":"zero_or_more","parent_table":"public.comments","parent_columns":["post_id","user_id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments(post_id, user_id)"},{"table":"public.hyphen-table","columns":["CamelizeTableId"],"cardinality":"zero_or_more","parent_table":"public.CamelizeTable","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (\"CamelizeTableId\") REFERENCES \"CamelizeTable\"(id) ON DELETE CASCADE"},{"table":"administrator.blogs","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"public.users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"},{"table":"backup.blog_options","columns":["blog_id"],"cardinality":"zero_or_more","parent_table":"backup.blogs","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (blog_id) REFERENCES blogs(id) ON DELETE CASCADE"},{"table":"time.referencing","columns":["bar_id"],"cardinality":"zero_or_more","parent_table":"time.bar","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (bar_id) REFERENCES \"time\".bar(id)"},{"table":"time.referencing","columns":["ht_id"],"cardinality":"zero_or_more","parent_table":"time.hyphenated-table","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (ht_id) REFERENCES \"time\".\"hyphenated-table\"(id)"},{"table":"public.logs","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"public.users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"logs-\u003eusers","virtual":true},{"table":"public.logs","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"public.posts","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"public.logs","columns":["comment_id"],"cardinality":"zero_or_more","parent_table":"public.comments","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"public.logs","columns":["comment_star_id"],"cardinality":"zero_or_more","parent_table":"public.comment_stars","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true}],"functions":[{"name":"public.uuid_nil","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_ns_dns","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_ns_url","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_ns_oid","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_ns_x500","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_generate_v1","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_generate_v1mc","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_generate_v3","return_type":"uuid","arguments":"namespace uuid, name text","type":"FUNCTION"},{"name":"public.uuid_generate_v4","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_generate_v5","return_type":"uuid","arguments":"namespace uuid, name text","type":"FUNCTION"},{"name":"public.update_updated","return_type":"trigger","arguments":"","type":"FUNCTION"},{"name":"public.reset_comment","return_type":"void","arguments":"IN comment_id integer","type":"PROCEDURE"}],"enums":[{"name":"public.post_types","values":["draft","private","public"]}],"driver":{"name":"postgres","database_version":"PostgreSQL 15.10 (Debian 15.10-1.pgdg120+1) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit","meta":{"current_schema":"public","search_paths":["postgres","public","backup"],"dict":{"Functions":"Stored procedures and functions"}}},"viewpoints":[{"name":"post","desc":"for post","tables":["public.post*"]},{"name":"administrator","desc":"administrator schema only","tables":["administrator.*"]}]}
+{
+  "name": "testdb",
+  "desc": "Sample PostgreSQL database document.",
+  "tables": [
+    {
+      "name": "public.users",
+      "type": "BASE TABLE",
+      "comment": "Users table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('users_id_seq'::regclass)"
+        },
+        {
+          "name": "username",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "password",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "email",
+          "type": "varchar(355)",
+          "nullable": false,
+          "comment": "ex. user@example.com"
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "users_pkey",
+          "def": "CREATE UNIQUE INDEX users_pkey ON public.users USING btree (id)",
+          "table": "public.users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "users_username_key",
+          "def": "CREATE UNIQUE INDEX users_username_key ON public.users USING btree (username)",
+          "table": "public.users",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "users_email_key",
+          "def": "CREATE UNIQUE INDEX users_email_key ON public.users USING btree (email)",
+          "table": "public.users",
+          "columns": [
+            "email"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "users_username_check",
+          "type": "CHECK",
+          "def": "CHECK ((char_length((username)::text) \u003e 4))",
+          "table": "public.users",
+          "referenced_table": "",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "users_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "public.users",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "users_username_key",
+          "type": "UNIQUE",
+          "def": "UNIQUE (username)",
+          "table": "public.users",
+          "referenced_table": "",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "users_email_key",
+          "type": "UNIQUE",
+          "def": "UNIQUE (email)",
+          "table": "public.users",
+          "referenced_table": "",
+          "columns": [
+            "email"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_users_updated",
+          "def": "CREATE TRIGGER update_users_updated AFTER INSERT OR UPDATE ON public.users FOR EACH ROW EXECUTE FUNCTION update_updated()",
+          "comment": "Update updated when users insert or update"
+        }
+      ]
+    },
+    {
+      "name": "public.user_options",
+      "type": "BASE TABLE",
+      "comment": "User options table",
+      "columns": [
+        {
+          "name": "user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "show_email",
+          "type": "boolean",
+          "nullable": false,
+          "default": "false"
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "user_options_pkey",
+          "def": "CREATE UNIQUE INDEX user_options_pkey ON public.user_options USING btree (user_id)",
+          "table": "public.user_options",
+          "columns": [
+            "user_id"
+          ],
+          "comment": "PRIMARY KEY"
+        }
+      ],
+      "constraints": [
+        {
+          "name": "user_options_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE",
+          "table": "public.user_options",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ],
+          "comment": "FK"
+        },
+        {
+          "name": "user_options_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (user_id)",
+          "table": "public.user_options",
+          "referenced_table": "",
+          "columns": [
+            "user_id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "public.posts",
+      "type": "BASE TABLE",
+      "comment": "Posts table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "default": "nextval('posts_id_seq'::regclass)"
+        },
+        {
+          "name": "user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "'Untitled'::character varying"
+        },
+        {
+          "name": "body",
+          "type": "text",
+          "nullable": false,
+          "comment": "post body"
+        },
+        {
+          "name": "post_type",
+          "type": "post_types",
+          "nullable": false,
+          "comment": "public/private/draft"
+        },
+        {
+          "name": "labels",
+          "type": "varchar(50)[]",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "posts_id_pk",
+          "def": "CREATE UNIQUE INDEX posts_id_pk ON public.posts USING btree (id)",
+          "table": "public.posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "posts_user_id_title_key",
+          "def": "CREATE UNIQUE INDEX posts_user_id_title_key ON public.posts USING btree (user_id, title)",
+          "table": "public.posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        },
+        {
+          "name": "posts_user_id_idx",
+          "def": "CREATE INDEX posts_user_id_idx ON public.posts USING btree (user_id)",
+          "table": "public.posts",
+          "columns": [
+            "user_id"
+          ],
+          "comment": "posts.user_id index"
+        }
+      ],
+      "constraints": [
+        {
+          "name": "update_posts_updated",
+          "type": "TRIGGER",
+          "def": "CREATE CONSTRAINT TRIGGER update_posts_updated AFTER INSERT OR UPDATE ON public.posts NOT DEFERRABLE INITIALLY IMMEDIATE FOR EACH ROW EXECUTE FUNCTION update_updated()",
+          "table": "public.posts",
+          "referenced_table": ""
+        },
+        {
+          "name": "posts_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL (user_id)",
+          "table": "public.posts",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ],
+          "comment": "posts -\u003e users"
+        },
+        {
+          "name": "posts_id_pk",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "public.posts",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "posts_user_id_title_key",
+          "type": "UNIQUE",
+          "def": "UNIQUE (user_id, title)",
+          "table": "public.posts",
+          "referenced_table": "",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_posts_updated",
+          "def": "CREATE CONSTRAINT TRIGGER update_posts_updated AFTER INSERT OR UPDATE ON public.posts NOT DEFERRABLE INITIALLY IMMEDIATE FOR EACH ROW EXECUTE FUNCTION update_updated()",
+          "comment": "Update updated when posts update"
+        }
+      ]
+    },
+    {
+      "name": "public.comments",
+      "type": "BASE TABLE",
+      "comment": "Comments\nMulti-line\r\ntable\rcomment",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "default": "nextval('comments_id_seq'::regclass)"
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": false,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "post_id_desc",
+          "type": "bigint",
+          "nullable": true,
+          "extra_def": "GENERATED ALWAYS AS (post_id * '-1'::integer) STORED"
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comments_id_pk",
+          "def": "CREATE UNIQUE INDEX comments_id_pk ON public.comments USING btree (id)",
+          "table": "public.comments",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_post_id_user_id_key",
+          "def": "CREATE UNIQUE INDEX comments_post_id_user_id_key ON public.comments USING btree (post_id, user_id)",
+          "table": "public.comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "comments_post_id_user_id_idx",
+          "def": "CREATE INDEX comments_post_id_user_id_idx ON public.comments USING btree (post_id, user_id)",
+          "table": "public.comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comments_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users(id)",
+          "table": "public.comments",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (post_id) REFERENCES posts(id)",
+          "table": "public.comments",
+          "referenced_table": "posts",
+          "columns": [
+            "post_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_id_pk",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "public.comments",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_post_id_user_id_key",
+          "type": "UNIQUE",
+          "def": "UNIQUE (post_id, user_id)",
+          "table": "public.comments",
+          "referenced_table": "",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "public.comment_stars",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "uuid",
+          "nullable": false,
+          "default": "uuid_generate_v4()"
+        },
+        {
+          "name": "user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "comment_post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "comment_user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comment_stars_user_id_comment_post_id_comment_user_id_key",
+          "def": "CREATE UNIQUE INDEX comment_stars_user_id_comment_post_id_comment_user_id_key ON public.comment_stars USING btree (user_id, comment_post_id, comment_user_id)",
+          "table": "public.comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_user_id) REFERENCES users(id)",
+          "table": "public.comment_stars",
+          "referenced_table": "users",
+          "columns": [
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments(post_id, user_id)",
+          "table": "public.comment_stars",
+          "referenced_table": "comments",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_comment_post_id_comment_user_id_key",
+          "type": "UNIQUE",
+          "def": "UNIQUE (user_id, comment_post_id, comment_user_id)",
+          "table": "public.comment_stars",
+          "referenced_table": "",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "public.logs",
+      "type": "BASE TABLE",
+      "comment": "audit log table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "uuid",
+          "nullable": false,
+          "default": "uuid_generate_v4()"
+        },
+        {
+          "name": "user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_star_id",
+          "type": "uuid",
+          "nullable": true
+        },
+        {
+          "name": "payload",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        }
+      ]
+    },
+    {
+      "name": "public.post_comments",
+      "type": "VIEW",
+      "comment": "post and comments View table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": true,
+          "comment": "comments.id"
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": true,
+          "comment": "posts.title"
+        },
+        {
+          "name": "post_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "posts.users.username"
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "comment_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "comments.users.username"
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": true,
+          "comment": "comments.created"
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true,
+          "comment": "comments.updated"
+        }
+      ],
+      "def": "CREATE VIEW post_comments AS (\n SELECT c.id,\n    p.title,\n    u.username AS post_user,\n    c.comment,\n    u2.username AS comment_user,\n    c.created,\n    c.updated\n   FROM (((posts p\n     LEFT JOIN comments c ON ((p.id = c.post_id)))\n     LEFT JOIN users u ON ((u.id = p.user_id)))\n     LEFT JOIN users u2 ON ((u2.id = c.user_id)))\n)",
+      "referenced_tables": [
+        "public.posts",
+        "public.comments",
+        "public.users"
+      ]
+    },
+    {
+      "name": "public.post_comment_stars",
+      "type": "MATERIALIZED VIEW",
+      "columns": [
+        {
+          "name": "id",
+          "type": "uuid",
+          "nullable": true
+        },
+        {
+          "name": "comment_user",
+          "type": "varchar(50)",
+          "nullable": true
+        },
+        {
+          "name": "comment_star_user",
+          "type": "varchar(50)",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": true
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "def": "CREATE MATERIALIZED VIEW post_comment_stars AS (\n SELECT cs.id,\n    cu.username AS comment_user,\n    csu.username AS comment_star_user,\n    cs.created,\n    cs.updated\n   FROM (((comments c\n     LEFT JOIN comment_stars cs ON (((cs.comment_post_id = c.id) AND (cs.comment_user_id = c.user_id))))\n     LEFT JOIN users cu ON ((cu.id = cs.comment_user_id)))\n     LEFT JOIN users csu ON ((csu.id = cs.user_id)))\n)",
+      "referenced_tables": [
+        "public.comments",
+        "public.comment_stars",
+        "public.users"
+      ]
+    },
+    {
+      "name": "public.CamelizeTable",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "uuid",
+          "nullable": false,
+          "default": "uuid_generate_v4()"
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "CamelizeTable_id_key",
+          "def": "CREATE UNIQUE INDEX \"CamelizeTable_id_key\" ON public.\"CamelizeTable\" USING btree (id)",
+          "table": "public.CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "CamelizeTable_id_key",
+          "type": "UNIQUE",
+          "def": "UNIQUE (id)",
+          "table": "public.CamelizeTable",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "public.hyphen-table",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "uuid",
+          "nullable": false,
+          "default": "uuid_generate_v4()"
+        },
+        {
+          "name": "hyphen-column",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "CamelizeTableId",
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "hyphen-table_hyphen-column_key",
+          "def": "CREATE UNIQUE INDEX \"hyphen-table_hyphen-column_key\" ON public.\"hyphen-table\" USING btree (\"hyphen-column\")",
+          "table": "public.hyphen-table",
+          "columns": [
+            "hyphen-column"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "hyphen-table_CamelizeTableId_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (\"CamelizeTableId\") REFERENCES \"CamelizeTable\"(id) ON DELETE CASCADE",
+          "table": "public.hyphen-table",
+          "referenced_table": "CamelizeTable",
+          "columns": [
+            "CamelizeTableId"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "hyphen-table_hyphen-column_key",
+          "type": "UNIQUE",
+          "def": "UNIQUE (\"hyphen-column\")",
+          "table": "public.hyphen-table",
+          "referenced_table": "",
+          "columns": [
+            "hyphen-column"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "administrator.blogs",
+      "type": "BASE TABLE",
+      "comment": "admin blogs",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('administrator.blogs_id_seq'::regclass)"
+        },
+        {
+          "name": "user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "name",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "description",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "blogs_pkey",
+          "def": "CREATE UNIQUE INDEX blogs_pkey ON administrator.blogs USING btree (id)",
+          "table": "administrator.blogs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "blogs_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE",
+          "table": "administrator.blogs",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "blogs_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "administrator.blogs",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "backup.blogs",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('blogs_id_seq'::regclass)"
+        },
+        {
+          "name": "user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "dump",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "blogs_pkey",
+          "def": "CREATE UNIQUE INDEX blogs_pkey ON backup.blogs USING btree (id)",
+          "table": "backup.blogs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "blogs_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "backup.blogs",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "backup.blog_options",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('blog_options_id_seq'::regclass)"
+        },
+        {
+          "name": "blog_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "label",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "blog_options_pkey",
+          "def": "CREATE UNIQUE INDEX blog_options_pkey ON backup.blog_options USING btree (id)",
+          "table": "backup.blog_options",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "blog_options_blog_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (blog_id) REFERENCES blogs(id) ON DELETE CASCADE",
+          "table": "backup.blog_options",
+          "referenced_table": "blogs",
+          "columns": [
+            "blog_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "blog_options_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "backup.blog_options",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "time.bar",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "bar_pkey",
+          "def": "CREATE UNIQUE INDEX bar_pkey ON \"time\".bar USING btree (id)",
+          "table": "time.bar",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "bar_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "time.bar",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "time.hyphenated-table",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "hyphenated-table_pkey",
+          "def": "CREATE UNIQUE INDEX \"hyphenated-table_pkey\" ON \"time\".\"hyphenated-table\" USING btree (id)",
+          "table": "time.hyphenated-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "hyphenated-table_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "time.hyphenated-table",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "time.referencing",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "bar_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "ht_id",
+          "type": "integer",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "referencing_pkey",
+          "def": "CREATE UNIQUE INDEX referencing_pkey ON \"time\".referencing USING btree (id)",
+          "table": "time.referencing",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "referencing_bar_id",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (bar_id) REFERENCES \"time\".bar(id)",
+          "table": "time.referencing",
+          "referenced_table": "bar",
+          "columns": [
+            "bar_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "referencing_ht_id",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (ht_id) REFERENCES \"time\".\"hyphenated-table\"(id)",
+          "table": "time.referencing",
+          "referenced_table": "hyphenated-table",
+          "columns": [
+            "ht_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "referencing_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "time.referencing",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    }
+  ],
+  "relations": [
+    {
+      "table": "public.user_options",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_one",
+      "parent_table": "public.users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"
+    },
+    {
+      "table": "public.posts",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL (user_id)"
+    },
+    {
+      "table": "public.comments",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users(id)"
+    },
+    {
+      "table": "public.comments",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (post_id) REFERENCES posts(id)"
+    },
+    {
+      "table": "public.comment_stars",
+      "columns": [
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_user_id) REFERENCES users(id)"
+    },
+    {
+      "table": "public.comment_stars",
+      "columns": [
+        "comment_post_id",
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.comments",
+      "parent_columns": [
+        "post_id",
+        "user_id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments(post_id, user_id)"
+    },
+    {
+      "table": "public.hyphen-table",
+      "columns": [
+        "CamelizeTableId"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.CamelizeTable",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (\"CamelizeTableId\") REFERENCES \"CamelizeTable\"(id) ON DELETE CASCADE"
+    },
+    {
+      "table": "administrator.blogs",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"
+    },
+    {
+      "table": "backup.blog_options",
+      "columns": [
+        "blog_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "backup.blogs",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (blog_id) REFERENCES blogs(id) ON DELETE CASCADE"
+    },
+    {
+      "table": "time.referencing",
+      "columns": [
+        "bar_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "time.bar",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (bar_id) REFERENCES \"time\".bar(id)"
+    },
+    {
+      "table": "time.referencing",
+      "columns": [
+        "ht_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "time.hyphenated-table",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (ht_id) REFERENCES \"time\".\"hyphenated-table\"(id)"
+    },
+    {
+      "table": "public.logs",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "logs-\u003eusers",
+      "virtual": true
+    },
+    {
+      "table": "public.logs",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "public.logs",
+      "columns": [
+        "comment_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.comments",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "public.logs",
+      "columns": [
+        "comment_star_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.comment_stars",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    }
+  ],
+  "functions": [
+    {
+      "name": "public.uuid_nil",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_ns_dns",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_ns_url",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_ns_oid",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_ns_x500",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_generate_v1",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_generate_v1mc",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_generate_v3",
+      "return_type": "uuid",
+      "arguments": "namespace uuid, name text",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_generate_v4",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_generate_v5",
+      "return_type": "uuid",
+      "arguments": "namespace uuid, name text",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.update_updated",
+      "return_type": "trigger",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.reset_comment",
+      "return_type": "void",
+      "arguments": "IN comment_id integer",
+      "type": "PROCEDURE"
+    }
+  ],
+  "enums": [
+    {
+      "name": "public.post_types",
+      "values": [
+        "draft",
+        "private",
+        "public"
+      ]
+    }
+  ],
+  "driver": {
+    "name": "postgres",
+    "database_version": "PostgreSQL 15.13 (Debian 15.13-1.pgdg120+1) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit",
+    "meta": {
+      "current_schema": "public",
+      "search_paths": [
+        "postgres",
+        "public",
+        "backup"
+      ],
+      "dict": {
+        "Functions": "Stored procedures and functions"
+      }
+    }
+  },
+  "viewpoints": [
+    {
+      "name": "post",
+      "desc": "for post",
+      "tables": [
+        "public.post*"
+      ]
+    },
+    {
+      "name": "administrator",
+      "desc": "administrator schema only",
+      "tables": [
+        "administrator.*"
+      ]
+    }
+  ]
+}

--- a/sample/bigquery_crypto_bitcoin/README.md
+++ b/sample/bigquery_crypto_bitcoin/README.md
@@ -1,5 +1,9 @@
 # bigquery-public-data:crypto_bitcoin
 
+## Labels
+
+`dg_data_confidentiality:public` `dg_data_context:metadata` `dg_data_source:public`
+
 ## Tables
 
 | Name | Columns | Description | Type | Labels |

--- a/sample/clickhouse/schema.json
+++ b/sample/clickhouse/schema.json
@@ -1,1 +1,277 @@
-{"name":"testdb","tables":[{"name":"id_value_dictionary","type":"Dictionary","columns":[{"name":"id","type":"UInt64","nullable":false},{"name":"value","type":"String","nullable":false}],"def":"CREATE DICTIONARY testdb.id_value_dictionary (`id` UInt64, `value` String) PRIMARY KEY id SOURCE(CLICKHOUSE(TABLE 'source_table')) LIFETIME(MIN 0 MAX 1000) LAYOUT(FLAT())"},{"name":"materialized_view","type":"MaterializedView","columns":[{"name":"name1","type":"UInt64","nullable":false},{"name":"name2","type":"Nullable(String)","nullable":false}],"def":"CREATE MATERIALIZED VIEW testdb.materialized_view (`name1` UInt64, `name2` Nullable(String)) ENGINE = Memory AS SELECT name1, name2 FROM testdb.table_name ORDER BY name1 DESC","referenced_tables":["table_name"]},{"name":"numbers_table","type":"SystemNumbers","columns":[{"name":"number","type":"UInt64","nullable":false}],"def":"CREATE TABLE testdb.numbers_table (`number` UInt64) AS numbers(100)"},{"name":"source_table","type":"MergeTree","columns":[{"name":"id","type":"UInt64","nullable":false},{"name":"value","type":"String","nullable":false}],"constraints":[{"name":"sorting key","type":"SORTING KEY","def":"ORDER BY (id)","table":"source_table","columns":["id"]},{"name":"primary key","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"source_table","columns":["id"]}],"def":"CREATE TABLE testdb.source_table (`id` UInt64, `value` String) ENGINE = MergeTree PRIMARY KEY id ORDER BY id SETTINGS index_granularity = 8192"},{"name":"t1","type":"Memory","columns":[{"name":"x","type":"String","nullable":false}],"def":"CREATE TABLE testdb.t1 (`x` String) ENGINE = Memory"},{"name":"table_name","type":"MergeTree","comment":"comment for table","columns":[{"name":"name1","type":"UInt64","nullable":false,"comment":"comment for column 1"},{"name":"name2","type":"Nullable(String)","nullable":false,"default":"DEFAULT 'column 2'","comment":"comment for column 2"},{"name":"name3","type":"LowCardinality(String)","nullable":false,"default":"MATERIALIZED upper(name2)","comment":"comment for column 3"},{"name":"name4","type":"SimpleAggregateFunction(sum, Float64)","nullable":false},{"name":"name5","type":"DateTime","nullable":false,"default":"DEFAULT now()"},{"name":"name6","type":"String","nullable":false,"default":"ALIAS formatReadableSize(name1)"},{"name":"name7","type":"String","nullable":false,"default":"MATERIALIZED hex(name1)"},{"name":"name8","type":"FixedString(4)","nullable":false,"default":"DEFAULT unhex(name7)"}],"indexes":[{"name":"idx1","def":"bloom_filter(0.01)","table":"table_name","columns":["name1"]},{"name":"idx2","def":"minmax","table":"table_name","columns":["name1 * 2"]},{"name":"idx3","def":"set(1000)","table":"table_name","columns":["name1 * length(name2)"]}],"constraints":[{"name":"partition key","type":"PARTITION KEY","def":"PARTITION BY ((name1, name3, name5))","table":"table_name","columns":["name1","name3","name5"]},{"name":"sorting key","type":"SORTING KEY","def":"ORDER BY (name1, name5)","table":"table_name","columns":["name1","name5"]},{"name":"primary key","type":"PRIMARY KEY","def":"PRIMARY KEY (name1, name5)","table":"table_name","columns":["name1","name5"]},{"name":"sampling key","type":"SAMPLING KEY","def":"SAMPLE BY (name1)","table":"table_name","columns":["name1"]}],"def":"CREATE TABLE testdb.table_name (`name1` UInt64 COMMENT 'comment for column 1', `name2` Nullable(String) DEFAULT 'column 2' COMMENT 'comment for column 2' CODEC(ZSTD(1)), `name3` LowCardinality(String) MATERIALIZED upper(name2) COMMENT 'comment for column 3', `name4` SimpleAggregateFunction(sum, Float64) TTL name5 + toIntervalDay(1), `name5` DateTime DEFAULT now(), `name6` String ALIAS formatReadableSize(name1), `name7` String MATERIALIZED hex(name1), `name8` FixedString(4) DEFAULT unhex(name7), INDEX idx1 name1 TYPE bloom_filter(0.01) GRANULARITY 1, INDEX idx2 name1 * 2 TYPE minmax GRANULARITY 3, INDEX idx3 name1 * length(name2) TYPE set(1000) GRANULARITY 4, PROJECTION projection_name_1 (SELECT name1, name2, name3 ORDER BY name1)) ENGINE = MergeTree PARTITION BY (name1, name3, name5) PRIMARY KEY (name1, name5) ORDER BY (name1, name5) SAMPLE BY name1 SETTINGS index_granularity = 8192 COMMENT 'comment for table'"},{"name":"view","type":"View","columns":[{"name":"name1","type":"UInt64","nullable":false},{"name":"name2","type":"Nullable(String)","nullable":false},{"name":"name4","type":"SimpleAggregateFunction(sum, Float64)","nullable":false},{"name":"name5","type":"DateTime","nullable":false},{"name":"name8","type":"FixedString(4)","nullable":false}],"def":"CREATE VIEW testdb.view (`name1` UInt64, `name2` Nullable(String), `name4` SimpleAggregateFunction(sum, Float64), `name5` DateTime, `name8` FixedString(4)) AS SELECT * FROM testdb.table_name"}],"functions":[{"name":"linear_equation","return_type":"","arguments":"","type":""}],"driver":{"name":"clickhouse","database_version":"24.4.4.113","meta":{"dict":{"Functions":"Stored procedures and functions"}}}}
+{
+  "name": "testdb",
+  "tables": [
+    {
+      "name": "id_value_dictionary",
+      "type": "Dictionary",
+      "columns": [
+        {
+          "name": "id",
+          "type": "UInt64",
+          "nullable": false
+        },
+        {
+          "name": "value",
+          "type": "String",
+          "nullable": false
+        }
+      ],
+      "def": "CREATE DICTIONARY testdb.id_value_dictionary (`id` UInt64, `value` String) PRIMARY KEY id SOURCE(CLICKHOUSE(TABLE 'source_table')) LIFETIME(MIN 0 MAX 1000) LAYOUT(FLAT())"
+    },
+    {
+      "name": "materialized_view",
+      "type": "MaterializedView",
+      "columns": [
+        {
+          "name": "name1",
+          "type": "UInt64",
+          "nullable": false
+        },
+        {
+          "name": "name2",
+          "type": "Nullable(String)",
+          "nullable": false
+        }
+      ],
+      "def": "CREATE MATERIALIZED VIEW testdb.materialized_view (`name1` UInt64, `name2` Nullable(String)) ENGINE = Memory AS SELECT name1, name2 FROM testdb.table_name ORDER BY name1 DESC",
+      "referenced_tables": [
+        "table_name"
+      ]
+    },
+    {
+      "name": "numbers_table",
+      "type": "SystemNumbers",
+      "columns": [
+        {
+          "name": "number",
+          "type": "UInt64",
+          "nullable": false
+        }
+      ],
+      "def": "CREATE TABLE testdb.numbers_table (`number` UInt64) AS numbers(100)"
+    },
+    {
+      "name": "source_table",
+      "type": "MergeTree",
+      "columns": [
+        {
+          "name": "id",
+          "type": "UInt64",
+          "nullable": false
+        },
+        {
+          "name": "value",
+          "type": "String",
+          "nullable": false
+        }
+      ],
+      "constraints": [
+        {
+          "name": "sorting key",
+          "type": "SORTING KEY",
+          "def": "ORDER BY (id)",
+          "table": "source_table",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "primary key",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "source_table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE testdb.source_table (`id` UInt64, `value` String) ENGINE = MergeTree PRIMARY KEY id ORDER BY id SETTINGS index_granularity = 8192"
+    },
+    {
+      "name": "t1",
+      "type": "Memory",
+      "columns": [
+        {
+          "name": "x",
+          "type": "String",
+          "nullable": false
+        }
+      ],
+      "def": "CREATE TABLE testdb.t1 (`x` String) ENGINE = Memory"
+    },
+    {
+      "name": "table_name",
+      "type": "MergeTree",
+      "comment": "comment for table",
+      "columns": [
+        {
+          "name": "name1",
+          "type": "UInt64",
+          "nullable": false,
+          "comment": "comment for column 1"
+        },
+        {
+          "name": "name2",
+          "type": "Nullable(String)",
+          "nullable": false,
+          "default": "DEFAULT 'column 2'",
+          "comment": "comment for column 2"
+        },
+        {
+          "name": "name3",
+          "type": "LowCardinality(String)",
+          "nullable": false,
+          "default": "MATERIALIZED upper(name2)",
+          "comment": "comment for column 3"
+        },
+        {
+          "name": "name4",
+          "type": "SimpleAggregateFunction(sum, Float64)",
+          "nullable": false
+        },
+        {
+          "name": "name5",
+          "type": "DateTime",
+          "nullable": false,
+          "default": "DEFAULT now()"
+        },
+        {
+          "name": "name6",
+          "type": "String",
+          "nullable": false,
+          "default": "ALIAS formatReadableSize(name1)"
+        },
+        {
+          "name": "name7",
+          "type": "String",
+          "nullable": false,
+          "default": "MATERIALIZED hex(name1)"
+        },
+        {
+          "name": "name8",
+          "type": "FixedString(4)",
+          "nullable": false,
+          "default": "DEFAULT unhex(name7)"
+        }
+      ],
+      "indexes": [
+        {
+          "name": "idx1",
+          "def": "bloom_filter(0.01)",
+          "table": "table_name",
+          "columns": [
+            "name1"
+          ]
+        },
+        {
+          "name": "idx2",
+          "def": "minmax",
+          "table": "table_name",
+          "columns": [
+            "name1 * 2"
+          ]
+        },
+        {
+          "name": "idx3",
+          "def": "set(1000)",
+          "table": "table_name",
+          "columns": [
+            "name1 * length(name2)"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "partition key",
+          "type": "PARTITION KEY",
+          "def": "PARTITION BY ((name1, name3, name5))",
+          "table": "table_name",
+          "columns": [
+            "name1",
+            "name3",
+            "name5"
+          ]
+        },
+        {
+          "name": "sorting key",
+          "type": "SORTING KEY",
+          "def": "ORDER BY (name1, name5)",
+          "table": "table_name",
+          "columns": [
+            "name1",
+            "name5"
+          ]
+        },
+        {
+          "name": "primary key",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (name1, name5)",
+          "table": "table_name",
+          "columns": [
+            "name1",
+            "name5"
+          ]
+        },
+        {
+          "name": "sampling key",
+          "type": "SAMPLING KEY",
+          "def": "SAMPLE BY (name1)",
+          "table": "table_name",
+          "columns": [
+            "name1"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE testdb.table_name (`name1` UInt64 COMMENT 'comment for column 1', `name2` Nullable(String) DEFAULT 'column 2' COMMENT 'comment for column 2' CODEC(ZSTD(1)), `name3` LowCardinality(String) MATERIALIZED upper(name2) COMMENT 'comment for column 3', `name4` SimpleAggregateFunction(sum, Float64) TTL name5 + toIntervalDay(1), `name5` DateTime DEFAULT now(), `name6` String ALIAS formatReadableSize(name1), `name7` String MATERIALIZED hex(name1), `name8` FixedString(4) DEFAULT unhex(name7), INDEX idx1 name1 TYPE bloom_filter(0.01) GRANULARITY 1, INDEX idx2 name1 * 2 TYPE minmax GRANULARITY 3, INDEX idx3 name1 * length(name2) TYPE set(1000) GRANULARITY 4, PROJECTION projection_name_1 (SELECT name1, name2, name3 ORDER BY name1)) ENGINE = MergeTree PARTITION BY (name1, name3, name5) PRIMARY KEY (name1, name5) ORDER BY (name1, name5) SAMPLE BY name1 SETTINGS index_granularity = 8192 COMMENT 'comment for table'"
+    },
+    {
+      "name": "view",
+      "type": "View",
+      "columns": [
+        {
+          "name": "name1",
+          "type": "UInt64",
+          "nullable": false
+        },
+        {
+          "name": "name2",
+          "type": "Nullable(String)",
+          "nullable": false
+        },
+        {
+          "name": "name4",
+          "type": "SimpleAggregateFunction(sum, Float64)",
+          "nullable": false
+        },
+        {
+          "name": "name5",
+          "type": "DateTime",
+          "nullable": false
+        },
+        {
+          "name": "name8",
+          "type": "FixedString(4)",
+          "nullable": false
+        }
+      ],
+      "def": "CREATE VIEW testdb.view (`name1` UInt64, `name2` Nullable(String), `name4` SimpleAggregateFunction(sum, Float64), `name5` DateTime, `name8` FixedString(4)) AS SELECT * FROM testdb.table_name"
+    }
+  ],
+  "functions": [
+    {
+      "name": "linear_equation",
+      "return_type": "",
+      "arguments": "",
+      "type": ""
+    }
+  ],
+  "driver": {
+    "name": "clickhouse",
+    "database_version": "24.4.4.113",
+    "meta": {
+      "dict": {
+        "Functions": "Stored procedures and functions"
+      }
+    }
+  }
+}

--- a/sample/detect_relations/schema.json
+++ b/sample/detect_relations/schema.json
@@ -1,1 +1,828 @@
-{"name":"relations","desc":"Sample database document.","tables":[{"name":"CamelizeTable","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"CamelizeTable","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"CamelizeTable","columns":["id"]}],"def":"CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"comment_stars","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"comment_post_id","type":"bigint","nullable":false},{"name":"comment_user_id","type":"int","nullable":false},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comment_stars","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comment_stars","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"def":"CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"comments","type":"BASE TABLE","comment":"Comments\nMulti-line\r\ntable\rcomment","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"post_id","type":"bigint","nullable":false},{"name":"user_id","type":"int","nullable":false},{"name":"comment","type":"text","nullable":false,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"comments_post_id_user_id_idx","def":"KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comments","columns":["id"]},{"name":"post_id","def":"UNIQUE KEY post_id (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]}],"constraints":[{"name":"post_id","type":"UNIQUE","def":"UNIQUE KEY post_id (post_id, user_id)","table":"comments","columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comments","columns":["id"]}],"def":"CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"},{"name":"hyphen-table","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"hyphen-column","type":"text","nullable":false},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"hyphen-table","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"hyphen-table","columns":["id"]}],"def":"CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"logs","type":"BASE TABLE","comment":"Auditログ","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"post_id","type":"bigint","nullable":true},{"name":"comment_id","type":"bigint","nullable":true},{"name":"comment_star_id","type":"bigint","nullable":true},{"name":"payload","type":"text","nullable":true},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"logs","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"logs","columns":["id"]}],"def":"CREATE TABLE `logs` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"},{"name":"post_comments","type":"VIEW","comment":"post and comments View table","columns":[{"name":"id","type":"bigint","nullable":true,"default":"0","comment":"comments.id"},{"name":"title","type":"varchar(255)","nullable":false,"comment":"posts.title"},{"name":"post_user","type":"varchar(50)","nullable":true,"comment":"posts.users.username"},{"name":"comment","type":"text","nullable":true,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"comment_user","type":"varchar(50)","nullable":true,"comment":"comments.users.username"},{"name":"created","type":"datetime","nullable":true,"comment":"comments.created"},{"name":"updated","type":"datetime","nullable":true,"comment":"comments.updated"}],"def":"CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`relations`.`posts` `p` left join `relations`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `relations`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `relations`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))","referenced_tables":["posts","comments","users"]},{"name":"posts","type":"BASE TABLE","comment":"Posts table","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"title","type":"varchar(255)","nullable":false},{"name":"body","type":"text","nullable":false,"comment":"post body"},{"name":"post_type","type":"enum('public','private','draft')","nullable":false,"comment":"public/private/draft"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"posts_user_id_idx","def":"KEY posts_user_id_idx (id) USING BTREE","table":"posts","columns":["id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"posts","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, title) USING BTREE","table":"posts","columns":["user_id","title"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"posts","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, title)","table":"posts","columns":["user_id","title"]}],"triggers":[{"name":"update_posts_updated","def":"CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"}],"def":"CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL,\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'","labels":[{"name":"green","virtual":true},{"name":"red","virtual":true},{"name":"blue","virtual":true}]},{"name":"user_options","type":"BASE TABLE","comment":"User options table","columns":[{"name":"user_id","type":"int","nullable":false},{"name":"show_email","type":"tinyint(1)","nullable":false,"default":"0"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (user_id) USING BTREE","table":"user_options","columns":["user_id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id) USING BTREE","table":"user_options","columns":["user_id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_options_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"user_options","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]}],"def":"CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'"},{"name":"users","type":"BASE TABLE","comment":"Users table","columns":[{"name":"id","type":"int","nullable":false,"extra_def":"auto_increment"},{"name":"username","type":"varchar(50)","nullable":false},{"name":"password","type":"varchar(50)","nullable":false},{"name":"email","type":"varchar(355)","nullable":false,"comment":"ex. user@example.com"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"users","columns":["id"]},{"name":"email","def":"UNIQUE KEY email (email) USING BTREE","table":"users","columns":["email"]},{"name":"username","def":"UNIQUE KEY username (username) USING BTREE","table":"users","columns":["username"]}],"constraints":[{"name":"email","type":"UNIQUE","def":"UNIQUE KEY email (email)","table":"users","columns":["email"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"users","columns":["id"]},{"name":"username","type":"UNIQUE","def":"UNIQUE KEY username (username)","table":"users","columns":["username"]}],"def":"CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`)\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'"}],"relations":[{"table":"user_options","columns":["user_id"],"cardinality":"zero_or_one","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"comment_stars","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"Detected Relation","virtual":true},{"table":"comments","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"Detected Relation","virtual":true},{"table":"comments","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"Detected Relation","virtual":true},{"table":"logs","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"Detected Relation","virtual":true},{"table":"logs","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Detected Relation","virtual":true},{"table":"logs","columns":["comment_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Detected Relation","virtual":true},{"table":"logs","columns":["comment_star_id"],"cardinality":"zero_or_more","parent_table":"comment_stars","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Detected Relation","virtual":true},{"table":"posts","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"Detected Relation","virtual":true}],"functions":[{"name":"CustomerLevel","return_type":"varchar","arguments":"credit decimal","type":"FUNCTION"},{"name":"GetAllComments","return_type":"","arguments":"","type":"PROCEDURE"}],"driver":{"name":"mysql","database_version":"8.4.4","meta":{"dict":{"Functions":"Stored procedures and functions"}}},"labels":[{"name":"sample","virtual":true},{"name":"tbls","virtual":true}]}
+{
+  "name": "relations",
+  "desc": "Sample database document.",
+  "tables": [
+    {
+      "name": "CamelizeTable",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "comment_stars",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment_post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "comment_user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "comments",
+      "type": "BASE TABLE",
+      "comment": "Comments\nMulti-line\r\ntable\rcomment",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": false,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comments_post_id_user_id_idx",
+          "def": "KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "def": "UNIQUE KEY post_id (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "post_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY post_id (post_id, user_id)",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"
+    },
+    {
+      "name": "hyphen-table",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "hyphen-column",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "logs",
+      "type": "BASE TABLE",
+      "comment": "Auditログ",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_star_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "payload",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `logs` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"
+    },
+    {
+      "name": "post_comments",
+      "type": "VIEW",
+      "comment": "post and comments View table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": true,
+          "default": "0",
+          "comment": "comments.id"
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "comment": "posts.title"
+        },
+        {
+          "name": "post_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "posts.users.username"
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": true,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "comment_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "comments.users.username"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.created"
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.updated"
+        }
+      ],
+      "def": "CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`relations`.`posts` `p` left join `relations`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `relations`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `relations`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))",
+      "referenced_tables": [
+        "posts",
+        "comments",
+        "users"
+      ]
+    },
+    {
+      "name": "posts",
+      "type": "BASE TABLE",
+      "comment": "Posts table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false
+        },
+        {
+          "name": "body",
+          "type": "text",
+          "nullable": false,
+          "comment": "post body"
+        },
+        {
+          "name": "post_type",
+          "type": "enum('public','private','draft')",
+          "nullable": false,
+          "comment": "public/private/draft"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "posts_user_id_idx",
+          "def": "KEY posts_user_id_idx (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, title) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, title)",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_posts_updated",
+          "def": "CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"
+        }
+      ],
+      "def": "CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL,\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'",
+      "labels": [
+        {
+          "name": "green",
+          "virtual": true
+        },
+        {
+          "name": "red",
+          "virtual": true
+        },
+        {
+          "name": "blue",
+          "virtual": true
+        }
+      ]
+    },
+    {
+      "name": "user_options",
+      "type": "BASE TABLE",
+      "comment": "User options table",
+      "columns": [
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "show_email",
+          "type": "tinyint(1)",
+          "nullable": false,
+          "default": "0"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_options_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "user_options",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'"
+    },
+    {
+      "name": "users",
+      "type": "BASE TABLE",
+      "comment": "Users table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "username",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "password",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "email",
+          "type": "varchar(355)",
+          "nullable": false,
+          "comment": "ex. user@example.com"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "email",
+          "def": "UNIQUE KEY email (email) USING BTREE",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "username",
+          "def": "UNIQUE KEY username (username) USING BTREE",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "email",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY email (email)",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "username",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY username (username)",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`)\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'"
+    }
+  ],
+  "relations": [
+    {
+      "table": "user_options",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_one",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "comment_stars",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "Detected Relation",
+      "virtual": true
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "Detected Relation",
+      "virtual": true
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "Detected Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "Detected Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Detected Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "comment_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Detected Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "comment_star_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comment_stars",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Detected Relation",
+      "virtual": true
+    },
+    {
+      "table": "posts",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "Detected Relation",
+      "virtual": true
+    }
+  ],
+  "functions": [
+    {
+      "name": "CustomerLevel",
+      "return_type": "varchar",
+      "arguments": "credit decimal",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "GetAllComments",
+      "return_type": "",
+      "arguments": "",
+      "type": "PROCEDURE"
+    }
+  ],
+  "driver": {
+    "name": "mysql",
+    "database_version": "8.4.6",
+    "meta": {
+      "dict": {
+        "Functions": "Stored procedures and functions"
+      }
+    }
+  },
+  "labels": [
+    {
+      "name": "sample",
+      "virtual": true
+    },
+    {
+      "name": "tbls",
+      "virtual": true
+    }
+  ]
+}

--- a/sample/detect_relations_singular/schema.json
+++ b/sample/detect_relations_singular/schema.json
@@ -1,1 +1,828 @@
-{"name":"relations_singular","desc":"Sample database document.","tables":[{"name":"CamelizeTable","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"CamelizeTable","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"CamelizeTable","columns":["id"]}],"def":"CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"comment","type":"BASE TABLE","comment":"Comment\nMulti-line\r\ntable\rcomment","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"post_id","type":"bigint","nullable":false},{"name":"user_id","type":"int","nullable":false},{"name":"comment","type":"text","nullable":false,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"comment_post_id_user_id_idx","def":"KEY comment_post_id_user_id_idx (post_id, user_id) USING BTREE","table":"comment","columns":["post_id","user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comment","columns":["id"]},{"name":"post_id","def":"UNIQUE KEY post_id (post_id, user_id) USING BTREE","table":"comment","columns":["post_id","user_id"]}],"constraints":[{"name":"post_id","type":"UNIQUE","def":"UNIQUE KEY post_id (post_id, user_id)","table":"comment","columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comment","columns":["id"]}],"def":"CREATE TABLE `comment` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comment_post_id_user_id_idx` (`post_id`,`user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comment\\nMulti-line\\r\\ntable\\rcomment'"},{"name":"comment_star","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"comment_post_id","type":"bigint","nullable":false},{"name":"comment_user_id","type":"int","nullable":false},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comment_star","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE","table":"comment_star","columns":["user_id","comment_post_id","comment_user_id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comment_star","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)","table":"comment_star","columns":["user_id","comment_post_id","comment_user_id"]}],"def":"CREATE TABLE `comment_star` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"hyphen-table","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"hyphen-column","type":"text","nullable":false},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"hyphen-table","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"hyphen-table","columns":["id"]}],"def":"CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"log","type":"BASE TABLE","comment":"Auditログ","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"post_id","type":"bigint","nullable":true},{"name":"comment_id","type":"bigint","nullable":true},{"name":"comment_star_id","type":"bigint","nullable":true},{"name":"payload","type":"text","nullable":true},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"log","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"log","columns":["id"]}],"def":"CREATE TABLE `log` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"},{"name":"post","type":"BASE TABLE","comment":"Post table","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"title","type":"varchar(255)","nullable":false},{"name":"body","type":"text","nullable":false,"comment":"post body"},{"name":"post_type","type":"enum('public','private','draft')","nullable":false,"comment":"public/private/draft"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"post_user_id_idx","def":"KEY post_user_id_idx (id) USING BTREE","table":"post","columns":["id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"post","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, title) USING BTREE","table":"post","columns":["user_id","title"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"post","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, title)","table":"post","columns":["user_id","title"]}],"triggers":[{"name":"update_posts_updated","def":"CREATE TRIGGER update_posts_updated BEFORE UPDATE ON post\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"}],"def":"CREATE TABLE `post` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL,\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `post_user_id_idx` (`id`) USING BTREE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Post table'","labels":[{"name":"green","virtual":true},{"name":"red","virtual":true},{"name":"blue","virtual":true}]},{"name":"post_comment","type":"VIEW","comment":"post and comments View table","columns":[{"name":"id","type":"bigint","nullable":true,"default":"0","comment":"comment.id"},{"name":"title","type":"varchar(255)","nullable":false,"comment":"post.title"},{"name":"post_user","type":"varchar(50)","nullable":true,"comment":"post.user.username"},{"name":"comment","type":"text","nullable":true,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"comment_user","type":"varchar(50)","nullable":true,"comment":"comment.user.username"},{"name":"created","type":"datetime","nullable":true,"comment":"comment.created"},{"name":"updated","type":"datetime","nullable":true,"comment":"comment.updated"}],"def":"CREATE VIEW post_comment AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`relations_singular`.`post` `p` left join `relations_singular`.`comment` `c` on((`p`.`id` = `c`.`post_id`))) left join `relations_singular`.`user` `u` on((`u`.`id` = `p`.`user_id`))) left join `relations_singular`.`user` `u2` on((`u2`.`id` = `c`.`user_id`))))","referenced_tables":["post","comment","user"]},{"name":"user","type":"BASE TABLE","comment":"User table","columns":[{"name":"id","type":"int","nullable":false,"extra_def":"auto_increment"},{"name":"username","type":"varchar(50)","nullable":false},{"name":"password","type":"varchar(50)","nullable":false},{"name":"email","type":"varchar(355)","nullable":false,"comment":"ex. user@example.com"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"user","columns":["id"]},{"name":"email","def":"UNIQUE KEY email (email) USING BTREE","table":"user","columns":["email"]},{"name":"username","def":"UNIQUE KEY username (username) USING BTREE","table":"user","columns":["username"]}],"constraints":[{"name":"email","type":"UNIQUE","def":"UNIQUE KEY email (email)","table":"user","columns":["email"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"user","columns":["id"]},{"name":"username","type":"UNIQUE","def":"UNIQUE KEY username (username)","table":"user","columns":["username"]}],"def":"CREATE TABLE `user` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`)\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User table'"},{"name":"user_option","type":"BASE TABLE","comment":"User option table","columns":[{"name":"user_id","type":"int","nullable":false},{"name":"show_email","type":"tinyint(1)","nullable":false,"default":"0"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (user_id) USING BTREE","table":"user_option","columns":["user_id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id) USING BTREE","table":"user_option","columns":["user_id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (user_id)","table":"user_option","columns":["user_id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id)","table":"user_option","columns":["user_id"]},{"name":"user_option_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES user (id)","table":"user_option","referenced_table":"user","columns":["user_id"],"referenced_columns":["id"]}],"def":"CREATE TABLE `user_option` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_option_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User option table'"}],"relations":[{"table":"user_option","columns":["user_id"],"cardinality":"zero_or_one","parent_table":"user","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES user (id)"},{"table":"comment","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"post","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"Detected Relation","virtual":true},{"table":"comment","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"user","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"Detected Relation","virtual":true},{"table":"comment_star","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"user","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"Detected Relation","virtual":true},{"table":"log","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"user","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"Detected Relation","virtual":true},{"table":"log","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"post","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Detected Relation","virtual":true},{"table":"log","columns":["comment_id"],"cardinality":"zero_or_more","parent_table":"comment","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Detected Relation","virtual":true},{"table":"log","columns":["comment_star_id"],"cardinality":"zero_or_more","parent_table":"comment_star","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Detected Relation","virtual":true},{"table":"post","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"user","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"Detected Relation","virtual":true}],"functions":[{"name":"CustomerLevel","return_type":"varchar","arguments":"credit decimal","type":"FUNCTION"},{"name":"GetAllComments","return_type":"","arguments":"","type":"PROCEDURE"}],"driver":{"name":"mysql","database_version":"8.4.4","meta":{"dict":{"Functions":"Stored procedures and functions"}}},"labels":[{"name":"sample","virtual":true},{"name":"tbls","virtual":true}]}
+{
+  "name": "relations_singular",
+  "desc": "Sample database document.",
+  "tables": [
+    {
+      "name": "CamelizeTable",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "comment",
+      "type": "BASE TABLE",
+      "comment": "Comment\nMulti-line\r\ntable\rcomment",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": false,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comment_post_id_user_id_idx",
+          "def": "KEY comment_post_id_user_id_idx (post_id, user_id) USING BTREE",
+          "table": "comment",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comment",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "def": "UNIQUE KEY post_id (post_id, user_id) USING BTREE",
+          "table": "comment",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "post_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY post_id (post_id, user_id)",
+          "table": "comment",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comment",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comment` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comment_post_id_user_id_idx` (`post_id`,`user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comment\\nMulti-line\\r\\ntable\\rcomment'"
+    },
+    {
+      "name": "comment_star",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment_post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "comment_user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comment_star",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_star",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comment_star",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)",
+          "table": "comment_star",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comment_star` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "hyphen-table",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "hyphen-column",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "log",
+      "type": "BASE TABLE",
+      "comment": "Auditログ",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_star_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "payload",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "log",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "log",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `log` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"
+    },
+    {
+      "name": "post",
+      "type": "BASE TABLE",
+      "comment": "Post table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false
+        },
+        {
+          "name": "body",
+          "type": "text",
+          "nullable": false,
+          "comment": "post body"
+        },
+        {
+          "name": "post_type",
+          "type": "enum('public','private','draft')",
+          "nullable": false,
+          "comment": "public/private/draft"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "post_user_id_idx",
+          "def": "KEY post_user_id_idx (id) USING BTREE",
+          "table": "post",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "post",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, title) USING BTREE",
+          "table": "post",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "post",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, title)",
+          "table": "post",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_posts_updated",
+          "def": "CREATE TRIGGER update_posts_updated BEFORE UPDATE ON post\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"
+        }
+      ],
+      "def": "CREATE TABLE `post` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL,\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `post_user_id_idx` (`id`) USING BTREE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Post table'",
+      "labels": [
+        {
+          "name": "green",
+          "virtual": true
+        },
+        {
+          "name": "red",
+          "virtual": true
+        },
+        {
+          "name": "blue",
+          "virtual": true
+        }
+      ]
+    },
+    {
+      "name": "post_comment",
+      "type": "VIEW",
+      "comment": "post and comments View table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": true,
+          "default": "0",
+          "comment": "comment.id"
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "comment": "post.title"
+        },
+        {
+          "name": "post_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "post.user.username"
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": true,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "comment_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "comment.user.username"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comment.created"
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comment.updated"
+        }
+      ],
+      "def": "CREATE VIEW post_comment AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`relations_singular`.`post` `p` left join `relations_singular`.`comment` `c` on((`p`.`id` = `c`.`post_id`))) left join `relations_singular`.`user` `u` on((`u`.`id` = `p`.`user_id`))) left join `relations_singular`.`user` `u2` on((`u2`.`id` = `c`.`user_id`))))",
+      "referenced_tables": [
+        "post",
+        "comment",
+        "user"
+      ]
+    },
+    {
+      "name": "user",
+      "type": "BASE TABLE",
+      "comment": "User table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "username",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "password",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "email",
+          "type": "varchar(355)",
+          "nullable": false,
+          "comment": "ex. user@example.com"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "user",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "email",
+          "def": "UNIQUE KEY email (email) USING BTREE",
+          "table": "user",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "username",
+          "def": "UNIQUE KEY username (username) USING BTREE",
+          "table": "user",
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "email",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY email (email)",
+          "table": "user",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "user",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "username",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY username (username)",
+          "table": "user",
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `user` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`)\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User table'"
+    },
+    {
+      "name": "user_option",
+      "type": "BASE TABLE",
+      "comment": "User option table",
+      "columns": [
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "show_email",
+          "type": "tinyint(1)",
+          "nullable": false,
+          "default": "0"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (user_id) USING BTREE",
+          "table": "user_option",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id) USING BTREE",
+          "table": "user_option",
+          "columns": [
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (user_id)",
+          "table": "user_option",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id)",
+          "table": "user_option",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_option_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES user (id)",
+          "table": "user_option",
+          "referenced_table": "user",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `user_option` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_option_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User option table'"
+    }
+  ],
+  "relations": [
+    {
+      "table": "user_option",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_one",
+      "parent_table": "user",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES user (id)"
+    },
+    {
+      "table": "comment",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "post",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "Detected Relation",
+      "virtual": true
+    },
+    {
+      "table": "comment",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "user",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "Detected Relation",
+      "virtual": true
+    },
+    {
+      "table": "comment_star",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "user",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "Detected Relation",
+      "virtual": true
+    },
+    {
+      "table": "log",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "user",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "Detected Relation",
+      "virtual": true
+    },
+    {
+      "table": "log",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "post",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Detected Relation",
+      "virtual": true
+    },
+    {
+      "table": "log",
+      "columns": [
+        "comment_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comment",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Detected Relation",
+      "virtual": true
+    },
+    {
+      "table": "log",
+      "columns": [
+        "comment_star_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comment_star",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Detected Relation",
+      "virtual": true
+    },
+    {
+      "table": "post",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "user",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "Detected Relation",
+      "virtual": true
+    }
+  ],
+  "functions": [
+    {
+      "name": "CustomerLevel",
+      "return_type": "varchar",
+      "arguments": "credit decimal",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "GetAllComments",
+      "return_type": "",
+      "arguments": "",
+      "type": "PROCEDURE"
+    }
+  ],
+  "driver": {
+    "name": "mysql",
+    "database_version": "8.4.6",
+    "meta": {
+      "dict": {
+        "Functions": "Stored procedures and functions"
+      }
+    }
+  },
+  "labels": [
+    {
+      "name": "sample",
+      "virtual": true
+    },
+    {
+      "name": "tbls",
+      "virtual": true
+    }
+  ]
+}

--- a/sample/dict/schema.json
+++ b/sample/dict/schema.json
@@ -1,1 +1,896 @@
-{"name":"testdb","tables":[{"name":"CamelizeTable","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"CamelizeTable","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"CamelizeTable","columns":["id"]}],"def":"CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"comment_stars","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"comment_post_id","type":"bigint","nullable":false},{"name":"comment_user_id","type":"int","nullable":false},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"comment_stars_user_id_fk","def":"KEY comment_stars_user_id_fk (comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_user_id"]},{"name":"comment_stars_user_id_post_id_fk","def":"KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_post_id","comment_user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comment_stars","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"constraints":[{"name":"comment_stars_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)","table":"comment_stars","referenced_table":"users","columns":["comment_user_id"],"referenced_columns":["id"]},{"name":"comment_stars_user_id_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)","table":"comment_stars","referenced_table":"comments","columns":["comment_post_id","comment_user_id"],"referenced_columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comment_stars","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"def":"CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"comments","type":"BASE TABLE","comment":"Comments\nMulti-line\r\ntable\rcomment","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"post_id","type":"bigint","nullable":false},{"name":"user_id","type":"int","nullable":false},{"name":"comment","type":"text","nullable":false,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"post_id_desc","type":"bigint","nullable":true,"extra_def":"GENERATED ALWAYS AS (`post_id` * -(1)) VIRTUAL"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"comments_post_id_user_id_idx","def":"KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]},{"name":"comments_user_id_fk","def":"KEY comments_user_id_fk (user_id) USING BTREE","table":"comments","columns":["user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comments","columns":["id"]},{"name":"post_id","def":"UNIQUE KEY post_id (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]}],"constraints":[{"name":"comments_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (post_id) REFERENCES posts (id)","table":"comments","referenced_table":"posts","columns":["post_id"],"referenced_columns":["id"]},{"name":"comments_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"comments","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"post_id","type":"UNIQUE","def":"UNIQUE KEY post_id (post_id, user_id)","table":"comments","columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comments","columns":["id"]}],"def":"CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint GENERATED ALWAYS AS ((`post_id` * -(1))) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`),\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"},{"name":"hyphen-table","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"hyphen-column","type":"text","nullable":false},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"hyphen-table","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"hyphen-table","columns":["id"]}],"def":"CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"logs","type":"BASE TABLE","comment":"Auditログ","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"post_id","type":"bigint","nullable":true},{"name":"comment_id","type":"bigint","nullable":true},{"name":"comment_star_id","type":"bigint","nullable":true},{"name":"payload","type":"text","nullable":true},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"logs","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"logs","columns":["id"]}],"def":"CREATE TABLE `logs` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"},{"name":"long_long_long_long_long_long_long_long_table_name","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"long_long_long_long_long_long_long_long_table_name","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"long_long_long_long_long_long_long_long_table_name","columns":["id"]}],"def":"CREATE TABLE `long_long_long_long_long_long_long_long_table_name` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"post_comments","type":"VIEW","comment":"VIEW","columns":[{"name":"id","type":"bigint","nullable":true,"default":"0"},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled"},{"name":"post_user","type":"varchar(50)","nullable":true},{"name":"comment","type":"text","nullable":true,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"comment_user","type":"varchar(50)","nullable":true},{"name":"created","type":"datetime","nullable":true},{"name":"updated","type":"datetime","nullable":true}],"def":"CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))","referenced_tables":["posts","comments","users"]},{"name":"posts","type":"BASE TABLE","comment":"Posts table","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled"},{"name":"body","type":"text","nullable":false},{"name":"post_type","type":"enum('public','private','draft')","nullable":false,"comment":"public/private/draft"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"posts_user_id_idx","def":"KEY posts_user_id_idx (id) USING BTREE","table":"posts","columns":["id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"posts","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, title) USING BTREE","table":"posts","columns":["user_id","title"]}],"constraints":[{"name":"posts_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"posts","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"posts","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, title)","table":"posts","columns":["user_id","title"]}],"triggers":[{"name":"update_posts_updated","def":"CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"}],"def":"CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'"},{"name":"user_options","type":"BASE TABLE","comment":"User options table","columns":[{"name":"user_id","type":"int","nullable":false},{"name":"show_email","type":"tinyint(1)","nullable":false,"default":"0"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (user_id) USING BTREE","table":"user_options","columns":["user_id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id) USING BTREE","table":"user_options","columns":["user_id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_options_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"user_options","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]}],"def":"CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'"},{"name":"users","type":"BASE TABLE","comment":"Users table","columns":[{"name":"id","type":"int","nullable":false,"extra_def":"auto_increment"},{"name":"username","type":"varchar(50)","nullable":false},{"name":"password","type":"varchar(50)","nullable":false},{"name":"email","type":"varchar(355)","nullable":false,"comment":"ex. user@example.com"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"users","columns":["id"]},{"name":"email","def":"UNIQUE KEY email (email) USING BTREE","table":"users","columns":["email"]},{"name":"username","def":"UNIQUE KEY username (username) USING BTREE","table":"users","columns":["username"]}],"constraints":[{"name":"email","type":"UNIQUE","def":"UNIQUE KEY email (email)","table":"users","columns":["email"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"users","columns":["id"]},{"name":"username","type":"UNIQUE","def":"UNIQUE KEY username (username)","table":"users","columns":["username"]},{"name":"users_chk_1","type":"CHECK","def":"CHECK ((char_length(`username`) \u003e 4))","table":"users"}],"def":"CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`),\n  CONSTRAINT `users_chk_1` CHECK ((char_length(`username`) \u003e 4))\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'"}],"relations":[{"table":"comment_stars","columns":["comment_user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)"},{"table":"comment_stars","columns":["comment_post_id","comment_user_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["post_id","user_id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"},{"table":"comments","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (post_id) REFERENCES posts (id)"},{"table":"comments","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"posts","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"user_options","columns":["user_id"],"cardinality":"zero_or_one","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"}],"functions":[{"name":"CustomerLevel","return_type":"varchar","arguments":"credit decimal","type":"FUNCTION"},{"name":"GetAllComments","return_type":"","arguments":"","type":"PROCEDURE"}],"driver":{"name":"mysql","database_version":"8.4.4","meta":{"dict":{"Functions":"Stored procedures and functions"}}}}
+{
+  "name": "testdb",
+  "tables": [
+    {
+      "name": "CamelizeTable",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "comment_stars",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment_post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "comment_user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "def": "KEY comment_stars_user_id_fk (comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "def": "KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)",
+          "table": "comment_stars",
+          "referenced_table": "users",
+          "columns": [
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)",
+          "table": "comment_stars",
+          "referenced_table": "comments",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "comments",
+      "type": "BASE TABLE",
+      "comment": "Comments\nMulti-line\r\ntable\rcomment",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": false,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "post_id_desc",
+          "type": "bigint",
+          "nullable": true,
+          "extra_def": "GENERATED ALWAYS AS (`post_id` * -(1)) VIRTUAL"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comments_post_id_user_id_idx",
+          "def": "KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "def": "KEY comments_user_id_fk (user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "def": "UNIQUE KEY post_id (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comments_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (post_id) REFERENCES posts (id)",
+          "table": "comments",
+          "referenced_table": "posts",
+          "columns": [
+            "post_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "comments",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY post_id (post_id, user_id)",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint GENERATED ALWAYS AS ((`post_id` * -(1))) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`),\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"
+    },
+    {
+      "name": "hyphen-table",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "hyphen-column",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "logs",
+      "type": "BASE TABLE",
+      "comment": "Auditログ",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_star_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "payload",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `logs` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"
+    },
+    {
+      "name": "long_long_long_long_long_long_long_long_table_name",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "long_long_long_long_long_long_long_long_table_name",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "long_long_long_long_long_long_long_long_table_name",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `long_long_long_long_long_long_long_long_table_name` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "post_comments",
+      "type": "VIEW",
+      "comment": "VIEW",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": true,
+          "default": "0"
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled"
+        },
+        {
+          "name": "post_user",
+          "type": "varchar(50)",
+          "nullable": true
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": true,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "comment_user",
+          "type": "varchar(50)",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": true
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "def": "CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))",
+      "referenced_tables": [
+        "posts",
+        "comments",
+        "users"
+      ]
+    },
+    {
+      "name": "posts",
+      "type": "BASE TABLE",
+      "comment": "Posts table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled"
+        },
+        {
+          "name": "body",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "post_type",
+          "type": "enum('public','private','draft')",
+          "nullable": false,
+          "comment": "public/private/draft"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "posts_user_id_idx",
+          "def": "KEY posts_user_id_idx (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, title) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "posts_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "posts",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, title)",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_posts_updated",
+          "def": "CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"
+        }
+      ],
+      "def": "CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'"
+    },
+    {
+      "name": "user_options",
+      "type": "BASE TABLE",
+      "comment": "User options table",
+      "columns": [
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "show_email",
+          "type": "tinyint(1)",
+          "nullable": false,
+          "default": "0"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_options_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "user_options",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'"
+    },
+    {
+      "name": "users",
+      "type": "BASE TABLE",
+      "comment": "Users table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "username",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "password",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "email",
+          "type": "varchar(355)",
+          "nullable": false,
+          "comment": "ex. user@example.com"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "email",
+          "def": "UNIQUE KEY email (email) USING BTREE",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "username",
+          "def": "UNIQUE KEY username (username) USING BTREE",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "email",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY email (email)",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "username",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY username (username)",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "users_chk_1",
+          "type": "CHECK",
+          "def": "CHECK ((char_length(`username`) \u003e 4))",
+          "table": "users"
+        }
+      ],
+      "def": "CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`),\n  CONSTRAINT `users_chk_1` CHECK ((char_length(`username`) \u003e 4))\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'"
+    }
+  ],
+  "relations": [
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_post_id",
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "post_id",
+        "user_id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (post_id) REFERENCES posts (id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "posts",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "user_options",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_one",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    }
+  ],
+  "functions": [
+    {
+      "name": "CustomerLevel",
+      "return_type": "varchar",
+      "arguments": "credit decimal",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "GetAllComments",
+      "return_type": "",
+      "arguments": "",
+      "type": "PROCEDURE"
+    }
+  ],
+  "driver": {
+    "name": "mysql",
+    "database_version": "8.4.6",
+    "meta": {
+      "dict": {
+        "Functions": "Stored procedures and functions"
+      }
+    }
+  }
+}

--- a/sample/dynamodb/schema.json
+++ b/sample/dynamodb/schema.json
@@ -1,1 +1,145 @@
-{"name":"Amazon DynamoDB (ap-northeast-1)","tables":[{"name":"Forum","type":"BASIC TABLE","columns":[{"name":"Name","type":"S","nullable":false}],"constraints":[{"name":"Primary Key","type":"Partition key","def":"[{ AttributeName: \"Name\", KeyType: \"HASH\" }]","table":null,"columns":["Name"]}]},{"name":"ProductCatalog","type":"BASIC TABLE","columns":[{"name":"Id","type":"N","nullable":false}],"constraints":[{"name":"Primary Key","type":"Partition key","def":"[{ AttributeName: \"Id\", KeyType: \"HASH\" }]","table":null,"columns":["Id"]}]},{"name":"Reply","type":"BASIC TABLE","columns":[{"name":"Id","type":"S","nullable":false},{"name":"ReplyDateTime","type":"S","nullable":false},{"name":"PostedBy","type":"S","nullable":false}],"indexes":[{"name":"PostedBy-index","def":"LocalSecondaryIndex { [{ AttributeName: \"Id\", KeyType: \"HASH\" } { AttributeName: \"PostedBy\", KeyType: \"RANGE\" }], { ProjectionType: \"KEYS_ONLY\" } }","table":null,"columns":null}],"constraints":[{"name":"Primary Key","type":"Partition key and sort key","def":"[{ AttributeName: \"Id\", KeyType: \"HASH\" } { AttributeName: \"ReplyDateTime\", KeyType: \"RANGE\" }]","table":null,"columns":["Id","ReplyDateTime"]}]},{"name":"Thread","type":"BASIC TABLE","columns":[{"name":"ForumName","type":"S","nullable":false},{"name":"Subject","type":"S","nullable":false}],"constraints":[{"name":"Primary Key","type":"Partition key and sort key","def":"[{ AttributeName: \"ForumName\", KeyType: \"HASH\" } { AttributeName: \"Subject\", KeyType: \"RANGE\" }]","table":null,"columns":["ForumName","Subject"]}]}],"relations":[{"table":"Thread","columns":["ForumName"],"cardinality":"zero_or_more","parent_table":"Forum","parent_columns":["Name"],"parent_cardinality":"exactly_one","def":"Thread-\u003eForum","virtual":true}],"driver":{"name":"dynamodb","meta":{"dict":{"Column":"Attribute","Columns":"Attributes","Constraints":"Primary Key","Indexes":"Secondary Indexes"}}}}
+{
+  "name": "Amazon DynamoDB (ap-northeast-1)",
+  "tables": [
+    {
+      "name": "Forum",
+      "type": "BASIC TABLE",
+      "columns": [
+        {
+          "name": "Name",
+          "type": "S",
+          "nullable": false
+        }
+      ],
+      "constraints": [
+        {
+          "name": "Primary Key",
+          "type": "Partition key",
+          "def": "[{ AttributeName: \"Name\", KeyType: \"HASH\" }]",
+          "table": null,
+          "columns": [
+            "Name"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ProductCatalog",
+      "type": "BASIC TABLE",
+      "columns": [
+        {
+          "name": "Id",
+          "type": "N",
+          "nullable": false
+        }
+      ],
+      "constraints": [
+        {
+          "name": "Primary Key",
+          "type": "Partition key",
+          "def": "[{ AttributeName: \"Id\", KeyType: \"HASH\" }]",
+          "table": null,
+          "columns": [
+            "Id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Reply",
+      "type": "BASIC TABLE",
+      "columns": [
+        {
+          "name": "Id",
+          "type": "S",
+          "nullable": false
+        },
+        {
+          "name": "ReplyDateTime",
+          "type": "S",
+          "nullable": false
+        },
+        {
+          "name": "PostedBy",
+          "type": "S",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PostedBy-index",
+          "def": "LocalSecondaryIndex { [{ AttributeName: \"Id\", KeyType: \"HASH\" } { AttributeName: \"PostedBy\", KeyType: \"RANGE\" }], { ProjectionType: \"KEYS_ONLY\" } }",
+          "table": null,
+          "columns": null
+        }
+      ],
+      "constraints": [
+        {
+          "name": "Primary Key",
+          "type": "Partition key and sort key",
+          "def": "[{ AttributeName: \"Id\", KeyType: \"HASH\" } { AttributeName: \"ReplyDateTime\", KeyType: \"RANGE\" }]",
+          "table": null,
+          "columns": [
+            "Id",
+            "ReplyDateTime"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Thread",
+      "type": "BASIC TABLE",
+      "columns": [
+        {
+          "name": "ForumName",
+          "type": "S",
+          "nullable": false
+        },
+        {
+          "name": "Subject",
+          "type": "S",
+          "nullable": false
+        }
+      ],
+      "constraints": [
+        {
+          "name": "Primary Key",
+          "type": "Partition key and sort key",
+          "def": "[{ AttributeName: \"ForumName\", KeyType: \"HASH\" } { AttributeName: \"Subject\", KeyType: \"RANGE\" }]",
+          "table": null,
+          "columns": [
+            "ForumName",
+            "Subject"
+          ]
+        }
+      ]
+    }
+  ],
+  "relations": [
+    {
+      "table": "Thread",
+      "columns": [
+        "ForumName"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "Forum",
+      "parent_columns": [
+        "Name"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "Thread-\u003eForum",
+      "virtual": true
+    }
+  ],
+  "driver": {
+    "name": "dynamodb",
+    "meta": {
+      "dict": {
+        "Column": "Attribute",
+        "Columns": "Attributes",
+        "Constraints": "Primary Key",
+        "Indexes": "Secondary Indexes"
+      }
+    }
+  }
+}

--- a/sample/exclude/schema.json
+++ b/sample/exclude/schema.json
@@ -1,1 +1,799 @@
-{"name":"testdb","tables":[{"name":"comment_stars","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"comment_post_id","type":"bigint","nullable":false},{"name":"comment_user_id","type":"int","nullable":false},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"comment_stars_user_id_fk","def":"KEY comment_stars_user_id_fk (comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_user_id"]},{"name":"comment_stars_user_id_post_id_fk","def":"KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_post_id","comment_user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comment_stars","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"constraints":[{"name":"comment_stars_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)","table":"comment_stars","referenced_table":"users","columns":["comment_user_id"],"referenced_columns":["id"]},{"name":"comment_stars_user_id_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)","table":"comment_stars","referenced_table":"comments","columns":["comment_post_id","comment_user_id"],"referenced_columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comment_stars","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"def":"CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"comments","type":"BASE TABLE","comment":"Comments\nMulti-line\r\ntable\rcomment","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"post_id","type":"bigint","nullable":false},{"name":"user_id","type":"int","nullable":false},{"name":"comment","type":"text","nullable":false,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"post_id_desc","type":"bigint","nullable":true,"extra_def":"GENERATED ALWAYS AS (`post_id` * -(1)) VIRTUAL"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"comments_post_id_user_id_idx","def":"KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]},{"name":"comments_user_id_fk","def":"KEY comments_user_id_fk (user_id) USING BTREE","table":"comments","columns":["user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comments","columns":["id"]},{"name":"post_id","def":"UNIQUE KEY post_id (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]}],"constraints":[{"name":"comments_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (post_id) REFERENCES posts (id)","table":"comments","referenced_table":"posts","columns":["post_id"],"referenced_columns":["id"]},{"name":"comments_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"comments","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"post_id","type":"UNIQUE","def":"UNIQUE KEY post_id (post_id, user_id)","table":"comments","columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comments","columns":["id"]}],"def":"CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint GENERATED ALWAYS AS ((`post_id` * -(1))) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`),\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"},{"name":"hyphen-table","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"hyphen-column","type":"text","nullable":false},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"hyphen-table","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"hyphen-table","columns":["id"]}],"def":"CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"long_long_long_long_long_long_long_long_table_name","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"long_long_long_long_long_long_long_long_table_name","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"long_long_long_long_long_long_long_long_table_name","columns":["id"]}],"def":"CREATE TABLE `long_long_long_long_long_long_long_long_table_name` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"post_comments","type":"VIEW","comment":"post and comments View table","columns":[{"name":"id","type":"bigint","nullable":true,"default":"0","comment":"comments.id"},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled","comment":"posts.title"},{"name":"post_user","type":"varchar(50)","nullable":true,"comment":"posts.users.username"},{"name":"comment","type":"text","nullable":true,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"comment_user","type":"varchar(50)","nullable":true,"comment":"comments.users.username"},{"name":"created","type":"datetime","nullable":true,"comment":"comments.created"},{"name":"updated","type":"datetime","nullable":true,"comment":"comments.updated"}],"def":"CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))","referenced_tables":["posts","comments","users"]},{"name":"posts","type":"BASE TABLE","comment":"Posts table","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled"},{"name":"body","type":"text","nullable":false,"comment":"post body"},{"name":"post_type","type":"enum('public','private','draft')","nullable":false,"comment":"public/private/draft"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"posts_user_id_idx","def":"KEY posts_user_id_idx (id) USING BTREE","table":"posts","columns":["id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"posts","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, title) USING BTREE","table":"posts","columns":["user_id","title"]}],"constraints":[{"name":"posts_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"posts","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"posts","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, title)","table":"posts","columns":["user_id","title"]}],"triggers":[{"name":"update_posts_updated","def":"CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"}],"def":"CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'"},{"name":"user_options","type":"BASE TABLE","comment":"User options table","columns":[{"name":"user_id","type":"int","nullable":false},{"name":"show_email","type":"tinyint(1)","nullable":false,"default":"0"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (user_id) USING BTREE","table":"user_options","columns":["user_id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id) USING BTREE","table":"user_options","columns":["user_id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_options_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"user_options","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]}],"def":"CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'"},{"name":"users","type":"BASE TABLE","comment":"Users table","columns":[{"name":"id","type":"int","nullable":false,"extra_def":"auto_increment"},{"name":"username","type":"varchar(50)","nullable":false},{"name":"password","type":"varchar(50)","nullable":false},{"name":"email","type":"varchar(355)","nullable":false,"comment":"ex. user@example.com"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"users","columns":["id"]},{"name":"email","def":"UNIQUE KEY email (email) USING BTREE","table":"users","columns":["email"]},{"name":"username","def":"UNIQUE KEY username (username) USING BTREE","table":"users","columns":["username"]}],"constraints":[{"name":"email","type":"UNIQUE","def":"UNIQUE KEY email (email)","table":"users","columns":["email"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"users","columns":["id"]},{"name":"username","type":"UNIQUE","def":"UNIQUE KEY username (username)","table":"users","columns":["username"]},{"name":"users_chk_1","type":"CHECK","def":"CHECK ((char_length(`username`) \u003e 4))","table":"users"}],"def":"CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`),\n  CONSTRAINT `users_chk_1` CHECK ((char_length(`username`) \u003e 4))\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'"}],"relations":[{"table":"comment_stars","columns":["comment_user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)"},{"table":"comment_stars","columns":["comment_post_id","comment_user_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["post_id","user_id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"},{"table":"comments","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (post_id) REFERENCES posts (id)"},{"table":"comments","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"posts","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"user_options","columns":["user_id"],"cardinality":"zero_or_one","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"}],"functions":[{"name":"CustomerLevel","return_type":"varchar","arguments":"credit decimal","type":"FUNCTION"},{"name":"GetAllComments","return_type":"","arguments":"","type":"PROCEDURE"}],"driver":{"name":"mysql","database_version":"8.4.4","meta":{"dict":{"Functions":"Stored procedures and functions"}}}}
+{
+  "name": "testdb",
+  "tables": [
+    {
+      "name": "comment_stars",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment_post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "comment_user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "def": "KEY comment_stars_user_id_fk (comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "def": "KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)",
+          "table": "comment_stars",
+          "referenced_table": "users",
+          "columns": [
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)",
+          "table": "comment_stars",
+          "referenced_table": "comments",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "comments",
+      "type": "BASE TABLE",
+      "comment": "Comments\nMulti-line\r\ntable\rcomment",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": false,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "post_id_desc",
+          "type": "bigint",
+          "nullable": true,
+          "extra_def": "GENERATED ALWAYS AS (`post_id` * -(1)) VIRTUAL"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comments_post_id_user_id_idx",
+          "def": "KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "def": "KEY comments_user_id_fk (user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "def": "UNIQUE KEY post_id (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comments_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (post_id) REFERENCES posts (id)",
+          "table": "comments",
+          "referenced_table": "posts",
+          "columns": [
+            "post_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "comments",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY post_id (post_id, user_id)",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint GENERATED ALWAYS AS ((`post_id` * -(1))) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`),\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"
+    },
+    {
+      "name": "hyphen-table",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "hyphen-column",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "long_long_long_long_long_long_long_long_table_name",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "long_long_long_long_long_long_long_long_table_name",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "long_long_long_long_long_long_long_long_table_name",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `long_long_long_long_long_long_long_long_table_name` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "post_comments",
+      "type": "VIEW",
+      "comment": "post and comments View table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": true,
+          "default": "0",
+          "comment": "comments.id"
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled",
+          "comment": "posts.title"
+        },
+        {
+          "name": "post_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "posts.users.username"
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": true,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "comment_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "comments.users.username"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.created"
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.updated"
+        }
+      ],
+      "def": "CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))",
+      "referenced_tables": [
+        "posts",
+        "comments",
+        "users"
+      ]
+    },
+    {
+      "name": "posts",
+      "type": "BASE TABLE",
+      "comment": "Posts table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled"
+        },
+        {
+          "name": "body",
+          "type": "text",
+          "nullable": false,
+          "comment": "post body"
+        },
+        {
+          "name": "post_type",
+          "type": "enum('public','private','draft')",
+          "nullable": false,
+          "comment": "public/private/draft"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "posts_user_id_idx",
+          "def": "KEY posts_user_id_idx (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, title) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "posts_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "posts",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, title)",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_posts_updated",
+          "def": "CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"
+        }
+      ],
+      "def": "CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'"
+    },
+    {
+      "name": "user_options",
+      "type": "BASE TABLE",
+      "comment": "User options table",
+      "columns": [
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "show_email",
+          "type": "tinyint(1)",
+          "nullable": false,
+          "default": "0"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_options_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "user_options",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'"
+    },
+    {
+      "name": "users",
+      "type": "BASE TABLE",
+      "comment": "Users table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "username",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "password",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "email",
+          "type": "varchar(355)",
+          "nullable": false,
+          "comment": "ex. user@example.com"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "email",
+          "def": "UNIQUE KEY email (email) USING BTREE",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "username",
+          "def": "UNIQUE KEY username (username) USING BTREE",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "email",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY email (email)",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "username",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY username (username)",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "users_chk_1",
+          "type": "CHECK",
+          "def": "CHECK ((char_length(`username`) \u003e 4))",
+          "table": "users"
+        }
+      ],
+      "def": "CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`),\n  CONSTRAINT `users_chk_1` CHECK ((char_length(`username`) \u003e 4))\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'"
+    }
+  ],
+  "relations": [
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_post_id",
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "post_id",
+        "user_id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (post_id) REFERENCES posts (id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "posts",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "user_options",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_one",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    }
+  ],
+  "functions": [
+    {
+      "name": "CustomerLevel",
+      "return_type": "varchar",
+      "arguments": "credit decimal",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "GetAllComments",
+      "return_type": "",
+      "arguments": "",
+      "type": "PROCEDURE"
+    }
+  ],
+  "driver": {
+    "name": "mysql",
+    "database_version": "8.4.6",
+    "meta": {
+      "dict": {
+        "Functions": "Stored procedures and functions"
+      }
+    }
+  }
+}

--- a/sample/font/schema.json
+++ b/sample/font/schema.json
@@ -1,1 +1,913 @@
-{"name":"testdb","tables":[{"name":"CamelizeTable","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"CamelizeTable","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"CamelizeTable","columns":["id"]}],"def":"CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"comment_stars","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"comment_post_id","type":"bigint","nullable":false},{"name":"comment_user_id","type":"int","nullable":false},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"comment_stars_user_id_fk","def":"KEY comment_stars_user_id_fk (comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_user_id"]},{"name":"comment_stars_user_id_post_id_fk","def":"KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_post_id","comment_user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comment_stars","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"constraints":[{"name":"comment_stars_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)","table":"comment_stars","referenced_table":"users","columns":["comment_user_id"],"referenced_columns":["id"]},{"name":"comment_stars_user_id_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)","table":"comment_stars","referenced_table":"comments","columns":["comment_post_id","comment_user_id"],"referenced_columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comment_stars","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"def":"CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"comments","type":"BASE TABLE","comment":"Comments\nMulti-line\r\ntable\rcomment","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"post_id","type":"bigint","nullable":false},{"name":"user_id","type":"int","nullable":false},{"name":"comment","type":"text","nullable":false,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"post_id_desc","type":"bigint","nullable":true,"extra_def":"GENERATED ALWAYS AS (`post_id` * -(1)) VIRTUAL"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"comments_post_id_user_id_idx","def":"KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]},{"name":"comments_user_id_fk","def":"KEY comments_user_id_fk (user_id) USING BTREE","table":"comments","columns":["user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comments","columns":["id"]},{"name":"post_id","def":"UNIQUE KEY post_id (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]}],"constraints":[{"name":"comments_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (post_id) REFERENCES posts (id)","table":"comments","referenced_table":"posts","columns":["post_id"],"referenced_columns":["id"]},{"name":"comments_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"comments","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"post_id","type":"UNIQUE","def":"UNIQUE KEY post_id (post_id, user_id)","table":"comments","columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comments","columns":["id"]}],"def":"CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint GENERATED ALWAYS AS ((`post_id` * -(1))) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`),\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"},{"name":"hyphen-table","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"hyphen-column","type":"text","nullable":false},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"hyphen-table","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"hyphen-table","columns":["id"]}],"def":"CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"logs","type":"BASE TABLE","comment":"Auditログ","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"post_id","type":"bigint","nullable":true},{"name":"comment_id","type":"bigint","nullable":true},{"name":"comment_star_id","type":"bigint","nullable":true},{"name":"payload","type":"text","nullable":true},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"logs","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"logs","columns":["id"]}],"def":"CREATE TABLE `logs` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"},{"name":"long_long_long_long_long_long_long_long_table_name","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"long_long_long_long_long_long_long_long_table_name","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"long_long_long_long_long_long_long_long_table_name","columns":["id"]}],"def":"CREATE TABLE `long_long_long_long_long_long_long_long_table_name` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"post_comments","type":"VIEW","comment":"post and comments View table","columns":[{"name":"id","type":"bigint","nullable":true,"default":"0","comment":"comments.id"},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled","comment":"posts.title"},{"name":"post_user","type":"varchar(50)","nullable":true,"comment":"posts.users.username"},{"name":"comment","type":"text","nullable":true,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"comment_user","type":"varchar(50)","nullable":true,"comment":"comments.users.username"},{"name":"created","type":"datetime","nullable":true,"comment":"comments.created"},{"name":"updated","type":"datetime","nullable":true,"comment":"comments.updated"}],"def":"CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))","referenced_tables":["posts","comments","users"]},{"name":"posts","type":"BASE TABLE","comment":"エントリ","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled"},{"name":"body","type":"text","nullable":false,"comment":"本文"},{"name":"post_type","type":"enum('public','private','draft')","nullable":false,"comment":"public/private/draft"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"posts_user_id_idx","def":"KEY posts_user_id_idx (id) USING BTREE","table":"posts","columns":["id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"posts","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, title) USING BTREE","table":"posts","columns":["user_id","title"]}],"constraints":[{"name":"posts_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"posts","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"posts","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, title)","table":"posts","columns":["user_id","title"]}],"triggers":[{"name":"update_posts_updated","def":"CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"}],"def":"CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'"},{"name":"user_options","type":"BASE TABLE","comment":"User options table","columns":[{"name":"user_id","type":"int","nullable":false},{"name":"show_email","type":"tinyint(1)","nullable":false,"default":"0"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (user_id) USING BTREE","table":"user_options","columns":["user_id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id) USING BTREE","table":"user_options","columns":["user_id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_options_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"user_options","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]}],"def":"CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'"},{"name":"users","type":"BASE TABLE","comment":"Users table","columns":[{"name":"id","type":"int","nullable":false,"extra_def":"auto_increment"},{"name":"username","type":"varchar(50)","nullable":false},{"name":"password","type":"varchar(50)","nullable":false},{"name":"email","type":"varchar(355)","nullable":false,"comment":"ex. user@example.com"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"users","columns":["id"]},{"name":"email","def":"UNIQUE KEY email (email) USING BTREE","table":"users","columns":["email"]},{"name":"username","def":"UNIQUE KEY username (username) USING BTREE","table":"users","columns":["username"]}],"constraints":[{"name":"email","type":"UNIQUE","def":"UNIQUE KEY email (email)","table":"users","columns":["email"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"users","columns":["id"]},{"name":"username","type":"UNIQUE","def":"UNIQUE KEY username (username)","table":"users","columns":["username"]},{"name":"users_chk_1","type":"CHECK","def":"CHECK ((char_length(`username`) \u003e 4))","table":"users"}],"def":"CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`),\n  CONSTRAINT `users_chk_1` CHECK ((char_length(`username`) \u003e 4))\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'"}],"relations":[{"table":"comment_stars","columns":["comment_user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)"},{"table":"comment_stars","columns":["comment_post_id","comment_user_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["post_id","user_id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"},{"table":"comments","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (post_id) REFERENCES posts (id)"},{"table":"comments","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"posts","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"user_options","columns":["user_id"],"cardinality":"zero_or_one","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"}],"functions":[{"name":"CustomerLevel","return_type":"varchar","arguments":"credit decimal","type":"FUNCTION"},{"name":"GetAllComments","return_type":"","arguments":"","type":"PROCEDURE"}],"driver":{"name":"mysql","database_version":"8.4.4","meta":{"dict":{"Functions":"Stored procedures and functions"}}},"labels":[{"name":"サンプル","virtual":true},{"name":"tbls","virtual":true}]}
+{
+  "name": "testdb",
+  "tables": [
+    {
+      "name": "CamelizeTable",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "comment_stars",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment_post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "comment_user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "def": "KEY comment_stars_user_id_fk (comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "def": "KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)",
+          "table": "comment_stars",
+          "referenced_table": "users",
+          "columns": [
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)",
+          "table": "comment_stars",
+          "referenced_table": "comments",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "comments",
+      "type": "BASE TABLE",
+      "comment": "Comments\nMulti-line\r\ntable\rcomment",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": false,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "post_id_desc",
+          "type": "bigint",
+          "nullable": true,
+          "extra_def": "GENERATED ALWAYS AS (`post_id` * -(1)) VIRTUAL"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comments_post_id_user_id_idx",
+          "def": "KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "def": "KEY comments_user_id_fk (user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "def": "UNIQUE KEY post_id (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comments_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (post_id) REFERENCES posts (id)",
+          "table": "comments",
+          "referenced_table": "posts",
+          "columns": [
+            "post_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "comments",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY post_id (post_id, user_id)",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint GENERATED ALWAYS AS ((`post_id` * -(1))) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`),\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"
+    },
+    {
+      "name": "hyphen-table",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "hyphen-column",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "logs",
+      "type": "BASE TABLE",
+      "comment": "Auditログ",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_star_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "payload",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `logs` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"
+    },
+    {
+      "name": "long_long_long_long_long_long_long_long_table_name",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "long_long_long_long_long_long_long_long_table_name",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "long_long_long_long_long_long_long_long_table_name",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `long_long_long_long_long_long_long_long_table_name` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "post_comments",
+      "type": "VIEW",
+      "comment": "post and comments View table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": true,
+          "default": "0",
+          "comment": "comments.id"
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled",
+          "comment": "posts.title"
+        },
+        {
+          "name": "post_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "posts.users.username"
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": true,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "comment_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "comments.users.username"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.created"
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.updated"
+        }
+      ],
+      "def": "CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))",
+      "referenced_tables": [
+        "posts",
+        "comments",
+        "users"
+      ]
+    },
+    {
+      "name": "posts",
+      "type": "BASE TABLE",
+      "comment": "エントリ",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled"
+        },
+        {
+          "name": "body",
+          "type": "text",
+          "nullable": false,
+          "comment": "本文"
+        },
+        {
+          "name": "post_type",
+          "type": "enum('public','private','draft')",
+          "nullable": false,
+          "comment": "public/private/draft"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "posts_user_id_idx",
+          "def": "KEY posts_user_id_idx (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, title) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "posts_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "posts",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, title)",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_posts_updated",
+          "def": "CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"
+        }
+      ],
+      "def": "CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'"
+    },
+    {
+      "name": "user_options",
+      "type": "BASE TABLE",
+      "comment": "User options table",
+      "columns": [
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "show_email",
+          "type": "tinyint(1)",
+          "nullable": false,
+          "default": "0"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_options_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "user_options",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'"
+    },
+    {
+      "name": "users",
+      "type": "BASE TABLE",
+      "comment": "Users table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "username",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "password",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "email",
+          "type": "varchar(355)",
+          "nullable": false,
+          "comment": "ex. user@example.com"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "email",
+          "def": "UNIQUE KEY email (email) USING BTREE",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "username",
+          "def": "UNIQUE KEY username (username) USING BTREE",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "email",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY email (email)",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "username",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY username (username)",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "users_chk_1",
+          "type": "CHECK",
+          "def": "CHECK ((char_length(`username`) \u003e 4))",
+          "table": "users"
+        }
+      ],
+      "def": "CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`),\n  CONSTRAINT `users_chk_1` CHECK ((char_length(`username`) \u003e 4))\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'"
+    }
+  ],
+  "relations": [
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_post_id",
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "post_id",
+        "user_id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (post_id) REFERENCES posts (id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "posts",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "user_options",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_one",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    }
+  ],
+  "functions": [
+    {
+      "name": "CustomerLevel",
+      "return_type": "varchar",
+      "arguments": "credit decimal",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "GetAllComments",
+      "return_type": "",
+      "arguments": "",
+      "type": "PROCEDURE"
+    }
+  ],
+  "driver": {
+    "name": "mysql",
+    "database_version": "8.4.6",
+    "meta": {
+      "dict": {
+        "Functions": "Stored procedures and functions"
+      }
+    }
+  },
+  "labels": [
+    {
+      "name": "サンプル",
+      "virtual": true
+    },
+    {
+      "name": "tbls",
+      "virtual": true
+    }
+  ]
+}

--- a/sample/hide/schema.json
+++ b/sample/hide/schema.json
@@ -1,1 +1,918 @@
-{"name":"testdb","desc":"Sample database document.","tables":[{"name":"CamelizeTable","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"CamelizeTable","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"CamelizeTable","columns":["id"]}],"def":"CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"comment_stars","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"comment_post_id","type":"bigint","nullable":false},{"name":"comment_user_id","type":"int","nullable":false},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"comment_stars_user_id_fk","def":"KEY comment_stars_user_id_fk (comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_user_id"]},{"name":"comment_stars_user_id_post_id_fk","def":"KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_post_id","comment_user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comment_stars","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"constraints":[{"name":"comment_stars_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)","table":"comment_stars","referenced_table":"users","columns":["comment_user_id"],"referenced_columns":["id"]},{"name":"comment_stars_user_id_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)","table":"comment_stars","referenced_table":"comments","columns":["comment_post_id","comment_user_id"],"referenced_columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comment_stars","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"def":"CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"comments","type":"BASE TABLE","comment":"Comments\nMulti-line\r\ntable\rcomment","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"post_id","type":"bigint","nullable":false},{"name":"user_id","type":"int","nullable":false},{"name":"comment","type":"text","nullable":false,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"post_id_desc","type":"bigint","nullable":true,"extra_def":"GENERATED ALWAYS AS (`post_id` * -(1)) VIRTUAL"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"comments_post_id_user_id_idx","def":"KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]},{"name":"comments_user_id_fk","def":"KEY comments_user_id_fk (user_id) USING BTREE","table":"comments","columns":["user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comments","columns":["id"]},{"name":"post_id","def":"UNIQUE KEY post_id (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]}],"constraints":[{"name":"comments_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (post_id) REFERENCES posts (id)","table":"comments","referenced_table":"posts","columns":["post_id"],"referenced_columns":["id"]},{"name":"comments_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"comments","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"post_id","type":"UNIQUE","def":"UNIQUE KEY post_id (post_id, user_id)","table":"comments","columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comments","columns":["id"]}],"def":"CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint GENERATED ALWAYS AS ((`post_id` * -(1))) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`),\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"},{"name":"hyphen-table","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"hyphen-column","type":"text","nullable":false},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"hyphen-table","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"hyphen-table","columns":["id"]}],"def":"CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"logs","type":"BASE TABLE","comment":"Auditログ","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"post_id","type":"bigint","nullable":true},{"name":"comment_id","type":"bigint","nullable":true},{"name":"comment_star_id","type":"bigint","nullable":true},{"name":"payload","type":"text","nullable":true},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"logs","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"logs","columns":["id"]}],"def":"CREATE TABLE `logs` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"},{"name":"long_long_long_long_long_long_long_long_table_name","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"long_long_long_long_long_long_long_long_table_name","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"long_long_long_long_long_long_long_long_table_name","columns":["id"]}],"def":"CREATE TABLE `long_long_long_long_long_long_long_long_table_name` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"post_comments","type":"VIEW","comment":"post and comments View table","columns":[{"name":"id","type":"bigint","nullable":true,"default":"0","comment":"comments.id"},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled","comment":"posts.title"},{"name":"post_user","type":"varchar(50)","nullable":true,"comment":"posts.users.username"},{"name":"comment","type":"text","nullable":true,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"comment_user","type":"varchar(50)","nullable":true,"comment":"comments.users.username"},{"name":"created","type":"datetime","nullable":true,"comment":"comments.created"},{"name":"updated","type":"datetime","nullable":true,"comment":"comments.updated"}],"def":"CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))","referenced_tables":["posts","comments","users"]},{"name":"posts","type":"BASE TABLE","comment":"Posts table","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled"},{"name":"body","type":"text","nullable":false,"comment":"post body"},{"name":"post_type","type":"enum('public','private','draft')","nullable":false,"comment":"public/private/draft"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"posts_user_id_idx","def":"KEY posts_user_id_idx (id) USING BTREE","table":"posts","columns":["id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"posts","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, title) USING BTREE","table":"posts","columns":["user_id","title"]}],"constraints":[{"name":"posts_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"posts","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"posts","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, title)","table":"posts","columns":["user_id","title"]}],"triggers":[{"name":"update_posts_updated","def":"CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"}],"def":"CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'","labels":[{"name":"green","virtual":true},{"name":"red","virtual":true},{"name":"blue","virtual":true}]},{"name":"user_options","type":"BASE TABLE","comment":"User options table","columns":[{"name":"user_id","type":"int","nullable":false},{"name":"show_email","type":"tinyint(1)","nullable":false,"default":"0"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (user_id) USING BTREE","table":"user_options","columns":["user_id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id) USING BTREE","table":"user_options","columns":["user_id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_options_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"user_options","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]}],"def":"CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'"},{"name":"users","type":"BASE TABLE","comment":"Users table","columns":[{"name":"id","type":"int","nullable":false,"extra_def":"auto_increment"},{"name":"username","type":"varchar(50)","nullable":false},{"name":"password","type":"varchar(50)","nullable":false},{"name":"email","type":"varchar(355)","nullable":false,"comment":"ex. user@example.com"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"users","columns":["id"]},{"name":"email","def":"UNIQUE KEY email (email) USING BTREE","table":"users","columns":["email"]},{"name":"username","def":"UNIQUE KEY username (username) USING BTREE","table":"users","columns":["username"]}],"constraints":[{"name":"email","type":"UNIQUE","def":"UNIQUE KEY email (email)","table":"users","columns":["email"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"users","columns":["id"]},{"name":"username","type":"UNIQUE","def":"UNIQUE KEY username (username)","table":"users","columns":["username"]},{"name":"users_chk_1","type":"CHECK","def":"CHECK ((char_length(`username`) \u003e 4))","table":"users"}],"def":"CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`),\n  CONSTRAINT `users_chk_1` CHECK ((char_length(`username`) \u003e 4))\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'"}],"relations":[{"table":"comment_stars","columns":["comment_user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)"},{"table":"comment_stars","columns":["comment_post_id","comment_user_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["post_id","user_id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"},{"table":"comments","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (post_id) REFERENCES posts (id)"},{"table":"comments","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"posts","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"user_options","columns":["user_id"],"cardinality":"zero_or_one","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"}],"functions":[{"name":"CustomerLevel","return_type":"varchar","arguments":"credit decimal","type":"FUNCTION"},{"name":"GetAllComments","return_type":"","arguments":"","type":"PROCEDURE"}],"driver":{"name":"mysql","database_version":"8.4.4","meta":{"dict":{"Functions":"Stored procedures and functions"}}}}
+{
+  "name": "testdb",
+  "desc": "Sample database document.",
+  "tables": [
+    {
+      "name": "CamelizeTable",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "comment_stars",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment_post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "comment_user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "def": "KEY comment_stars_user_id_fk (comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "def": "KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)",
+          "table": "comment_stars",
+          "referenced_table": "users",
+          "columns": [
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)",
+          "table": "comment_stars",
+          "referenced_table": "comments",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "comments",
+      "type": "BASE TABLE",
+      "comment": "Comments\nMulti-line\r\ntable\rcomment",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": false,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "post_id_desc",
+          "type": "bigint",
+          "nullable": true,
+          "extra_def": "GENERATED ALWAYS AS (`post_id` * -(1)) VIRTUAL"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comments_post_id_user_id_idx",
+          "def": "KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "def": "KEY comments_user_id_fk (user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "def": "UNIQUE KEY post_id (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comments_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (post_id) REFERENCES posts (id)",
+          "table": "comments",
+          "referenced_table": "posts",
+          "columns": [
+            "post_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "comments",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY post_id (post_id, user_id)",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint GENERATED ALWAYS AS ((`post_id` * -(1))) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`),\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"
+    },
+    {
+      "name": "hyphen-table",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "hyphen-column",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "logs",
+      "type": "BASE TABLE",
+      "comment": "Auditログ",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_star_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "payload",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `logs` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"
+    },
+    {
+      "name": "long_long_long_long_long_long_long_long_table_name",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "long_long_long_long_long_long_long_long_table_name",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "long_long_long_long_long_long_long_long_table_name",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `long_long_long_long_long_long_long_long_table_name` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "post_comments",
+      "type": "VIEW",
+      "comment": "post and comments View table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": true,
+          "default": "0",
+          "comment": "comments.id"
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled",
+          "comment": "posts.title"
+        },
+        {
+          "name": "post_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "posts.users.username"
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": true,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "comment_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "comments.users.username"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.created"
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.updated"
+        }
+      ],
+      "def": "CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))",
+      "referenced_tables": [
+        "posts",
+        "comments",
+        "users"
+      ]
+    },
+    {
+      "name": "posts",
+      "type": "BASE TABLE",
+      "comment": "Posts table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled"
+        },
+        {
+          "name": "body",
+          "type": "text",
+          "nullable": false,
+          "comment": "post body"
+        },
+        {
+          "name": "post_type",
+          "type": "enum('public','private','draft')",
+          "nullable": false,
+          "comment": "public/private/draft"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "posts_user_id_idx",
+          "def": "KEY posts_user_id_idx (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, title) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "posts_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "posts",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, title)",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_posts_updated",
+          "def": "CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"
+        }
+      ],
+      "def": "CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'",
+      "labels": [
+        {
+          "name": "green",
+          "virtual": true
+        },
+        {
+          "name": "red",
+          "virtual": true
+        },
+        {
+          "name": "blue",
+          "virtual": true
+        }
+      ]
+    },
+    {
+      "name": "user_options",
+      "type": "BASE TABLE",
+      "comment": "User options table",
+      "columns": [
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "show_email",
+          "type": "tinyint(1)",
+          "nullable": false,
+          "default": "0"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_options_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "user_options",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'"
+    },
+    {
+      "name": "users",
+      "type": "BASE TABLE",
+      "comment": "Users table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "username",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "password",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "email",
+          "type": "varchar(355)",
+          "nullable": false,
+          "comment": "ex. user@example.com"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "email",
+          "def": "UNIQUE KEY email (email) USING BTREE",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "username",
+          "def": "UNIQUE KEY username (username) USING BTREE",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "email",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY email (email)",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "username",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY username (username)",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "users_chk_1",
+          "type": "CHECK",
+          "def": "CHECK ((char_length(`username`) \u003e 4))",
+          "table": "users"
+        }
+      ],
+      "def": "CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`),\n  CONSTRAINT `users_chk_1` CHECK ((char_length(`username`) \u003e 4))\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'"
+    }
+  ],
+  "relations": [
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_post_id",
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "post_id",
+        "user_id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (post_id) REFERENCES posts (id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "posts",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "user_options",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_one",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    }
+  ],
+  "functions": [
+    {
+      "name": "CustomerLevel",
+      "return_type": "varchar",
+      "arguments": "credit decimal",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "GetAllComments",
+      "return_type": "",
+      "arguments": "",
+      "type": "PROCEDURE"
+    }
+  ],
+  "driver": {
+    "name": "mysql",
+    "database_version": "8.4.6",
+    "meta": {
+      "dict": {
+        "Functions": "Stored procedures and functions"
+      }
+    }
+  }
+}

--- a/sample/hide_not_related_column/schema.json
+++ b/sample/hide_not_related_column/schema.json
@@ -1,1 +1,1000 @@
-{"name":"testdb","desc":"Sample database document.","tables":[{"name":"CamelizeTable","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"CamelizeTable","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"CamelizeTable","columns":["id"]}],"def":"CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"comment_stars","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"comment_post_id","type":"bigint","nullable":false},{"name":"comment_user_id","type":"int","nullable":false},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"comment_stars_user_id_fk","def":"KEY comment_stars_user_id_fk (comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_user_id"]},{"name":"comment_stars_user_id_post_id_fk","def":"KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_post_id","comment_user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comment_stars","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"constraints":[{"name":"comment_stars_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)","table":"comment_stars","referenced_table":"users","columns":["comment_user_id"],"referenced_columns":["id"]},{"name":"comment_stars_user_id_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)","table":"comment_stars","referenced_table":"comments","columns":["comment_post_id","comment_user_id"],"referenced_columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comment_stars","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"def":"CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"comments","type":"BASE TABLE","comment":"Comments\nMulti-line\r\ntable\rcomment","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"post_id","type":"bigint","nullable":false},{"name":"user_id","type":"int","nullable":false},{"name":"comment","type":"text","nullable":false,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"post_id_desc","type":"bigint","nullable":true,"extra_def":"GENERATED ALWAYS AS (`post_id` * -(1)) VIRTUAL"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"comments_post_id_user_id_idx","def":"KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]},{"name":"comments_user_id_fk","def":"KEY comments_user_id_fk (user_id) USING BTREE","table":"comments","columns":["user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comments","columns":["id"]},{"name":"post_id","def":"UNIQUE KEY post_id (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]}],"constraints":[{"name":"comments_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (post_id) REFERENCES posts (id)","table":"comments","referenced_table":"posts","columns":["post_id"],"referenced_columns":["id"]},{"name":"comments_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"comments","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"post_id","type":"UNIQUE","def":"UNIQUE KEY post_id (post_id, user_id)","table":"comments","columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comments","columns":["id"]}],"def":"CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint GENERATED ALWAYS AS ((`post_id` * -(1))) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`),\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"},{"name":"hyphen-table","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"hyphen-column","type":"text","nullable":false},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"hyphen-table","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"hyphen-table","columns":["id"]}],"def":"CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"logs","type":"BASE TABLE","comment":"Auditログ","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"post_id","type":"bigint","nullable":true},{"name":"comment_id","type":"bigint","nullable":true},{"name":"comment_star_id","type":"bigint","nullable":true},{"name":"payload","type":"text","nullable":true},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"logs","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"logs","columns":["id"]}],"def":"CREATE TABLE `logs` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"},{"name":"long_long_long_long_long_long_long_long_table_name","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"long_long_long_long_long_long_long_long_table_name","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"long_long_long_long_long_long_long_long_table_name","columns":["id"]}],"def":"CREATE TABLE `long_long_long_long_long_long_long_long_table_name` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"post_comments","type":"VIEW","comment":"post and comments View table","columns":[{"name":"id","type":"bigint","nullable":true,"default":"0","comment":"comments.id"},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled","comment":"posts.title"},{"name":"post_user","type":"varchar(50)","nullable":true,"comment":"posts.users.username"},{"name":"comment","type":"text","nullable":true,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"comment_user","type":"varchar(50)","nullable":true,"comment":"comments.users.username"},{"name":"created","type":"datetime","nullable":true,"comment":"comments.created"},{"name":"updated","type":"datetime","nullable":true,"comment":"comments.updated"}],"def":"CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))","referenced_tables":["posts","comments","users"]},{"name":"posts","type":"BASE TABLE","comment":"Posts table","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled"},{"name":"body","type":"text","nullable":false,"comment":"post body"},{"name":"post_type","type":"enum('public','private','draft')","nullable":false,"comment":"public/private/draft"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"posts_user_id_idx","def":"KEY posts_user_id_idx (id) USING BTREE","table":"posts","columns":["id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"posts","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, title) USING BTREE","table":"posts","columns":["user_id","title"]}],"constraints":[{"name":"posts_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"posts","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"posts","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, title)","table":"posts","columns":["user_id","title"]}],"triggers":[{"name":"update_posts_updated","def":"CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"}],"def":"CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'","labels":[{"name":"green","virtual":true},{"name":"red","virtual":true},{"name":"blue","virtual":true}]},{"name":"user_options","type":"BASE TABLE","comment":"User options table","columns":[{"name":"user_id","type":"int","nullable":false},{"name":"show_email","type":"tinyint(1)","nullable":false,"default":"0"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (user_id) USING BTREE","table":"user_options","columns":["user_id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id) USING BTREE","table":"user_options","columns":["user_id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_options_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"user_options","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]}],"def":"CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'"},{"name":"users","type":"BASE TABLE","comment":"Users table","columns":[{"name":"id","type":"int","nullable":false,"extra_def":"auto_increment"},{"name":"username","type":"varchar(50)","nullable":false},{"name":"password","type":"varchar(50)","nullable":false,"labels":[{"name":"secure","virtual":true},{"name":"encrypted","virtual":true}]},{"name":"email","type":"varchar(355)","nullable":false,"labels":[{"name":"secure","virtual":true}],"comment":"ex. user@example.com"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"users","columns":["id"]},{"name":"email","def":"UNIQUE KEY email (email) USING BTREE","table":"users","columns":["email"]},{"name":"username","def":"UNIQUE KEY username (username) USING BTREE","table":"users","columns":["username"]}],"constraints":[{"name":"email","type":"UNIQUE","def":"UNIQUE KEY email (email)","table":"users","columns":["email"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"users","columns":["id"]},{"name":"username","type":"UNIQUE","def":"UNIQUE KEY username (username)","table":"users","columns":["username"]},{"name":"users_chk_1","type":"CHECK","def":"CHECK ((char_length(`username`) \u003e 4))","table":"users"}],"def":"CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`),\n  CONSTRAINT `users_chk_1` CHECK ((char_length(`username`) \u003e 4))\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'"}],"relations":[{"table":"comment_stars","columns":["comment_user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)"},{"table":"comment_stars","columns":["comment_post_id","comment_user_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["post_id","user_id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"},{"table":"comments","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (post_id) REFERENCES posts (id)"},{"table":"comments","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"posts","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"user_options","columns":["user_id"],"cardinality":"zero_or_one","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"logs","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"logs-\u003eusers","virtual":true},{"table":"logs","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"logs","columns":["comment_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"logs","columns":["comment_star_id"],"cardinality":"zero_or_more","parent_table":"comment_stars","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true}],"functions":[{"name":"CustomerLevel","return_type":"varchar","arguments":"credit decimal","type":"FUNCTION"},{"name":"GetAllComments","return_type":"","arguments":"","type":"PROCEDURE"}],"driver":{"name":"mysql","database_version":"8.4.4","meta":{"dict":{"Functions":"Stored procedures and functions"}}},"labels":[{"name":"sample","virtual":true},{"name":"tbls","virtual":true}]}
+{
+  "name": "testdb",
+  "desc": "Sample database document.",
+  "tables": [
+    {
+      "name": "CamelizeTable",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "comment_stars",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment_post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "comment_user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "def": "KEY comment_stars_user_id_fk (comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "def": "KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)",
+          "table": "comment_stars",
+          "referenced_table": "users",
+          "columns": [
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)",
+          "table": "comment_stars",
+          "referenced_table": "comments",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "comments",
+      "type": "BASE TABLE",
+      "comment": "Comments\nMulti-line\r\ntable\rcomment",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": false,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "post_id_desc",
+          "type": "bigint",
+          "nullable": true,
+          "extra_def": "GENERATED ALWAYS AS (`post_id` * -(1)) VIRTUAL"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comments_post_id_user_id_idx",
+          "def": "KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "def": "KEY comments_user_id_fk (user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "def": "UNIQUE KEY post_id (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comments_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (post_id) REFERENCES posts (id)",
+          "table": "comments",
+          "referenced_table": "posts",
+          "columns": [
+            "post_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "comments",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY post_id (post_id, user_id)",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint GENERATED ALWAYS AS ((`post_id` * -(1))) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`),\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"
+    },
+    {
+      "name": "hyphen-table",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "hyphen-column",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "logs",
+      "type": "BASE TABLE",
+      "comment": "Auditログ",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_star_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "payload",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `logs` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"
+    },
+    {
+      "name": "long_long_long_long_long_long_long_long_table_name",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "long_long_long_long_long_long_long_long_table_name",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "long_long_long_long_long_long_long_long_table_name",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `long_long_long_long_long_long_long_long_table_name` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "post_comments",
+      "type": "VIEW",
+      "comment": "post and comments View table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": true,
+          "default": "0",
+          "comment": "comments.id"
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled",
+          "comment": "posts.title"
+        },
+        {
+          "name": "post_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "posts.users.username"
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": true,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "comment_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "comments.users.username"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.created"
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.updated"
+        }
+      ],
+      "def": "CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))",
+      "referenced_tables": [
+        "posts",
+        "comments",
+        "users"
+      ]
+    },
+    {
+      "name": "posts",
+      "type": "BASE TABLE",
+      "comment": "Posts table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled"
+        },
+        {
+          "name": "body",
+          "type": "text",
+          "nullable": false,
+          "comment": "post body"
+        },
+        {
+          "name": "post_type",
+          "type": "enum('public','private','draft')",
+          "nullable": false,
+          "comment": "public/private/draft"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "posts_user_id_idx",
+          "def": "KEY posts_user_id_idx (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, title) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "posts_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "posts",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, title)",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_posts_updated",
+          "def": "CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"
+        }
+      ],
+      "def": "CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'",
+      "labels": [
+        {
+          "name": "green",
+          "virtual": true
+        },
+        {
+          "name": "red",
+          "virtual": true
+        },
+        {
+          "name": "blue",
+          "virtual": true
+        }
+      ]
+    },
+    {
+      "name": "user_options",
+      "type": "BASE TABLE",
+      "comment": "User options table",
+      "columns": [
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "show_email",
+          "type": "tinyint(1)",
+          "nullable": false,
+          "default": "0"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_options_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "user_options",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'"
+    },
+    {
+      "name": "users",
+      "type": "BASE TABLE",
+      "comment": "Users table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "username",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "password",
+          "type": "varchar(50)",
+          "nullable": false,
+          "labels": [
+            {
+              "name": "secure",
+              "virtual": true
+            },
+            {
+              "name": "encrypted",
+              "virtual": true
+            }
+          ]
+        },
+        {
+          "name": "email",
+          "type": "varchar(355)",
+          "nullable": false,
+          "labels": [
+            {
+              "name": "secure",
+              "virtual": true
+            }
+          ],
+          "comment": "ex. user@example.com"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "email",
+          "def": "UNIQUE KEY email (email) USING BTREE",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "username",
+          "def": "UNIQUE KEY username (username) USING BTREE",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "email",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY email (email)",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "username",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY username (username)",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "users_chk_1",
+          "type": "CHECK",
+          "def": "CHECK ((char_length(`username`) \u003e 4))",
+          "table": "users"
+        }
+      ],
+      "def": "CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`),\n  CONSTRAINT `users_chk_1` CHECK ((char_length(`username`) \u003e 4))\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'"
+    }
+  ],
+  "relations": [
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_post_id",
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "post_id",
+        "user_id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (post_id) REFERENCES posts (id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "posts",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "user_options",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_one",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "logs-\u003eusers",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "comment_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "comment_star_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comment_stars",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    }
+  ],
+  "functions": [
+    {
+      "name": "CustomerLevel",
+      "return_type": "varchar",
+      "arguments": "credit decimal",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "GetAllComments",
+      "return_type": "",
+      "arguments": "",
+      "type": "PROCEDURE"
+    }
+  ],
+  "driver": {
+    "name": "mysql",
+    "database_version": "8.4.6",
+    "meta": {
+      "dict": {
+        "Functions": "Stored procedures and functions"
+      }
+    }
+  },
+  "labels": [
+    {
+      "name": "sample",
+      "virtual": true
+    },
+    {
+      "name": "tbls",
+      "virtual": true
+    }
+  ]
+}

--- a/sample/mariadb/schema.json
+++ b/sample/mariadb/schema.json
@@ -1,1 +1,1025 @@
-{"name":"testdb","desc":"Sample database document.","tables":[{"name":"CamelizeTable","type":"BASE TABLE","columns":[{"name":"id","type":"bigint(20)","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"CamelizeTable","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"CamelizeTable","columns":["id"]}],"def":"CREATE TABLE `CamelizeTable` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"},{"name":"comments","type":"BASE TABLE","comment":"Comments\nMulti-line\r\ntable\rcomment","columns":[{"name":"id","type":"bigint(20)","nullable":false,"extra_def":"auto_increment"},{"name":"post_id","type":"bigint(20)","nullable":false},{"name":"user_id","type":"int(11)","nullable":false},{"name":"comment","type":"text","nullable":false,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"post_id_desc","type":"bigint(20)","nullable":true,"default":"NULL","extra_def":"GENERATED ALWAYS AS `post_id` * -1 VIRTUAL"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true,"default":"NULL"}],"indexes":[{"name":"comments_post_id_user_id_idx","def":"KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]},{"name":"comments_user_id_fk","def":"KEY comments_user_id_fk (user_id) USING BTREE","table":"comments","columns":["user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comments","columns":["id"]},{"name":"post_id","def":"UNIQUE KEY post_id (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]}],"constraints":[{"name":"comments_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (post_id) REFERENCES posts (id)","table":"comments","referenced_table":"posts","columns":["post_id"],"referenced_columns":["id"]},{"name":"comments_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"comments","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"post_id","type":"UNIQUE","def":"UNIQUE KEY post_id (post_id, user_id)","table":"comments","columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comments","columns":["id"]}],"def":"CREATE TABLE `comments` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `post_id` bigint(20) NOT NULL,\n  `user_id` int(11) NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint(20) GENERATED ALWAYS AS (`post_id` * -1) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`) USING HASH,\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"},{"name":"comment_stars","type":"BASE TABLE","columns":[{"name":"id","type":"bigint(20)","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int(11)","nullable":false},{"name":"comment_post_id","type":"bigint(20)","nullable":false},{"name":"comment_user_id","type":"int(11)","nullable":false},{"name":"created","type":"timestamp","nullable":false,"default":"current_timestamp()","extra_def":"on update current_timestamp()"},{"name":"updated","type":"timestamp","nullable":false,"default":"'0000-00-00 00:00:00'"}],"indexes":[{"name":"comment_stars_user_id_fk","def":"KEY comment_stars_user_id_fk (comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_user_id"]},{"name":"comment_stars_user_id_post_id_fk","def":"KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_post_id","comment_user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comment_stars","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"constraints":[{"name":"comment_stars_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)","table":"comment_stars","referenced_table":"users","columns":["comment_user_id"],"referenced_columns":["id"]},{"name":"comment_stars_user_id_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)","table":"comment_stars","referenced_table":"comments","columns":["comment_post_id","comment_user_id"],"referenced_columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comment_stars","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"def":"CREATE TABLE `comment_stars` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `user_id` int(11) NOT NULL,\n  `comment_post_id` bigint(20) NOT NULL,\n  `comment_user_id` int(11) NOT NULL,\n  `created` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),\n  `updated` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"},{"name":"hyphen-table","type":"BASE TABLE","columns":[{"name":"id","type":"bigint(20)","nullable":false,"extra_def":"auto_increment"},{"name":"hyphen-column","type":"text","nullable":false},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"hyphen-table","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"hyphen-table","columns":["id"]}],"def":"CREATE TABLE `hyphen-table` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"},{"name":"logs","type":"BASE TABLE","comment":"Auditログ","columns":[{"name":"id","type":"bigint(20)","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int(11)","nullable":false},{"name":"post_id","type":"bigint(20)","nullable":true,"default":"NULL"},{"name":"comment_id","type":"bigint(20)","nullable":true,"default":"NULL"},{"name":"comment_star_id","type":"bigint(20)","nullable":true,"default":"NULL"},{"name":"payload","type":"text","nullable":true,"default":"NULL"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"logs","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"logs","columns":["id"]}],"def":"CREATE TABLE `logs` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `user_id` int(11) NOT NULL,\n  `post_id` bigint(20) DEFAULT NULL,\n  `comment_id` bigint(20) DEFAULT NULL,\n  `comment_star_id` bigint(20) DEFAULT NULL,\n  `payload` text DEFAULT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='Auditログ'"},{"name":"posts","type":"BASE TABLE","comment":"Posts table","columns":[{"name":"id","type":"bigint(20)","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int(11)","nullable":false},{"name":"title","type":"varchar(255)","nullable":false,"default":"'Untitled'"},{"name":"body","type":"text","nullable":false,"comment":"post body"},{"name":"post_type","type":"enum('public','private','draft')","nullable":false,"comment":"public/private/draft"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true,"default":"NULL"}],"indexes":[{"name":"posts_user_id_idx","def":"KEY posts_user_id_idx (id) USING BTREE","table":"posts","columns":["id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"posts","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, title) USING BTREE","table":"posts","columns":["user_id","title"]}],"constraints":[{"name":"posts_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"posts","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"posts","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, title)","table":"posts","columns":["user_id","title"]}],"triggers":[{"name":"update_posts_updated","def":"CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"}],"def":"CREATE TABLE `posts` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `user_id` int(11) NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='Posts table'","labels":[{"name":"green","virtual":true},{"name":"red","virtual":true},{"name":"blue","virtual":true}]},{"name":"post_comments","type":"VIEW","comment":"post and comments View table","columns":[{"name":"id","type":"bigint(20)","nullable":true,"default":"0","comment":"comments.id"},{"name":"title","type":"varchar(255)","nullable":false,"default":"'Untitled'","comment":"posts.title"},{"name":"post_user","type":"varchar(50)","nullable":true,"comment":"posts.users.username"},{"name":"comment","type":"text","nullable":true,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"comment_user","type":"varchar(50)","nullable":true,"comment":"comments.users.username"},{"name":"created","type":"datetime","nullable":true,"comment":"comments.created"},{"name":"updated","type":"datetime","nullable":true,"default":"NULL","comment":"comments.updated"}],"def":"CREATE VIEW post_comments AS ((select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on(`p`.`id` = `c`.`post_id`)) left join `testdb`.`users` `u` on(`u`.`id` = `p`.`user_id`)) left join `testdb`.`users` `u2` on(`u2`.`id` = `c`.`user_id`))))","referenced_tables":["posts","comments","users"]},{"name":"same_name_constraints","type":"BASE TABLE","columns":[{"name":"id","type":"bigint(20)","nullable":true,"default":"NULL"},{"name":"user_id","type":"int(11)","nullable":false}],"indexes":[{"name":"same_name","def":"UNIQUE KEY same_name (user_id, id) USING BTREE","table":"same_name_constraints","columns":["user_id","id"]}],"constraints":[{"name":"same_name","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"same_name_constraints","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"same_name","type":"UNIQUE","def":"UNIQUE KEY same_name (user_id, id)","table":"same_name_constraints","columns":["user_id","id"]}],"def":"CREATE TABLE `same_name_constraints` (\n  `id` bigint(20) DEFAULT NULL,\n  `user_id` int(11) NOT NULL,\n  UNIQUE KEY `same_name` (`user_id`,`id`),\n  CONSTRAINT `same_name` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"},{"name":"users","type":"BASE TABLE","comment":"Users table","columns":[{"name":"id","type":"int(11)","nullable":false,"extra_def":"auto_increment"},{"name":"username","type":"varchar(50)","nullable":false},{"name":"password","type":"varchar(50)","nullable":false,"labels":[{"name":"secure","virtual":true},{"name":"encrypted","virtual":true}]},{"name":"email","type":"varchar(355)","nullable":false,"labels":[{"name":"secure","virtual":true}],"comment":"ex. user@example.com"},{"name":"created","type":"timestamp","nullable":false,"default":"current_timestamp()","extra_def":"on update current_timestamp()"},{"name":"updated","type":"timestamp","nullable":false,"default":"'0000-00-00 00:00:00'"}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"users","columns":["id"]},{"name":"email","def":"UNIQUE KEY email (email) USING BTREE","table":"users","columns":["email"]},{"name":"username","def":"UNIQUE KEY username (username) USING BTREE","table":"users","columns":["username"]}],"constraints":[{"name":"email","type":"UNIQUE","def":"UNIQUE KEY email (email)","table":"users","columns":["email"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"users","columns":["id"]},{"name":"username","type":"UNIQUE","def":"UNIQUE KEY username (username)","table":"users","columns":["username"]}],"def":"CREATE TABLE `users` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),\n  `updated` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`)\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='Users table'"},{"name":"user_options","type":"BASE TABLE","comment":"User options table","columns":[{"name":"user_id","type":"int(11)","nullable":false},{"name":"show_email","type":"tinyint(1)","nullable":false,"default":"0"},{"name":"created","type":"timestamp","nullable":false,"default":"current_timestamp()","extra_def":"on update current_timestamp()"},{"name":"updated","type":"timestamp","nullable":false,"default":"'0000-00-00 00:00:00'"}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (user_id) USING BTREE","table":"user_options","columns":["user_id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id) USING BTREE","table":"user_options","columns":["user_id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_options_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"user_options","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]}],"def":"CREATE TABLE `user_options` (\n  `user_id` int(11) NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT 0,\n  `created` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),\n  `updated` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='User options table'"}],"relations":[{"table":"comments","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (post_id) REFERENCES posts (id)"},{"table":"comments","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"comment_stars","columns":["comment_user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)"},{"table":"comment_stars","columns":["comment_post_id","comment_user_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["post_id","user_id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"},{"table":"posts","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"same_name_constraints","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"user_options","columns":["user_id"],"cardinality":"zero_or_one","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"logs","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"logs-\u003eusers","virtual":true},{"table":"logs","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"logs","columns":["comment_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"logs","columns":["comment_star_id"],"cardinality":"exactly_one","parent_table":"comment_stars","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"Additional Relation","virtual":true}],"driver":{"name":"mariadb","database_version":"10.5.27-MariaDB-ubu2004","meta":{"dict":{"Functions":"Stored procedures and functions"}}},"labels":[{"name":"sample","virtual":true},{"name":"tbls","virtual":true}]}
+{
+  "name": "testdb",
+  "desc": "Sample database document.",
+  "tables": [
+    {
+      "name": "CamelizeTable",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint(20)",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `CamelizeTable` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"
+    },
+    {
+      "name": "comments",
+      "type": "BASE TABLE",
+      "comment": "Comments\nMulti-line\r\ntable\rcomment",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint(20)",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "post_id",
+          "type": "bigint(20)",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "int(11)",
+          "nullable": false
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": false,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "post_id_desc",
+          "type": "bigint(20)",
+          "nullable": true,
+          "default": "NULL",
+          "extra_def": "GENERATED ALWAYS AS `post_id` * -1 VIRTUAL"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true,
+          "default": "NULL"
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comments_post_id_user_id_idx",
+          "def": "KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "def": "KEY comments_user_id_fk (user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "def": "UNIQUE KEY post_id (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comments_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (post_id) REFERENCES posts (id)",
+          "table": "comments",
+          "referenced_table": "posts",
+          "columns": [
+            "post_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "comments",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY post_id (post_id, user_id)",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comments` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `post_id` bigint(20) NOT NULL,\n  `user_id` int(11) NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint(20) GENERATED ALWAYS AS (`post_id` * -1) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`) USING HASH,\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"
+    },
+    {
+      "name": "comment_stars",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint(20)",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int(11)",
+          "nullable": false
+        },
+        {
+          "name": "comment_post_id",
+          "type": "bigint(20)",
+          "nullable": false
+        },
+        {
+          "name": "comment_user_id",
+          "type": "int(11)",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false,
+          "default": "current_timestamp()",
+          "extra_def": "on update current_timestamp()"
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": false,
+          "default": "'0000-00-00 00:00:00'"
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "def": "KEY comment_stars_user_id_fk (comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "def": "KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)",
+          "table": "comment_stars",
+          "referenced_table": "users",
+          "columns": [
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)",
+          "table": "comment_stars",
+          "referenced_table": "comments",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comment_stars` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `user_id` int(11) NOT NULL,\n  `comment_post_id` bigint(20) NOT NULL,\n  `comment_user_id` int(11) NOT NULL,\n  `created` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),\n  `updated` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"
+    },
+    {
+      "name": "hyphen-table",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint(20)",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "hyphen-column",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `hyphen-table` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"
+    },
+    {
+      "name": "logs",
+      "type": "BASE TABLE",
+      "comment": "Auditログ",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint(20)",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int(11)",
+          "nullable": false
+        },
+        {
+          "name": "post_id",
+          "type": "bigint(20)",
+          "nullable": true,
+          "default": "NULL"
+        },
+        {
+          "name": "comment_id",
+          "type": "bigint(20)",
+          "nullable": true,
+          "default": "NULL"
+        },
+        {
+          "name": "comment_star_id",
+          "type": "bigint(20)",
+          "nullable": true,
+          "default": "NULL"
+        },
+        {
+          "name": "payload",
+          "type": "text",
+          "nullable": true,
+          "default": "NULL"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `logs` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `user_id` int(11) NOT NULL,\n  `post_id` bigint(20) DEFAULT NULL,\n  `comment_id` bigint(20) DEFAULT NULL,\n  `comment_star_id` bigint(20) DEFAULT NULL,\n  `payload` text DEFAULT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='Auditログ'"
+    },
+    {
+      "name": "posts",
+      "type": "BASE TABLE",
+      "comment": "Posts table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint(20)",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int(11)",
+          "nullable": false
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "'Untitled'"
+        },
+        {
+          "name": "body",
+          "type": "text",
+          "nullable": false,
+          "comment": "post body"
+        },
+        {
+          "name": "post_type",
+          "type": "enum('public','private','draft')",
+          "nullable": false,
+          "comment": "public/private/draft"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true,
+          "default": "NULL"
+        }
+      ],
+      "indexes": [
+        {
+          "name": "posts_user_id_idx",
+          "def": "KEY posts_user_id_idx (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, title) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "posts_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "posts",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, title)",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_posts_updated",
+          "def": "CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"
+        }
+      ],
+      "def": "CREATE TABLE `posts` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `user_id` int(11) NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='Posts table'",
+      "labels": [
+        {
+          "name": "green",
+          "virtual": true
+        },
+        {
+          "name": "red",
+          "virtual": true
+        },
+        {
+          "name": "blue",
+          "virtual": true
+        }
+      ]
+    },
+    {
+      "name": "post_comments",
+      "type": "VIEW",
+      "comment": "post and comments View table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint(20)",
+          "nullable": true,
+          "default": "0",
+          "comment": "comments.id"
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "'Untitled'",
+          "comment": "posts.title"
+        },
+        {
+          "name": "post_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "posts.users.username"
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": true,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "comment_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "comments.users.username"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.created"
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true,
+          "default": "NULL",
+          "comment": "comments.updated"
+        }
+      ],
+      "def": "CREATE VIEW post_comments AS ((select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on(`p`.`id` = `c`.`post_id`)) left join `testdb`.`users` `u` on(`u`.`id` = `p`.`user_id`)) left join `testdb`.`users` `u2` on(`u2`.`id` = `c`.`user_id`))))",
+      "referenced_tables": [
+        "posts",
+        "comments",
+        "users"
+      ]
+    },
+    {
+      "name": "same_name_constraints",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint(20)",
+          "nullable": true,
+          "default": "NULL"
+        },
+        {
+          "name": "user_id",
+          "type": "int(11)",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "same_name",
+          "def": "UNIQUE KEY same_name (user_id, id) USING BTREE",
+          "table": "same_name_constraints",
+          "columns": [
+            "user_id",
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "same_name",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "same_name_constraints",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "same_name",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY same_name (user_id, id)",
+          "table": "same_name_constraints",
+          "columns": [
+            "user_id",
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `same_name_constraints` (\n  `id` bigint(20) DEFAULT NULL,\n  `user_id` int(11) NOT NULL,\n  UNIQUE KEY `same_name` (`user_id`,`id`),\n  CONSTRAINT `same_name` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"
+    },
+    {
+      "name": "users",
+      "type": "BASE TABLE",
+      "comment": "Users table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int(11)",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "username",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "password",
+          "type": "varchar(50)",
+          "nullable": false,
+          "labels": [
+            {
+              "name": "secure",
+              "virtual": true
+            },
+            {
+              "name": "encrypted",
+              "virtual": true
+            }
+          ]
+        },
+        {
+          "name": "email",
+          "type": "varchar(355)",
+          "nullable": false,
+          "labels": [
+            {
+              "name": "secure",
+              "virtual": true
+            }
+          ],
+          "comment": "ex. user@example.com"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false,
+          "default": "current_timestamp()",
+          "extra_def": "on update current_timestamp()"
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": false,
+          "default": "'0000-00-00 00:00:00'"
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "email",
+          "def": "UNIQUE KEY email (email) USING BTREE",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "username",
+          "def": "UNIQUE KEY username (username) USING BTREE",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "email",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY email (email)",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "username",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY username (username)",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `users` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),\n  `updated` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`)\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='Users table'"
+    },
+    {
+      "name": "user_options",
+      "type": "BASE TABLE",
+      "comment": "User options table",
+      "columns": [
+        {
+          "name": "user_id",
+          "type": "int(11)",
+          "nullable": false
+        },
+        {
+          "name": "show_email",
+          "type": "tinyint(1)",
+          "nullable": false,
+          "default": "0"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false,
+          "default": "current_timestamp()",
+          "extra_def": "on update current_timestamp()"
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": false,
+          "default": "'0000-00-00 00:00:00'"
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_options_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "user_options",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `user_options` (\n  `user_id` int(11) NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT 0,\n  `created` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),\n  `updated` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci COMMENT='User options table'"
+    }
+  ],
+  "relations": [
+    {
+      "table": "comments",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (post_id) REFERENCES posts (id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_post_id",
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "post_id",
+        "user_id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"
+    },
+    {
+      "table": "posts",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "same_name_constraints",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "user_options",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_one",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "logs-\u003eusers",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "comment_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "comment_star_id"
+      ],
+      "cardinality": "exactly_one",
+      "parent_table": "comment_stars",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "Additional Relation",
+      "virtual": true
+    }
+  ],
+  "driver": {
+    "name": "mariadb",
+    "database_version": "10.5.29-MariaDB-ubu2004",
+    "meta": {
+      "dict": {
+        "Functions": "Stored procedures and functions"
+      }
+    }
+  },
+  "labels": [
+    {
+      "name": "sample",
+      "virtual": true
+    },
+    {
+      "name": "tbls",
+      "virtual": true
+    }
+  ]
+}

--- a/sample/mermaid/schema.json
+++ b/sample/mermaid/schema.json
@@ -1,1 +1,1000 @@
-{"name":"testdb","desc":"Sample database document.","tables":[{"name":"CamelizeTable","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"CamelizeTable","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"CamelizeTable","columns":["id"]}],"def":"CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"comment_stars","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"comment_post_id","type":"bigint","nullable":false},{"name":"comment_user_id","type":"int","nullable":false},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"comment_stars_user_id_fk","def":"KEY comment_stars_user_id_fk (comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_user_id"]},{"name":"comment_stars_user_id_post_id_fk","def":"KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_post_id","comment_user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comment_stars","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"constraints":[{"name":"comment_stars_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)","table":"comment_stars","referenced_table":"users","columns":["comment_user_id"],"referenced_columns":["id"]},{"name":"comment_stars_user_id_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)","table":"comment_stars","referenced_table":"comments","columns":["comment_post_id","comment_user_id"],"referenced_columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comment_stars","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"def":"CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"comments","type":"BASE TABLE","comment":"Comments\nMulti-line\r\ntable\rcomment","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"post_id","type":"bigint","nullable":false},{"name":"user_id","type":"int","nullable":false},{"name":"comment","type":"text","nullable":false,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"post_id_desc","type":"bigint","nullable":true,"extra_def":"GENERATED ALWAYS AS (`post_id` * -(1)) VIRTUAL"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"comments_post_id_user_id_idx","def":"KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]},{"name":"comments_user_id_fk","def":"KEY comments_user_id_fk (user_id) USING BTREE","table":"comments","columns":["user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comments","columns":["id"]},{"name":"post_id","def":"UNIQUE KEY post_id (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]}],"constraints":[{"name":"comments_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (post_id) REFERENCES posts (id)","table":"comments","referenced_table":"posts","columns":["post_id"],"referenced_columns":["id"]},{"name":"comments_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"comments","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"post_id","type":"UNIQUE","def":"UNIQUE KEY post_id (post_id, user_id)","table":"comments","columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comments","columns":["id"]}],"def":"CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint GENERATED ALWAYS AS ((`post_id` * -(1))) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`),\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"},{"name":"hyphen-table","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"hyphen-column","type":"text","nullable":false},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"hyphen-table","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"hyphen-table","columns":["id"]}],"def":"CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"logs","type":"BASE TABLE","comment":"Auditログ","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"post_id","type":"bigint","nullable":true},{"name":"comment_id","type":"bigint","nullable":true},{"name":"comment_star_id","type":"bigint","nullable":true},{"name":"payload","type":"text","nullable":true},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"logs","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"logs","columns":["id"]}],"def":"CREATE TABLE `logs` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"},{"name":"long_long_long_long_long_long_long_long_table_name","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"long_long_long_long_long_long_long_long_table_name","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"long_long_long_long_long_long_long_long_table_name","columns":["id"]}],"def":"CREATE TABLE `long_long_long_long_long_long_long_long_table_name` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"post_comments","type":"VIEW","comment":"post and comments View table","columns":[{"name":"id","type":"bigint","nullable":true,"default":"0","comment":"comments.id"},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled","comment":"posts.title"},{"name":"post_user","type":"varchar(50)","nullable":true,"comment":"posts.users.username"},{"name":"comment","type":"text","nullable":true,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"comment_user","type":"varchar(50)","nullable":true,"comment":"comments.users.username"},{"name":"created","type":"datetime","nullable":true,"comment":"comments.created"},{"name":"updated","type":"datetime","nullable":true,"comment":"comments.updated"}],"def":"CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))","referenced_tables":["posts","comments","users"]},{"name":"posts","type":"BASE TABLE","comment":"Posts table","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled"},{"name":"body","type":"text","nullable":false,"comment":"post body"},{"name":"post_type","type":"enum('public','private','draft')","nullable":false,"comment":"public/private/draft"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"posts_user_id_idx","def":"KEY posts_user_id_idx (id) USING BTREE","table":"posts","columns":["id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"posts","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, title) USING BTREE","table":"posts","columns":["user_id","title"]}],"constraints":[{"name":"posts_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"posts","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"posts","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, title)","table":"posts","columns":["user_id","title"]}],"triggers":[{"name":"update_posts_updated","def":"CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"}],"def":"CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'","labels":[{"name":"green","virtual":true},{"name":"red","virtual":true},{"name":"blue","virtual":true}]},{"name":"user_options","type":"BASE TABLE","comment":"User options table","columns":[{"name":"user_id","type":"int","nullable":false},{"name":"show_email","type":"tinyint(1)","nullable":false,"default":"0"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (user_id) USING BTREE","table":"user_options","columns":["user_id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id) USING BTREE","table":"user_options","columns":["user_id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_options_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"user_options","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]}],"def":"CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'"},{"name":"users","type":"BASE TABLE","comment":"Users table","columns":[{"name":"id","type":"int","nullable":false,"extra_def":"auto_increment"},{"name":"username","type":"varchar(50)","nullable":false},{"name":"password","type":"varchar(50)","nullable":false,"labels":[{"name":"secure","virtual":true},{"name":"encrypted","virtual":true}]},{"name":"email","type":"varchar(355)","nullable":false,"labels":[{"name":"secure","virtual":true}],"comment":"ex. user@example.com"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"users","columns":["id"]},{"name":"email","def":"UNIQUE KEY email (email) USING BTREE","table":"users","columns":["email"]},{"name":"username","def":"UNIQUE KEY username (username) USING BTREE","table":"users","columns":["username"]}],"constraints":[{"name":"email","type":"UNIQUE","def":"UNIQUE KEY email (email)","table":"users","columns":["email"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"users","columns":["id"]},{"name":"username","type":"UNIQUE","def":"UNIQUE KEY username (username)","table":"users","columns":["username"]},{"name":"users_chk_1","type":"CHECK","def":"CHECK ((char_length(`username`) \u003e 4))","table":"users"}],"def":"CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`),\n  CONSTRAINT `users_chk_1` CHECK ((char_length(`username`) \u003e 4))\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'"}],"relations":[{"table":"comment_stars","columns":["comment_user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)"},{"table":"comment_stars","columns":["comment_post_id","comment_user_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["post_id","user_id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"},{"table":"comments","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (post_id) REFERENCES posts (id)"},{"table":"comments","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"posts","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"user_options","columns":["user_id"],"cardinality":"zero_or_one","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"logs","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"logs-\u003eusers","virtual":true},{"table":"logs","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"logs","columns":["comment_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"logs","columns":["comment_star_id"],"cardinality":"exactly_one","parent_table":"comment_stars","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"Additional Relation","virtual":true}],"functions":[{"name":"CustomerLevel","return_type":"varchar","arguments":"credit decimal","type":"FUNCTION"},{"name":"GetAllComments","return_type":"","arguments":"","type":"PROCEDURE"}],"driver":{"name":"mysql","database_version":"8.4.4","meta":{"dict":{"Functions":"Stored procedures and functions"}}},"labels":[{"name":"sample","virtual":true},{"name":"tbls","virtual":true}]}
+{
+  "name": "testdb",
+  "desc": "Sample database document.",
+  "tables": [
+    {
+      "name": "CamelizeTable",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "comment_stars",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment_post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "comment_user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "def": "KEY comment_stars_user_id_fk (comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "def": "KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)",
+          "table": "comment_stars",
+          "referenced_table": "users",
+          "columns": [
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)",
+          "table": "comment_stars",
+          "referenced_table": "comments",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "comments",
+      "type": "BASE TABLE",
+      "comment": "Comments\nMulti-line\r\ntable\rcomment",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": false,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "post_id_desc",
+          "type": "bigint",
+          "nullable": true,
+          "extra_def": "GENERATED ALWAYS AS (`post_id` * -(1)) VIRTUAL"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comments_post_id_user_id_idx",
+          "def": "KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "def": "KEY comments_user_id_fk (user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "def": "UNIQUE KEY post_id (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comments_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (post_id) REFERENCES posts (id)",
+          "table": "comments",
+          "referenced_table": "posts",
+          "columns": [
+            "post_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "comments",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY post_id (post_id, user_id)",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint GENERATED ALWAYS AS ((`post_id` * -(1))) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`),\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"
+    },
+    {
+      "name": "hyphen-table",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "hyphen-column",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "logs",
+      "type": "BASE TABLE",
+      "comment": "Auditログ",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_star_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "payload",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `logs` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"
+    },
+    {
+      "name": "long_long_long_long_long_long_long_long_table_name",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "long_long_long_long_long_long_long_long_table_name",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "long_long_long_long_long_long_long_long_table_name",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `long_long_long_long_long_long_long_long_table_name` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "post_comments",
+      "type": "VIEW",
+      "comment": "post and comments View table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": true,
+          "default": "0",
+          "comment": "comments.id"
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled",
+          "comment": "posts.title"
+        },
+        {
+          "name": "post_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "posts.users.username"
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": true,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "comment_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "comments.users.username"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.created"
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.updated"
+        }
+      ],
+      "def": "CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))",
+      "referenced_tables": [
+        "posts",
+        "comments",
+        "users"
+      ]
+    },
+    {
+      "name": "posts",
+      "type": "BASE TABLE",
+      "comment": "Posts table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled"
+        },
+        {
+          "name": "body",
+          "type": "text",
+          "nullable": false,
+          "comment": "post body"
+        },
+        {
+          "name": "post_type",
+          "type": "enum('public','private','draft')",
+          "nullable": false,
+          "comment": "public/private/draft"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "posts_user_id_idx",
+          "def": "KEY posts_user_id_idx (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, title) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "posts_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "posts",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, title)",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_posts_updated",
+          "def": "CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"
+        }
+      ],
+      "def": "CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'",
+      "labels": [
+        {
+          "name": "green",
+          "virtual": true
+        },
+        {
+          "name": "red",
+          "virtual": true
+        },
+        {
+          "name": "blue",
+          "virtual": true
+        }
+      ]
+    },
+    {
+      "name": "user_options",
+      "type": "BASE TABLE",
+      "comment": "User options table",
+      "columns": [
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "show_email",
+          "type": "tinyint(1)",
+          "nullable": false,
+          "default": "0"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_options_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "user_options",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'"
+    },
+    {
+      "name": "users",
+      "type": "BASE TABLE",
+      "comment": "Users table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "username",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "password",
+          "type": "varchar(50)",
+          "nullable": false,
+          "labels": [
+            {
+              "name": "secure",
+              "virtual": true
+            },
+            {
+              "name": "encrypted",
+              "virtual": true
+            }
+          ]
+        },
+        {
+          "name": "email",
+          "type": "varchar(355)",
+          "nullable": false,
+          "labels": [
+            {
+              "name": "secure",
+              "virtual": true
+            }
+          ],
+          "comment": "ex. user@example.com"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "email",
+          "def": "UNIQUE KEY email (email) USING BTREE",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "username",
+          "def": "UNIQUE KEY username (username) USING BTREE",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "email",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY email (email)",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "username",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY username (username)",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "users_chk_1",
+          "type": "CHECK",
+          "def": "CHECK ((char_length(`username`) \u003e 4))",
+          "table": "users"
+        }
+      ],
+      "def": "CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`),\n  CONSTRAINT `users_chk_1` CHECK ((char_length(`username`) \u003e 4))\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'"
+    }
+  ],
+  "relations": [
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_post_id",
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "post_id",
+        "user_id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (post_id) REFERENCES posts (id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "posts",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "user_options",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_one",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "logs-\u003eusers",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "comment_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "comment_star_id"
+      ],
+      "cardinality": "exactly_one",
+      "parent_table": "comment_stars",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "Additional Relation",
+      "virtual": true
+    }
+  ],
+  "functions": [
+    {
+      "name": "CustomerLevel",
+      "return_type": "varchar",
+      "arguments": "credit decimal",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "GetAllComments",
+      "return_type": "",
+      "arguments": "",
+      "type": "PROCEDURE"
+    }
+  ],
+  "driver": {
+    "name": "mysql",
+    "database_version": "8.4.6",
+    "meta": {
+      "dict": {
+        "Functions": "Stored procedures and functions"
+      }
+    }
+  },
+  "labels": [
+    {
+      "name": "sample",
+      "virtual": true
+    },
+    {
+      "name": "tbls",
+      "virtual": true
+    }
+  ]
+}

--- a/sample/mongo/schema.json
+++ b/sample/mongo/schema.json
@@ -1,1 +1,65 @@
-{"tables":[{"name":"test.restaurants","type":"collection","comment":"Count of documents is 149","columns":[{"name":"_id","type":"objectId","nullable":false},{"name":"address","type":"document","nullable":false},{"name":"borough","type":"string","nullable":false},{"name":"cuisine","type":"string","nullable":false},{"name":"grades","type":"array","nullable":false},{"name":"name","type":"string","nullable":false},{"name":"restaurant_id","type":"string","nullable":false}],"indexes":[{"name":"_id_","def":"{\"_id\": {\"$numberInt\":\"1\"}}","table":null,"columns":null,"comment":"Non-unique, Version 2"}]}],"driver":{"name":"mongodb","meta":{"dict":{"Column":"Attribute","Columns":"Attributes","Indexes":"Indexes"}}}}
+{
+  "tables": [
+    {
+      "name": "test.restaurants",
+      "type": "collection",
+      "comment": "Count of documents is 149",
+      "columns": [
+        {
+          "name": "_id",
+          "type": "objectId",
+          "nullable": false
+        },
+        {
+          "name": "address",
+          "type": "document",
+          "nullable": false
+        },
+        {
+          "name": "borough",
+          "type": "string",
+          "nullable": false
+        },
+        {
+          "name": "cuisine",
+          "type": "string",
+          "nullable": false
+        },
+        {
+          "name": "grades",
+          "type": "array",
+          "nullable": false
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "nullable": false
+        },
+        {
+          "name": "restaurant_id",
+          "type": "string",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "_id_",
+          "def": "{\"_id\": {\"$numberInt\":\"1\"}}",
+          "table": null,
+          "columns": null,
+          "comment": "Non-unique, Version 2"
+        }
+      ]
+    }
+  ],
+  "driver": {
+    "name": "mongodb",
+    "meta": {
+      "dict": {
+        "Column": "Attribute",
+        "Columns": "Attributes",
+        "Indexes": "Indexes"
+      }
+    }
+  }
+}

--- a/sample/mssql/schema.json
+++ b/sample/mssql/schema.json
@@ -1,1 +1,1050 @@
-{"name":"testdb","desc":"Sample database document.","tables":[{"name":"users","type":"BASIC TABLE","comment":"Users table","columns":[{"name":"id","type":"int","nullable":false},{"name":"username","type":"varchar(50)","nullable":false},{"name":"password","type":"varchar(50)","nullable":false,"comment":"long long long long long long long long long long long long long long long long long long long long long description"},{"name":"email","type":"varchar(355)","nullable":false,"comment":"ex. user@example.com"},{"name":"created","type":"date","nullable":false},{"name":"updated","type":"date","nullable":true}],"indexes":[{"name":"PK__users_*","def":"CLUSTERED, unique, part of a PRIMARY KEY constraint, [ id ]","table":"users","columns":["id"]},{"name":"UQ__users_*","def":"NONCLUSTERED, unique, part of a UNIQUE constraint, [ email ]","table":"users","columns":["email"]},{"name":"UQ__users_*","def":"NONCLUSTERED, unique, part of a UNIQUE constraint, [ username ]","table":"users","columns":["username"]}],"constraints":[{"name":"PK__users_*","type":"PRIMARY KEY","def":"CLUSTERED, unique, part of a PRIMARY KEY constraint, [ id ]","table":"users","columns":["id"]},{"name":"UQ__users_*","type":"UNIQUE","def":"NONCLUSTERED, unique, part of a UNIQUE constraint, [ email ]","table":"users","columns":["email"]},{"name":"UQ__users_*","type":"UNIQUE","def":"NONCLUSTERED, unique, part of a UNIQUE constraint, [ username ]","table":"users","columns":["username"]},{"name":"CK__users__username_*","type":"CHECK","def":"CHECK(len([username])\u003e(4))","table":"users"}],"triggers":[{"name":"update_users_updated","def":"CREATE TRIGGER update_users_updated\nON users\nAFTER UPDATE\nAS\nBEGIN\n  UPDATE users SET updated = GETDATE()\n  WHERE id = ( SELECT id FROM deleted)\nEND;"}]},{"name":"user_options","type":"BASIC TABLE","comment":"User options table","columns":[{"name":"user_id","type":"int","nullable":false},{"name":"show_email","type":"bit","nullable":false,"default":"((0))"},{"name":"created","type":"date","nullable":false},{"name":"updated","type":"date","nullable":true}],"indexes":[{"name":"PK__user_opt_*","def":"CLUSTERED, unique, part of a PRIMARY KEY constraint, [ user_id ]","table":"user_options","columns":["user_id"]}],"constraints":[{"name":"PK__user_opt_*","type":"PRIMARY KEY","def":"CLUSTERED, unique, part of a PRIMARY KEY constraint, [ user_id ]","table":"user_options","columns":["user_id"]},{"name":"user_options_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY(user_id) REFERENCES users(id) ON UPDATE NO_ACTION ON DELETE CASCADE","table":"user_options","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]}]},{"name":"posts","type":"BASIC TABLE","columns":[{"name":"id","type":"int","nullable":false},{"name":"user_id","type":"int","nullable":false},{"name":"title","type":"varchar(255)","nullable":false},{"name":"body","type":"text","nullable":false,"comment":"post body"},{"name":"created","type":"date","nullable":false},{"name":"updated","type":"date","nullable":true}],"indexes":[{"name":"posts_id_pk","def":"CLUSTERED, unique, part of a PRIMARY KEY constraint, [ id ]","table":"posts","columns":["id"]},{"name":"UQ__posts_*","def":"NONCLUSTERED, unique, part of a UNIQUE constraint, [ user_id, title ]","table":"posts","columns":["user_id","title"]},{"name":"posts_user_id_idx","def":"NONCLUSTERED, [ user_id ]","table":"posts","columns":["user_id"]}],"constraints":[{"name":"posts_id_pk","type":"PRIMARY KEY","def":"CLUSTERED, unique, part of a PRIMARY KEY constraint, [ id ]","table":"posts","columns":["id"]},{"name":"UQ__posts_*","type":"UNIQUE","def":"NONCLUSTERED, unique, part of a UNIQUE constraint, [ user_id, title ]","table":"posts","columns":["user_id","title"]},{"name":"posts_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY(user_id) REFERENCES users(id) ON UPDATE NO_ACTION ON DELETE CASCADE","table":"posts","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]}],"triggers":[{"name":"update_posts_updated","def":"CREATE TRIGGER update_posts_updated\nON posts\nAFTER UPDATE\nAS\nBEGIN\n  UPDATE users SET updated = GETDATE()\n  WHERE id = ( SELECT user_id FROM deleted)\nEND;"}],"labels":[{"name":"green","virtual":true},{"name":"red","virtual":true},{"name":"blue","virtual":true}]},{"name":"comments","type":"BASIC TABLE","columns":[{"name":"id","type":"int","nullable":false},{"name":"post_id","type":"int","nullable":false},{"name":"user_id","type":"int","nullable":false},{"name":"comment","type":"text","nullable":false},{"name":"created","type":"date","nullable":false},{"name":"updated","type":"date","nullable":true}],"indexes":[{"name":"comments_id_pk","def":"CLUSTERED, unique, part of a PRIMARY KEY constraint, [ id ]","table":"comments","columns":["id"]},{"name":"UQ__comments_*","def":"NONCLUSTERED, unique, part of a UNIQUE constraint, [ post_id, user_id ]","table":"comments","columns":["post_id","user_id"]},{"name":"comments_post_id_user_id_idx","def":"NONCLUSTERED, [ post_id, user_id ]","table":"comments","columns":["post_id","user_id"]}],"constraints":[{"name":"comments_id_pk","type":"PRIMARY KEY","def":"CLUSTERED, unique, part of a PRIMARY KEY constraint, [ id ]","table":"comments","columns":["id"]},{"name":"UQ__comments_*","type":"UNIQUE","def":"NONCLUSTERED, unique, part of a UNIQUE constraint, [ post_id, user_id ]","table":"comments","columns":["post_id","user_id"]},{"name":"comments_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY(post_id) REFERENCES posts(id) ON UPDATE NO_ACTION ON DELETE NO_ACTION","table":"comments","referenced_table":"posts","columns":["post_id"],"referenced_columns":["id"]},{"name":"comments_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY(user_id) REFERENCES users(id) ON UPDATE NO_ACTION ON DELETE NO_ACTION","table":"comments","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]}]},{"name":"comment_stars","type":"BASIC TABLE","columns":[{"name":"id","type":"int","nullable":false},{"name":"user_id","type":"int","nullable":false},{"name":"comment_post_id","type":"int","nullable":false},{"name":"comment_user_id","type":"int","nullable":false},{"name":"created","type":"date","nullable":false},{"name":"updated","type":"date","nullable":true}],"indexes":[{"name":"UQ__comment__*","def":"NONCLUSTERED, unique, part of a UNIQUE constraint, [ user_id, comment_post_id, comment_user_id ]","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"constraints":[{"name":"UQ__comment__*","type":"UNIQUE","def":"NONCLUSTERED, unique, part of a UNIQUE constraint, [ user_id, comment_post_id, comment_user_id ]","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]},{"name":"comment_stars_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY(comment_user_id) REFERENCES users(id) ON UPDATE NO_ACTION ON DELETE NO_ACTION","table":"comment_stars","referenced_table":"users","columns":["comment_user_id"],"referenced_columns":["id"]},{"name":"comment_stars_user_id_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY(comment_post_id, comment_user_id) REFERENCES comments(post_id, user_id) ON UPDATE NO_ACTION ON DELETE NO_ACTION","table":"comment_stars","referenced_table":"comments","columns":["comment_post_id","comment_user_id"],"referenced_columns":["post_id","user_id"]}]},{"name":"logs","type":"BASIC TABLE","columns":[{"name":"id","type":"int","nullable":false},{"name":"user_id","type":"int","nullable":false},{"name":"post_id","type":"int","nullable":true},{"name":"comment_id","type":"int","nullable":true},{"name":"comment_star_id","type":"int","nullable":true},{"name":"payload","type":"text","nullable":true},{"name":"created","type":"date","nullable":false}]},{"name":"post_comments","type":"VIEW","comment":"post and comments View table","columns":[{"name":"id","type":"int","nullable":true,"comment":"comments.id"},{"name":"title","type":"varchar(255)","nullable":false,"comment":"posts.title"},{"name":"post_user","type":"varchar(50)","nullable":true,"comment":"posts.users.username"},{"name":"comment","type":"text","nullable":true},{"name":"comment_user","type":"varchar(50)","nullable":true,"comment":"comments.users.username"},{"name":"created","type":"date","nullable":true,"comment":"comments.created"},{"name":"updated","type":"date","nullable":true,"comment":"comments.updated"}],"def":"CREATE VIEW post_comments AS (\n  SELECT c.id, p.title, u2.username AS post_user, c.comment, u2.username AS comment_user, c.created, c.updated\n  FROM posts AS p\n  LEFT JOIN comments AS c on p.id = c.post_id\n  LEFT JOIN users AS u on u.id = p.user_id\n  LEFT JOIN users AS u2 on u2.id = c.user_id\n);","referenced_tables":["posts","comments","users"]},{"name":"CamelizeTable","type":"BASIC TABLE","columns":[{"name":"id","type":"int","nullable":false},{"name":"created","type":"date","nullable":false}]},{"name":"hyphen-table","type":"BASIC TABLE","columns":[{"name":"id","type":"int","nullable":false},{"name":"hyphen-column","type":"text","nullable":false},{"name":"created","type":"date","nullable":false}]},{"name":"administrator.blogs","type":"BASIC TABLE","comment":"admin blogs","columns":[{"name":"id","type":"int","nullable":false},{"name":"user_id","type":"int","nullable":false},{"name":"name","type":"text","nullable":false},{"name":"description","type":"text","nullable":true},{"name":"created","type":"date","nullable":false},{"name":"updated","type":"date","nullable":true}],"indexes":[{"name":"PK__blogs_*","def":"CLUSTERED, unique, part of a PRIMARY KEY constraint, [ id ]","table":"administrator.blogs","columns":["id"]}],"constraints":[{"name":"PK__blogs_*","type":"PRIMARY KEY","def":"CLUSTERED, unique, part of a PRIMARY KEY constraint, [ id ]","table":"administrator.blogs","columns":["id"]},{"name":"blogs_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY(user_id) REFERENCES users(id) ON UPDATE NO_ACTION ON DELETE CASCADE","table":"administrator.blogs","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]}]},{"name":"name with spaces","type":"VIEW","columns":[{"name":"title","type":"varchar(255)","nullable":false}],"def":"CREATE VIEW \"name with spaces\" AS (\n  SELECT TOP 1 p.title\n  FROM posts AS p\n);","referenced_tables":["posts"]},{"name":"Sales.Product","type":"BASIC TABLE","columns":[{"name":"ProductID","type":"int","nullable":false},{"name":"SalesPersonID","type":"int","nullable":true}],"indexes":[{"name":"PK__Product_*","def":"CLUSTERED, unique, part of a PRIMARY KEY constraint, [ ProductID ]","table":"Sales.Product","columns":["ProductID"]},{"name":"UQ__Product_*","def":"NONCLUSTERED, unique, part of a UNIQUE constraint, [ SalesPersonID ]","table":"Sales.Product","columns":["SalesPersonID"]}],"constraints":[{"name":"PK__Product_*","type":"PRIMARY KEY","def":"CLUSTERED, unique, part of a PRIMARY KEY constraint, [ ProductID ]","table":"Sales.Product","columns":["ProductID"]},{"name":"UQ__Product_*","type":"UNIQUE","def":"NONCLUSTERED, unique, part of a UNIQUE constraint, [ SalesPersonID ]","table":"Sales.Product","columns":["SalesPersonID"]}]},{"name":"Rabbits.Running","type":"BASIC TABLE","columns":[{"name":"LocationID","type":"int","nullable":false},{"name":"ProductID","type":"int","nullable":true},{"name":"EmployeeID","type":"int","nullable":true}],"indexes":[{"name":"PK__Running_*","def":"CLUSTERED, unique, part of a PRIMARY KEY constraint, [ LocationID ]","table":"Rabbits.Running","columns":["LocationID"]},{"name":"UQ__Running_*","def":"NONCLUSTERED, unique, part of a UNIQUE constraint, [ EmployeeID ]","table":"Rabbits.Running","columns":["EmployeeID"]},{"name":"UQ__Running_*","def":"NONCLUSTERED, unique, part of a UNIQUE constraint, [ ProductID ]","table":"Rabbits.Running","columns":["ProductID"]}],"constraints":[{"name":"PK__Running_*","type":"PRIMARY KEY","def":"CLUSTERED, unique, part of a PRIMARY KEY constraint, [ LocationID ]","table":"Rabbits.Running","columns":["LocationID"]},{"name":"UQ__Running_*","type":"UNIQUE","def":"NONCLUSTERED, unique, part of a UNIQUE constraint, [ EmployeeID ]","table":"Rabbits.Running","columns":["EmployeeID"]},{"name":"UQ__Running_*","type":"UNIQUE","def":"NONCLUSTERED, unique, part of a UNIQUE constraint, [ ProductID ]","table":"Rabbits.Running","columns":["ProductID"]},{"name":"FK_TempSales_SalesReason","type":"FOREIGN KEY","def":"FOREIGN KEY(ProductID) REFERENCES Sales.Product(SalesPersonID) ON UPDATE NO_ACTION ON DELETE NO_ACTION","table":"Rabbits.Running","referenced_table":"Sales.Product","columns":["ProductID"],"referenced_columns":["SalesPersonID"]}]}],"relations":[{"table":"user_options","columns":["user_id"],"cardinality":"zero_or_one","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":""},{"table":"posts","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":""},{"table":"comments","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"exactly_one","def":""},{"table":"comments","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":""},{"table":"comment_stars","columns":["comment_user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":""},{"table":"comment_stars","columns":["comment_post_id","comment_user_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["post_id","user_id"],"parent_cardinality":"exactly_one","def":""},{"table":"administrator.blogs","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":""},{"table":"Rabbits.Running","columns":["ProductID"],"cardinality":"zero_or_one","parent_table":"Sales.Product","parent_columns":["SalesPersonID"],"parent_cardinality":"zero_or_one","def":""},{"table":"logs","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"logs-\u003eusers","virtual":true},{"table":"logs","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"logs","columns":["comment_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"logs","columns":["comment_star_id"],"cardinality":"zero_or_more","parent_table":"comment_stars","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true}],"functions":[{"name":"dbo.get_user","return_type":"","arguments":"@userid int","type":"SQL inline table-valued function"},{"name":"dbo.What_DB_is_that","return_type":"","arguments":"@ID int","type":"SQL Stored Procedure"}],"driver":{"name":"sqlserver","database_version":"Microsoft SQL Server 2019 (RTM-CU30) (KB5049235) - 15.0.4415.2 (X64) \n\tNov 18 2024 17:45:37 \n\tCopyright (C) 2019 Microsoft Corporation\n\tDeveloper Edition (64-bit) on Linux (Ubuntu 20.04.6 LTS) \u003cX64\u003e","meta":{"dict":{"Functions":"Stored procedures and functions"}}},"labels":[{"name":"sample","virtual":true},{"name":"tbls","virtual":true}]}
+{
+  "name": "testdb",
+  "desc": "Sample database document.",
+  "tables": [
+    {
+      "name": "users",
+      "type": "BASIC TABLE",
+      "comment": "Users table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "username",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "password",
+          "type": "varchar(50)",
+          "nullable": false,
+          "comment": "long long long long long long long long long long long long long long long long long long long long long description"
+        },
+        {
+          "name": "email",
+          "type": "varchar(355)",
+          "nullable": false,
+          "comment": "ex. user@example.com"
+        },
+        {
+          "name": "created",
+          "type": "date",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "date",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PK__users_*",
+          "def": "CLUSTERED, unique, part of a PRIMARY KEY constraint, [ id ]",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "UQ__users_*",
+          "def": "NONCLUSTERED, unique, part of a UNIQUE constraint, [ email ]",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "UQ__users_*",
+          "def": "NONCLUSTERED, unique, part of a UNIQUE constraint, [ username ]",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PK__users_*",
+          "type": "PRIMARY KEY",
+          "def": "CLUSTERED, unique, part of a PRIMARY KEY constraint, [ id ]",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "UQ__users_*",
+          "type": "UNIQUE",
+          "def": "NONCLUSTERED, unique, part of a UNIQUE constraint, [ email ]",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "UQ__users_*",
+          "type": "UNIQUE",
+          "def": "NONCLUSTERED, unique, part of a UNIQUE constraint, [ username ]",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "CK__users__username_*",
+          "type": "CHECK",
+          "def": "CHECK(len([username])\u003e(4))",
+          "table": "users"
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_users_updated",
+          "def": "CREATE TRIGGER update_users_updated\nON users\nAFTER UPDATE\nAS\nBEGIN\n  UPDATE users SET updated = GETDATE()\n  WHERE id = ( SELECT id FROM deleted)\nEND;"
+        }
+      ]
+    },
+    {
+      "name": "user_options",
+      "type": "BASIC TABLE",
+      "comment": "User options table",
+      "columns": [
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "show_email",
+          "type": "bit",
+          "nullable": false,
+          "default": "((0))"
+        },
+        {
+          "name": "created",
+          "type": "date",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "date",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PK__user_opt_*",
+          "def": "CLUSTERED, unique, part of a PRIMARY KEY constraint, [ user_id ]",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PK__user_opt_*",
+          "type": "PRIMARY KEY",
+          "def": "CLUSTERED, unique, part of a PRIMARY KEY constraint, [ user_id ]",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_options_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY(user_id) REFERENCES users(id) ON UPDATE NO_ACTION ON DELETE CASCADE",
+          "table": "user_options",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "posts",
+      "type": "BASIC TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false
+        },
+        {
+          "name": "body",
+          "type": "text",
+          "nullable": false,
+          "comment": "post body"
+        },
+        {
+          "name": "created",
+          "type": "date",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "date",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "posts_id_pk",
+          "def": "CLUSTERED, unique, part of a PRIMARY KEY constraint, [ id ]",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "UQ__posts_*",
+          "def": "NONCLUSTERED, unique, part of a UNIQUE constraint, [ user_id, title ]",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        },
+        {
+          "name": "posts_user_id_idx",
+          "def": "NONCLUSTERED, [ user_id ]",
+          "table": "posts",
+          "columns": [
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "posts_id_pk",
+          "type": "PRIMARY KEY",
+          "def": "CLUSTERED, unique, part of a PRIMARY KEY constraint, [ id ]",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "UQ__posts_*",
+          "type": "UNIQUE",
+          "def": "NONCLUSTERED, unique, part of a UNIQUE constraint, [ user_id, title ]",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        },
+        {
+          "name": "posts_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY(user_id) REFERENCES users(id) ON UPDATE NO_ACTION ON DELETE CASCADE",
+          "table": "posts",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_posts_updated",
+          "def": "CREATE TRIGGER update_posts_updated\nON posts\nAFTER UPDATE\nAS\nBEGIN\n  UPDATE users SET updated = GETDATE()\n  WHERE id = ( SELECT user_id FROM deleted)\nEND;"
+        }
+      ],
+      "labels": [
+        {
+          "name": "green",
+          "virtual": true
+        },
+        {
+          "name": "red",
+          "virtual": true
+        },
+        {
+          "name": "blue",
+          "virtual": true
+        }
+      ]
+    },
+    {
+      "name": "comments",
+      "type": "BASIC TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "post_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "date",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "date",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comments_id_pk",
+          "def": "CLUSTERED, unique, part of a PRIMARY KEY constraint, [ id ]",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "UQ__comments_*",
+          "def": "NONCLUSTERED, unique, part of a UNIQUE constraint, [ post_id, user_id ]",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "comments_post_id_user_id_idx",
+          "def": "NONCLUSTERED, [ post_id, user_id ]",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comments_id_pk",
+          "type": "PRIMARY KEY",
+          "def": "CLUSTERED, unique, part of a PRIMARY KEY constraint, [ id ]",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "UQ__comments_*",
+          "type": "UNIQUE",
+          "def": "NONCLUSTERED, unique, part of a UNIQUE constraint, [ post_id, user_id ]",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "comments_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY(post_id) REFERENCES posts(id) ON UPDATE NO_ACTION ON DELETE NO_ACTION",
+          "table": "comments",
+          "referenced_table": "posts",
+          "columns": [
+            "post_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY(user_id) REFERENCES users(id) ON UPDATE NO_ACTION ON DELETE NO_ACTION",
+          "table": "comments",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "comment_stars",
+      "type": "BASIC TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment_post_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment_user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "date",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "date",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "UQ__comment__*",
+          "def": "NONCLUSTERED, unique, part of a UNIQUE constraint, [ user_id, comment_post_id, comment_user_id ]",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "UQ__comment__*",
+          "type": "UNIQUE",
+          "def": "NONCLUSTERED, unique, part of a UNIQUE constraint, [ user_id, comment_post_id, comment_user_id ]",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY(comment_user_id) REFERENCES users(id) ON UPDATE NO_ACTION ON DELETE NO_ACTION",
+          "table": "comment_stars",
+          "referenced_table": "users",
+          "columns": [
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY(comment_post_id, comment_user_id) REFERENCES comments(post_id, user_id) ON UPDATE NO_ACTION ON DELETE NO_ACTION",
+          "table": "comment_stars",
+          "referenced_table": "comments",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "logs",
+      "type": "BASIC TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "post_id",
+          "type": "int",
+          "nullable": true
+        },
+        {
+          "name": "comment_id",
+          "type": "int",
+          "nullable": true
+        },
+        {
+          "name": "comment_star_id",
+          "type": "int",
+          "nullable": true
+        },
+        {
+          "name": "payload",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "date",
+          "nullable": false
+        }
+      ]
+    },
+    {
+      "name": "post_comments",
+      "type": "VIEW",
+      "comment": "post and comments View table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int",
+          "nullable": true,
+          "comment": "comments.id"
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "comment": "posts.title"
+        },
+        {
+          "name": "post_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "posts.users.username"
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "comment_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "comments.users.username"
+        },
+        {
+          "name": "created",
+          "type": "date",
+          "nullable": true,
+          "comment": "comments.created"
+        },
+        {
+          "name": "updated",
+          "type": "date",
+          "nullable": true,
+          "comment": "comments.updated"
+        }
+      ],
+      "def": "CREATE VIEW post_comments AS (\n  SELECT c.id, p.title, u2.username AS post_user, c.comment, u2.username AS comment_user, c.created, c.updated\n  FROM posts AS p\n  LEFT JOIN comments AS c on p.id = c.post_id\n  LEFT JOIN users AS u on u.id = p.user_id\n  LEFT JOIN users AS u2 on u2.id = c.user_id\n);",
+      "referenced_tables": [
+        "posts",
+        "comments",
+        "users"
+      ]
+    },
+    {
+      "name": "CamelizeTable",
+      "type": "BASIC TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "date",
+          "nullable": false
+        }
+      ]
+    },
+    {
+      "name": "hyphen-table",
+      "type": "BASIC TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "hyphen-column",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "date",
+          "nullable": false
+        }
+      ]
+    },
+    {
+      "name": "administrator.blogs",
+      "type": "BASIC TABLE",
+      "comment": "admin blogs",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "name",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "description",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "date",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "date",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PK__blogs_*",
+          "def": "CLUSTERED, unique, part of a PRIMARY KEY constraint, [ id ]",
+          "table": "administrator.blogs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PK__blogs_*",
+          "type": "PRIMARY KEY",
+          "def": "CLUSTERED, unique, part of a PRIMARY KEY constraint, [ id ]",
+          "table": "administrator.blogs",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "blogs_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY(user_id) REFERENCES users(id) ON UPDATE NO_ACTION ON DELETE CASCADE",
+          "table": "administrator.blogs",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "name with spaces",
+      "type": "VIEW",
+      "columns": [
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false
+        }
+      ],
+      "def": "CREATE VIEW \"name with spaces\" AS (\n  SELECT TOP 1 p.title\n  FROM posts AS p\n);",
+      "referenced_tables": [
+        "posts"
+      ]
+    },
+    {
+      "name": "Sales.Product",
+      "type": "BASIC TABLE",
+      "columns": [
+        {
+          "name": "ProductID",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "SalesPersonID",
+          "type": "int",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PK__Product_*",
+          "def": "CLUSTERED, unique, part of a PRIMARY KEY constraint, [ ProductID ]",
+          "table": "Sales.Product",
+          "columns": [
+            "ProductID"
+          ]
+        },
+        {
+          "name": "UQ__Product_*",
+          "def": "NONCLUSTERED, unique, part of a UNIQUE constraint, [ SalesPersonID ]",
+          "table": "Sales.Product",
+          "columns": [
+            "SalesPersonID"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PK__Product_*",
+          "type": "PRIMARY KEY",
+          "def": "CLUSTERED, unique, part of a PRIMARY KEY constraint, [ ProductID ]",
+          "table": "Sales.Product",
+          "columns": [
+            "ProductID"
+          ]
+        },
+        {
+          "name": "UQ__Product_*",
+          "type": "UNIQUE",
+          "def": "NONCLUSTERED, unique, part of a UNIQUE constraint, [ SalesPersonID ]",
+          "table": "Sales.Product",
+          "columns": [
+            "SalesPersonID"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Rabbits.Running",
+      "type": "BASIC TABLE",
+      "columns": [
+        {
+          "name": "LocationID",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "ProductID",
+          "type": "int",
+          "nullable": true
+        },
+        {
+          "name": "EmployeeID",
+          "type": "int",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PK__Running_*",
+          "def": "CLUSTERED, unique, part of a PRIMARY KEY constraint, [ LocationID ]",
+          "table": "Rabbits.Running",
+          "columns": [
+            "LocationID"
+          ]
+        },
+        {
+          "name": "UQ__Running_*",
+          "def": "NONCLUSTERED, unique, part of a UNIQUE constraint, [ EmployeeID ]",
+          "table": "Rabbits.Running",
+          "columns": [
+            "EmployeeID"
+          ]
+        },
+        {
+          "name": "UQ__Running_*",
+          "def": "NONCLUSTERED, unique, part of a UNIQUE constraint, [ ProductID ]",
+          "table": "Rabbits.Running",
+          "columns": [
+            "ProductID"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PK__Running_*",
+          "type": "PRIMARY KEY",
+          "def": "CLUSTERED, unique, part of a PRIMARY KEY constraint, [ LocationID ]",
+          "table": "Rabbits.Running",
+          "columns": [
+            "LocationID"
+          ]
+        },
+        {
+          "name": "UQ__Running_*",
+          "type": "UNIQUE",
+          "def": "NONCLUSTERED, unique, part of a UNIQUE constraint, [ EmployeeID ]",
+          "table": "Rabbits.Running",
+          "columns": [
+            "EmployeeID"
+          ]
+        },
+        {
+          "name": "UQ__Running_*",
+          "type": "UNIQUE",
+          "def": "NONCLUSTERED, unique, part of a UNIQUE constraint, [ ProductID ]",
+          "table": "Rabbits.Running",
+          "columns": [
+            "ProductID"
+          ]
+        },
+        {
+          "name": "FK_TempSales_SalesReason",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY(ProductID) REFERENCES Sales.Product(SalesPersonID) ON UPDATE NO_ACTION ON DELETE NO_ACTION",
+          "table": "Rabbits.Running",
+          "referenced_table": "Sales.Product",
+          "columns": [
+            "ProductID"
+          ],
+          "referenced_columns": [
+            "SalesPersonID"
+          ]
+        }
+      ]
+    }
+  ],
+  "relations": [
+    {
+      "table": "user_options",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_one",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": ""
+    },
+    {
+      "table": "posts",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": ""
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": ""
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": ""
+    },
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": ""
+    },
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_post_id",
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "post_id",
+        "user_id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": ""
+    },
+    {
+      "table": "administrator.blogs",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": ""
+    },
+    {
+      "table": "Rabbits.Running",
+      "columns": [
+        "ProductID"
+      ],
+      "cardinality": "zero_or_one",
+      "parent_table": "Sales.Product",
+      "parent_columns": [
+        "SalesPersonID"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": ""
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "logs-\u003eusers",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "comment_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "comment_star_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comment_stars",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    }
+  ],
+  "functions": [
+    {
+      "name": "dbo.get_user",
+      "return_type": "",
+      "arguments": "@userid int",
+      "type": "SQL inline table-valued function"
+    },
+    {
+      "name": "dbo.What_DB_is_that",
+      "return_type": "",
+      "arguments": "@ID int",
+      "type": "SQL Stored Procedure"
+    }
+  ],
+  "driver": {
+    "name": "sqlserver",
+    "database_version": "Microsoft SQL Server 2019 (RTM-CU30) (KB5049235) - 15.0.4415.2 (X64) \n\tNov 18 2024 17:45:37 \n\tCopyright (C) 2019 Microsoft Corporation\n\tDeveloper Edition (64-bit) on Linux (Ubuntu 20.04.6 LTS) \u003cX64\u003e",
+    "meta": {
+      "dict": {
+        "Functions": "Stored procedures and functions"
+      }
+    }
+  },
+  "labels": [
+    {
+      "name": "sample",
+      "virtual": true
+    },
+    {
+      "name": "tbls",
+      "virtual": true
+    }
+  ]
+}

--- a/sample/mysql/schema.json
+++ b/sample/mysql/schema.json
@@ -1,1 +1,1000 @@
-{"name":"testdb","desc":"Sample database document.","tables":[{"name":"CamelizeTable","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"CamelizeTable","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"CamelizeTable","columns":["id"]}],"def":"CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"comment_stars","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"comment_post_id","type":"bigint","nullable":false},{"name":"comment_user_id","type":"int","nullable":false},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"comment_stars_user_id_fk","def":"KEY comment_stars_user_id_fk (comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_user_id"]},{"name":"comment_stars_user_id_post_id_fk","def":"KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_post_id","comment_user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comment_stars","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"constraints":[{"name":"comment_stars_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)","table":"comment_stars","referenced_table":"users","columns":["comment_user_id"],"referenced_columns":["id"]},{"name":"comment_stars_user_id_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)","table":"comment_stars","referenced_table":"comments","columns":["comment_post_id","comment_user_id"],"referenced_columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comment_stars","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"def":"CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"comments","type":"BASE TABLE","comment":"Comments\nMulti-line\r\ntable\rcomment","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"post_id","type":"bigint","nullable":false},{"name":"user_id","type":"int","nullable":false},{"name":"comment","type":"text","nullable":false,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"post_id_desc","type":"bigint","nullable":true,"extra_def":"GENERATED ALWAYS AS (`post_id` * -(1)) VIRTUAL"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"comments_post_id_user_id_idx","def":"KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]},{"name":"comments_user_id_fk","def":"KEY comments_user_id_fk (user_id) USING BTREE","table":"comments","columns":["user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comments","columns":["id"]},{"name":"post_id","def":"UNIQUE KEY post_id (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]}],"constraints":[{"name":"comments_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (post_id) REFERENCES posts (id)","table":"comments","referenced_table":"posts","columns":["post_id"],"referenced_columns":["id"]},{"name":"comments_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"comments","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"post_id","type":"UNIQUE","def":"UNIQUE KEY post_id (post_id, user_id)","table":"comments","columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comments","columns":["id"]}],"def":"CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint GENERATED ALWAYS AS ((`post_id` * -(1))) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`),\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"},{"name":"hyphen-table","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"hyphen-column","type":"text","nullable":false},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"hyphen-table","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"hyphen-table","columns":["id"]}],"def":"CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"logs","type":"BASE TABLE","comment":"Auditログ","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"post_id","type":"bigint","nullable":true},{"name":"comment_id","type":"bigint","nullable":true},{"name":"comment_star_id","type":"bigint","nullable":true},{"name":"payload","type":"text","nullable":true},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"logs","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"logs","columns":["id"]}],"def":"CREATE TABLE `logs` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"},{"name":"long_long_long_long_long_long_long_long_table_name","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"long_long_long_long_long_long_long_long_table_name","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"long_long_long_long_long_long_long_long_table_name","columns":["id"]}],"def":"CREATE TABLE `long_long_long_long_long_long_long_long_table_name` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"post_comments","type":"VIEW","comment":"post and comments View table","columns":[{"name":"id","type":"bigint","nullable":true,"default":"0","comment":"comments.id"},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled","comment":"posts.title"},{"name":"post_user","type":"varchar(50)","nullable":true,"comment":"posts.users.username"},{"name":"comment","type":"text","nullable":true,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"comment_user","type":"varchar(50)","nullable":true,"comment":"comments.users.username"},{"name":"created","type":"datetime","nullable":true,"comment":"comments.created"},{"name":"updated","type":"datetime","nullable":true,"comment":"comments.updated"}],"def":"CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))","referenced_tables":["posts","comments","users"]},{"name":"posts","type":"BASE TABLE","comment":"Posts table","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled"},{"name":"body","type":"text","nullable":false,"comment":"post body"},{"name":"post_type","type":"enum('public','private','draft')","nullable":false,"comment":"public/private/draft"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"posts_user_id_idx","def":"KEY posts_user_id_idx (id) USING BTREE","table":"posts","columns":["id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"posts","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, title) USING BTREE","table":"posts","columns":["user_id","title"]}],"constraints":[{"name":"posts_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"posts","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"posts","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, title)","table":"posts","columns":["user_id","title"]}],"triggers":[{"name":"update_posts_updated","def":"CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"}],"def":"CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'","labels":[{"name":"green","virtual":true},{"name":"red","virtual":true},{"name":"blue","virtual":true}]},{"name":"user_options","type":"BASE TABLE","comment":"User options table","columns":[{"name":"user_id","type":"int","nullable":false},{"name":"show_email","type":"tinyint(1)","nullable":false,"default":"0"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (user_id) USING BTREE","table":"user_options","columns":["user_id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id) USING BTREE","table":"user_options","columns":["user_id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_options_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"user_options","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]}],"def":"CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'"},{"name":"users","type":"BASE TABLE","comment":"Users table","columns":[{"name":"id","type":"int","nullable":false,"extra_def":"auto_increment"},{"name":"username","type":"varchar(50)","nullable":false},{"name":"password","type":"varchar(50)","nullable":false,"labels":[{"name":"secure","virtual":true},{"name":"encrypted","virtual":true}]},{"name":"email","type":"varchar(355)","nullable":false,"labels":[{"name":"secure","virtual":true}],"comment":"ex. user@example.com"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"users","columns":["id"]},{"name":"email","def":"UNIQUE KEY email (email) USING BTREE","table":"users","columns":["email"]},{"name":"username","def":"UNIQUE KEY username (username) USING BTREE","table":"users","columns":["username"]}],"constraints":[{"name":"email","type":"UNIQUE","def":"UNIQUE KEY email (email)","table":"users","columns":["email"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"users","columns":["id"]},{"name":"username","type":"UNIQUE","def":"UNIQUE KEY username (username)","table":"users","columns":["username"]},{"name":"users_chk_1","type":"CHECK","def":"CHECK ((char_length(`username`) \u003e 4))","table":"users"}],"def":"CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`),\n  CONSTRAINT `users_chk_1` CHECK ((char_length(`username`) \u003e 4))\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'"}],"relations":[{"table":"comment_stars","columns":["comment_user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)"},{"table":"comment_stars","columns":["comment_post_id","comment_user_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["post_id","user_id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"},{"table":"comments","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (post_id) REFERENCES posts (id)"},{"table":"comments","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"posts","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"user_options","columns":["user_id"],"cardinality":"zero_or_one","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"logs","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"logs-\u003eusers","virtual":true},{"table":"logs","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"logs","columns":["comment_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"logs","columns":["comment_star_id"],"cardinality":"exactly_one","parent_table":"comment_stars","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"Additional Relation","virtual":true}],"functions":[{"name":"CustomerLevel","return_type":"varchar","arguments":"credit decimal","type":"FUNCTION"},{"name":"GetAllComments","return_type":"","arguments":"","type":"PROCEDURE"}],"driver":{"name":"mysql","database_version":"8.4.4","meta":{"dict":{"Functions":"Stored procedures and functions"}}},"labels":[{"name":"sample","virtual":true},{"name":"tbls","virtual":true}]}
+{
+  "name": "testdb",
+  "desc": "Sample database document.",
+  "tables": [
+    {
+      "name": "CamelizeTable",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "comment_stars",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment_post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "comment_user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "def": "KEY comment_stars_user_id_fk (comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "def": "KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)",
+          "table": "comment_stars",
+          "referenced_table": "users",
+          "columns": [
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)",
+          "table": "comment_stars",
+          "referenced_table": "comments",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "comments",
+      "type": "BASE TABLE",
+      "comment": "Comments\nMulti-line\r\ntable\rcomment",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": false,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "post_id_desc",
+          "type": "bigint",
+          "nullable": true,
+          "extra_def": "GENERATED ALWAYS AS (`post_id` * -(1)) VIRTUAL"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comments_post_id_user_id_idx",
+          "def": "KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "def": "KEY comments_user_id_fk (user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "def": "UNIQUE KEY post_id (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comments_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (post_id) REFERENCES posts (id)",
+          "table": "comments",
+          "referenced_table": "posts",
+          "columns": [
+            "post_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "comments",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY post_id (post_id, user_id)",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint GENERATED ALWAYS AS ((`post_id` * -(1))) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`),\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"
+    },
+    {
+      "name": "hyphen-table",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "hyphen-column",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "logs",
+      "type": "BASE TABLE",
+      "comment": "Auditログ",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_star_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "payload",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `logs` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"
+    },
+    {
+      "name": "long_long_long_long_long_long_long_long_table_name",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "long_long_long_long_long_long_long_long_table_name",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "long_long_long_long_long_long_long_long_table_name",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `long_long_long_long_long_long_long_long_table_name` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "post_comments",
+      "type": "VIEW",
+      "comment": "post and comments View table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": true,
+          "default": "0",
+          "comment": "comments.id"
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled",
+          "comment": "posts.title"
+        },
+        {
+          "name": "post_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "posts.users.username"
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": true,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "comment_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "comments.users.username"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.created"
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.updated"
+        }
+      ],
+      "def": "CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))",
+      "referenced_tables": [
+        "posts",
+        "comments",
+        "users"
+      ]
+    },
+    {
+      "name": "posts",
+      "type": "BASE TABLE",
+      "comment": "Posts table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled"
+        },
+        {
+          "name": "body",
+          "type": "text",
+          "nullable": false,
+          "comment": "post body"
+        },
+        {
+          "name": "post_type",
+          "type": "enum('public','private','draft')",
+          "nullable": false,
+          "comment": "public/private/draft"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "posts_user_id_idx",
+          "def": "KEY posts_user_id_idx (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, title) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "posts_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "posts",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, title)",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_posts_updated",
+          "def": "CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"
+        }
+      ],
+      "def": "CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'",
+      "labels": [
+        {
+          "name": "green",
+          "virtual": true
+        },
+        {
+          "name": "red",
+          "virtual": true
+        },
+        {
+          "name": "blue",
+          "virtual": true
+        }
+      ]
+    },
+    {
+      "name": "user_options",
+      "type": "BASE TABLE",
+      "comment": "User options table",
+      "columns": [
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "show_email",
+          "type": "tinyint(1)",
+          "nullable": false,
+          "default": "0"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_options_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "user_options",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'"
+    },
+    {
+      "name": "users",
+      "type": "BASE TABLE",
+      "comment": "Users table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "username",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "password",
+          "type": "varchar(50)",
+          "nullable": false,
+          "labels": [
+            {
+              "name": "secure",
+              "virtual": true
+            },
+            {
+              "name": "encrypted",
+              "virtual": true
+            }
+          ]
+        },
+        {
+          "name": "email",
+          "type": "varchar(355)",
+          "nullable": false,
+          "labels": [
+            {
+              "name": "secure",
+              "virtual": true
+            }
+          ],
+          "comment": "ex. user@example.com"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "email",
+          "def": "UNIQUE KEY email (email) USING BTREE",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "username",
+          "def": "UNIQUE KEY username (username) USING BTREE",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "email",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY email (email)",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "username",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY username (username)",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "users_chk_1",
+          "type": "CHECK",
+          "def": "CHECK ((char_length(`username`) \u003e 4))",
+          "table": "users"
+        }
+      ],
+      "def": "CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`),\n  CONSTRAINT `users_chk_1` CHECK ((char_length(`username`) \u003e 4))\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'"
+    }
+  ],
+  "relations": [
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_post_id",
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "post_id",
+        "user_id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (post_id) REFERENCES posts (id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "posts",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "user_options",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_one",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "logs-\u003eusers",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "comment_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "comment_star_id"
+      ],
+      "cardinality": "exactly_one",
+      "parent_table": "comment_stars",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "Additional Relation",
+      "virtual": true
+    }
+  ],
+  "functions": [
+    {
+      "name": "CustomerLevel",
+      "return_type": "varchar",
+      "arguments": "credit decimal",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "GetAllComments",
+      "return_type": "",
+      "arguments": "",
+      "type": "PROCEDURE"
+    }
+  ],
+  "driver": {
+    "name": "mysql",
+    "database_version": "8.4.6",
+    "meta": {
+      "dict": {
+        "Functions": "Stored procedures and functions"
+      }
+    }
+  },
+  "labels": [
+    {
+      "name": "sample",
+      "virtual": true
+    },
+    {
+      "name": "tbls",
+      "virtual": true
+    }
+  ]
+}

--- a/sample/mysql56/schema.json
+++ b/sample/mysql56/schema.json
@@ -1,1 +1,944 @@
-{"name":"testdb","desc":"Sample database document.","tables":[{"name":"CamelizeTable","type":"BASE TABLE","columns":[{"name":"id","type":"bigint(20)","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"CamelizeTable","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"CamelizeTable","columns":["id"]}],"def":"CREATE TABLE `CamelizeTable` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=latin1"},{"name":"comment_stars","type":"BASE TABLE","columns":[{"name":"id","type":"bigint(20)","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int(11)","nullable":false},{"name":"comment_post_id","type":"bigint(20)","nullable":false},{"name":"comment_user_id","type":"int(11)","nullable":false},{"name":"created","type":"timestamp","nullable":false,"default":"CURRENT_TIMESTAMP","extra_def":"on update CURRENT_TIMESTAMP"},{"name":"updated","type":"timestamp","nullable":false,"default":"0000-00-00 00:00:00"}],"indexes":[{"name":"comment_stars_user_id_fk","def":"KEY comment_stars_user_id_fk (comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_user_id"]},{"name":"comment_stars_user_id_post_id_fk","def":"KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_post_id","comment_user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comment_stars","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"constraints":[{"name":"comment_stars_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)","table":"comment_stars","referenced_table":"users","columns":["comment_user_id"],"referenced_columns":["id"]},{"name":"comment_stars_user_id_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)","table":"comment_stars","referenced_table":"comments","columns":["comment_post_id","comment_user_id"],"referenced_columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comment_stars","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"def":"CREATE TABLE `comment_stars` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `user_id` int(11) NOT NULL,\n  `comment_post_id` bigint(20) NOT NULL,\n  `comment_user_id` int(11) NOT NULL,\n  `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,\n  `updated` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=latin1"},{"name":"comments","type":"BASE TABLE","comment":"Comments\nMulti-line\r\ntable\rcomment","columns":[{"name":"id","type":"bigint(20)","nullable":false,"extra_def":"auto_increment"},{"name":"post_id","type":"bigint(20)","nullable":false},{"name":"user_id","type":"int(11)","nullable":false},{"name":"comment","type":"text","nullable":false,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"comments_post_id_user_id_idx","def":"KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]},{"name":"comments_user_id_fk","def":"KEY comments_user_id_fk (user_id) USING BTREE","table":"comments","columns":["user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comments","columns":["id"]},{"name":"post_id","def":"UNIQUE KEY post_id (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]}],"constraints":[{"name":"comments_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (post_id) REFERENCES posts (id)","table":"comments","referenced_table":"posts","columns":["post_id"],"referenced_columns":["id"]},{"name":"comments_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"comments","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"post_id","type":"UNIQUE","def":"UNIQUE KEY post_id (post_id, user_id)","table":"comments","columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comments","columns":["id"]}],"def":"CREATE TABLE `comments` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `post_id` bigint(20) NOT NULL,\n  `user_id` int(11) NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`) USING HASH,\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"},{"name":"hyphen-table","type":"BASE TABLE","columns":[{"name":"id","type":"bigint(20)","nullable":false,"extra_def":"auto_increment"},{"name":"hyphen-column","type":"text","nullable":false},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"hyphen-table","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"hyphen-table","columns":["id"]}],"def":"CREATE TABLE `hyphen-table` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=latin1"},{"name":"logs","type":"BASE TABLE","comment":"Auditログ","columns":[{"name":"id","type":"bigint(20)","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int(11)","nullable":false},{"name":"post_id","type":"bigint(20)","nullable":true},{"name":"comment_id","type":"bigint(20)","nullable":true},{"name":"comment_star_id","type":"bigint(20)","nullable":true},{"name":"payload","type":"text","nullable":true},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"logs","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"logs","columns":["id"]}],"def":"CREATE TABLE `logs` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `user_id` int(11) NOT NULL,\n  `post_id` bigint(20) DEFAULT NULL,\n  `comment_id` bigint(20) DEFAULT NULL,\n  `comment_star_id` bigint(20) DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMMENT='Auditログ'"},{"name":"post_comments","type":"VIEW","comment":"post and comments View table","columns":[{"name":"id","type":"bigint(20)","nullable":true,"default":"0","comment":"comments.id"},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled","comment":"posts.title"},{"name":"post_user","type":"varchar(50)","nullable":true,"comment":"posts.users.username"},{"name":"comment","type":"text","nullable":true,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"comment_user","type":"varchar(50)","nullable":true,"comment":"comments.users.username"},{"name":"created","type":"datetime","nullable":true,"comment":"comments.created"},{"name":"updated","type":"datetime","nullable":true,"comment":"comments.updated"}],"def":"CREATE VIEW post_comments AS ((select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`)))))","referenced_tables":["posts","comments","users"]},{"name":"posts","type":"BASE TABLE","comment":"Posts table","columns":[{"name":"id","type":"bigint(20)","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int(11)","nullable":false},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled"},{"name":"body","type":"text","nullable":false,"comment":"post body"},{"name":"post_type","type":"enum('public','private','draft')","nullable":false,"comment":"public/private/draft"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"posts_user_id_idx","def":"KEY posts_user_id_idx (id) USING BTREE","table":"posts","columns":["id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"posts","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, title) USING BTREE","table":"posts","columns":["user_id","title"]}],"constraints":[{"name":"posts_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"posts","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"posts","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, title)","table":"posts","columns":["user_id","title"]}],"triggers":[{"name":"update_posts_updated","def":"CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"}],"def":"CREATE TABLE `posts` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `user_id` int(11) NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION\n) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMMENT='Posts table'","labels":[{"name":"green","virtual":true},{"name":"red","virtual":true},{"name":"blue","virtual":true}]},{"name":"user_options","type":"BASE TABLE","comment":"User options table","columns":[{"name":"user_id","type":"int(11)","nullable":false},{"name":"show_email","type":"tinyint(1)","nullable":false,"default":"0"},{"name":"created","type":"timestamp","nullable":false,"default":"CURRENT_TIMESTAMP","extra_def":"on update CURRENT_TIMESTAMP"},{"name":"updated","type":"timestamp","nullable":false,"default":"0000-00-00 00:00:00"}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (user_id) USING BTREE","table":"user_options","columns":["user_id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id) USING BTREE","table":"user_options","columns":["user_id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_options_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"user_options","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]}],"def":"CREATE TABLE `user_options` (\n  `user_id` int(11) NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,\n  `updated` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION\n) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMMENT='User options table'"},{"name":"users","type":"BASE TABLE","comment":"Users table","columns":[{"name":"id","type":"int(11)","nullable":false,"extra_def":"auto_increment"},{"name":"username","type":"varchar(50)","nullable":false},{"name":"password","type":"varchar(50)","nullable":false,"labels":[{"name":"secure","virtual":true},{"name":"encrypted","virtual":true}]},{"name":"email","type":"varchar(355)","nullable":false,"labels":[{"name":"secure","virtual":true}],"comment":"ex. user@example.com"},{"name":"created","type":"timestamp","nullable":false,"default":"CURRENT_TIMESTAMP","extra_def":"on update CURRENT_TIMESTAMP"},{"name":"updated","type":"timestamp","nullable":false,"default":"0000-00-00 00:00:00"}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"users","columns":["id"]},{"name":"email","def":"UNIQUE KEY email (email) USING BTREE","table":"users","columns":["email"]},{"name":"username","def":"UNIQUE KEY username (username) USING BTREE","table":"users","columns":["username"]}],"constraints":[{"name":"email","type":"UNIQUE","def":"UNIQUE KEY email (email)","table":"users","columns":["email"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"users","columns":["id"]},{"name":"username","type":"UNIQUE","def":"UNIQUE KEY username (username)","table":"users","columns":["username"]}],"def":"CREATE TABLE `users` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,\n  `updated` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`)\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=latin1 COMMENT='Users table'"}],"relations":[{"table":"comment_stars","columns":["comment_user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)"},{"table":"comment_stars","columns":["comment_post_id","comment_user_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["post_id","user_id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"},{"table":"comments","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (post_id) REFERENCES posts (id)"},{"table":"comments","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"posts","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"user_options","columns":["user_id"],"cardinality":"zero_or_one","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"logs","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"logs-\u003eusers","virtual":true},{"table":"logs","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"logs","columns":["comment_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"logs","columns":["comment_star_id"],"cardinality":"exactly_one","parent_table":"comment_stars","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"Additional Relation","virtual":true}],"driver":{"name":"mysql","database_version":"5.6.51","meta":{"dict":{"Functions":"Stored procedures and functions"}}},"labels":[{"name":"sample","virtual":true},{"name":"tbls","virtual":true}]}
+{
+  "name": "testdb",
+  "desc": "Sample database document.",
+  "tables": [
+    {
+      "name": "CamelizeTable",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint(20)",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `CamelizeTable` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=latin1"
+    },
+    {
+      "name": "comment_stars",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint(20)",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int(11)",
+          "nullable": false
+        },
+        {
+          "name": "comment_post_id",
+          "type": "bigint(20)",
+          "nullable": false
+        },
+        {
+          "name": "comment_user_id",
+          "type": "int(11)",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false,
+          "default": "CURRENT_TIMESTAMP",
+          "extra_def": "on update CURRENT_TIMESTAMP"
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": false,
+          "default": "0000-00-00 00:00:00"
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "def": "KEY comment_stars_user_id_fk (comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "def": "KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)",
+          "table": "comment_stars",
+          "referenced_table": "users",
+          "columns": [
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)",
+          "table": "comment_stars",
+          "referenced_table": "comments",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comment_stars` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `user_id` int(11) NOT NULL,\n  `comment_post_id` bigint(20) NOT NULL,\n  `comment_user_id` int(11) NOT NULL,\n  `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,\n  `updated` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=latin1"
+    },
+    {
+      "name": "comments",
+      "type": "BASE TABLE",
+      "comment": "Comments\nMulti-line\r\ntable\rcomment",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint(20)",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "post_id",
+          "type": "bigint(20)",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "int(11)",
+          "nullable": false
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": false,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comments_post_id_user_id_idx",
+          "def": "KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "def": "KEY comments_user_id_fk (user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "def": "UNIQUE KEY post_id (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comments_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (post_id) REFERENCES posts (id)",
+          "table": "comments",
+          "referenced_table": "posts",
+          "columns": [
+            "post_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "comments",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY post_id (post_id, user_id)",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comments` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `post_id` bigint(20) NOT NULL,\n  `user_id` int(11) NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`) USING HASH,\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"
+    },
+    {
+      "name": "hyphen-table",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint(20)",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "hyphen-column",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `hyphen-table` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=latin1"
+    },
+    {
+      "name": "logs",
+      "type": "BASE TABLE",
+      "comment": "Auditログ",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint(20)",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int(11)",
+          "nullable": false
+        },
+        {
+          "name": "post_id",
+          "type": "bigint(20)",
+          "nullable": true
+        },
+        {
+          "name": "comment_id",
+          "type": "bigint(20)",
+          "nullable": true
+        },
+        {
+          "name": "comment_star_id",
+          "type": "bigint(20)",
+          "nullable": true
+        },
+        {
+          "name": "payload",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `logs` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `user_id` int(11) NOT NULL,\n  `post_id` bigint(20) DEFAULT NULL,\n  `comment_id` bigint(20) DEFAULT NULL,\n  `comment_star_id` bigint(20) DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMMENT='Auditログ'"
+    },
+    {
+      "name": "post_comments",
+      "type": "VIEW",
+      "comment": "post and comments View table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint(20)",
+          "nullable": true,
+          "default": "0",
+          "comment": "comments.id"
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled",
+          "comment": "posts.title"
+        },
+        {
+          "name": "post_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "posts.users.username"
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": true,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "comment_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "comments.users.username"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.created"
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.updated"
+        }
+      ],
+      "def": "CREATE VIEW post_comments AS ((select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`)))))",
+      "referenced_tables": [
+        "posts",
+        "comments",
+        "users"
+      ]
+    },
+    {
+      "name": "posts",
+      "type": "BASE TABLE",
+      "comment": "Posts table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint(20)",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int(11)",
+          "nullable": false
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled"
+        },
+        {
+          "name": "body",
+          "type": "text",
+          "nullable": false,
+          "comment": "post body"
+        },
+        {
+          "name": "post_type",
+          "type": "enum('public','private','draft')",
+          "nullable": false,
+          "comment": "public/private/draft"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "posts_user_id_idx",
+          "def": "KEY posts_user_id_idx (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, title) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "posts_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "posts",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, title)",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_posts_updated",
+          "def": "CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"
+        }
+      ],
+      "def": "CREATE TABLE `posts` (\n  `id` bigint(20) NOT NULL AUTO_INCREMENT,\n  `user_id` int(11) NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION\n) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMMENT='Posts table'",
+      "labels": [
+        {
+          "name": "green",
+          "virtual": true
+        },
+        {
+          "name": "red",
+          "virtual": true
+        },
+        {
+          "name": "blue",
+          "virtual": true
+        }
+      ]
+    },
+    {
+      "name": "user_options",
+      "type": "BASE TABLE",
+      "comment": "User options table",
+      "columns": [
+        {
+          "name": "user_id",
+          "type": "int(11)",
+          "nullable": false
+        },
+        {
+          "name": "show_email",
+          "type": "tinyint(1)",
+          "nullable": false,
+          "default": "0"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false,
+          "default": "CURRENT_TIMESTAMP",
+          "extra_def": "on update CURRENT_TIMESTAMP"
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": false,
+          "default": "0000-00-00 00:00:00"
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_options_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "user_options",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `user_options` (\n  `user_id` int(11) NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,\n  `updated` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION\n) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMMENT='User options table'"
+    },
+    {
+      "name": "users",
+      "type": "BASE TABLE",
+      "comment": "Users table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int(11)",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "username",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "password",
+          "type": "varchar(50)",
+          "nullable": false,
+          "labels": [
+            {
+              "name": "secure",
+              "virtual": true
+            },
+            {
+              "name": "encrypted",
+              "virtual": true
+            }
+          ]
+        },
+        {
+          "name": "email",
+          "type": "varchar(355)",
+          "nullable": false,
+          "labels": [
+            {
+              "name": "secure",
+              "virtual": true
+            }
+          ],
+          "comment": "ex. user@example.com"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false,
+          "default": "CURRENT_TIMESTAMP",
+          "extra_def": "on update CURRENT_TIMESTAMP"
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": false,
+          "default": "0000-00-00 00:00:00"
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "email",
+          "def": "UNIQUE KEY email (email) USING BTREE",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "username",
+          "def": "UNIQUE KEY username (username) USING BTREE",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "email",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY email (email)",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "username",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY username (username)",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `users` (\n  `id` int(11) NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,\n  `updated` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`)\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=latin1 COMMENT='Users table'"
+    }
+  ],
+  "relations": [
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_post_id",
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "post_id",
+        "user_id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (post_id) REFERENCES posts (id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "posts",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "user_options",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_one",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "logs-\u003eusers",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "comment_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "comment_star_id"
+      ],
+      "cardinality": "exactly_one",
+      "parent_table": "comment_stars",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "Additional Relation",
+      "virtual": true
+    }
+  ],
+  "driver": {
+    "name": "mysql",
+    "database_version": "5.6.51",
+    "meta": {
+      "dict": {
+        "Functions": "Stored procedures and functions"
+      }
+    }
+  },
+  "labels": [
+    {
+      "name": "sample",
+      "virtual": true
+    },
+    {
+      "name": "tbls",
+      "virtual": true
+    }
+  ]
+}

--- a/sample/number/schema.json
+++ b/sample/number/schema.json
@@ -1,1 +1,928 @@
-{"name":"testdb","desc":"Sample database document.","tables":[{"name":"CamelizeTable","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"CamelizeTable","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"CamelizeTable","columns":["id"]}],"def":"CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"comment_stars","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"comment_post_id","type":"bigint","nullable":false},{"name":"comment_user_id","type":"int","nullable":false},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"comment_stars_user_id_fk","def":"KEY comment_stars_user_id_fk (comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_user_id"]},{"name":"comment_stars_user_id_post_id_fk","def":"KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_post_id","comment_user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comment_stars","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"constraints":[{"name":"comment_stars_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)","table":"comment_stars","referenced_table":"users","columns":["comment_user_id"],"referenced_columns":["id"]},{"name":"comment_stars_user_id_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)","table":"comment_stars","referenced_table":"comments","columns":["comment_post_id","comment_user_id"],"referenced_columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comment_stars","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"def":"CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"comments","type":"BASE TABLE","comment":"Comments\nMulti-line\r\ntable\rcomment","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"post_id","type":"bigint","nullable":false},{"name":"user_id","type":"int","nullable":false},{"name":"comment","type":"text","nullable":false,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"post_id_desc","type":"bigint","nullable":true,"extra_def":"GENERATED ALWAYS AS (`post_id` * -(1)) VIRTUAL"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"comments_post_id_user_id_idx","def":"KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]},{"name":"comments_user_id_fk","def":"KEY comments_user_id_fk (user_id) USING BTREE","table":"comments","columns":["user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comments","columns":["id"]},{"name":"post_id","def":"UNIQUE KEY post_id (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]}],"constraints":[{"name":"comments_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (post_id) REFERENCES posts (id)","table":"comments","referenced_table":"posts","columns":["post_id"],"referenced_columns":["id"]},{"name":"comments_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"comments","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"post_id","type":"UNIQUE","def":"UNIQUE KEY post_id (post_id, user_id)","table":"comments","columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comments","columns":["id"]}],"def":"CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint GENERATED ALWAYS AS ((`post_id` * -(1))) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`),\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"},{"name":"hyphen-table","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"hyphen-column","type":"text","nullable":false},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"hyphen-table","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"hyphen-table","columns":["id"]}],"def":"CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"logs","type":"BASE TABLE","comment":"Auditログ","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"post_id","type":"bigint","nullable":true},{"name":"comment_id","type":"bigint","nullable":true},{"name":"comment_star_id","type":"bigint","nullable":true},{"name":"payload","type":"text","nullable":true},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"logs","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"logs","columns":["id"]}],"def":"CREATE TABLE `logs` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"},{"name":"long_long_long_long_long_long_long_long_table_name","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"long_long_long_long_long_long_long_long_table_name","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"long_long_long_long_long_long_long_long_table_name","columns":["id"]}],"def":"CREATE TABLE `long_long_long_long_long_long_long_long_table_name` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"post_comments","type":"VIEW","comment":"post and comments View table","columns":[{"name":"id","type":"bigint","nullable":true,"default":"0","comment":"comments.id"},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled","comment":"posts.title"},{"name":"post_user","type":"varchar(50)","nullable":true,"comment":"posts.users.username"},{"name":"comment","type":"text","nullable":true,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"comment_user","type":"varchar(50)","nullable":true,"comment":"comments.users.username"},{"name":"created","type":"datetime","nullable":true,"comment":"comments.created"},{"name":"updated","type":"datetime","nullable":true,"comment":"comments.updated"}],"def":"CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))","referenced_tables":["posts","comments","users"]},{"name":"posts","type":"BASE TABLE","comment":"Posts table","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled"},{"name":"body","type":"text","nullable":false,"comment":"post body"},{"name":"post_type","type":"enum('public','private','draft')","nullable":false,"comment":"public/private/draft"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"posts_user_id_idx","def":"KEY posts_user_id_idx (id) USING BTREE","table":"posts","columns":["id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"posts","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, title) USING BTREE","table":"posts","columns":["user_id","title"]}],"constraints":[{"name":"posts_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"posts","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"posts","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, title)","table":"posts","columns":["user_id","title"]}],"triggers":[{"name":"update_posts_updated","def":"CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"}],"def":"CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'","labels":[{"name":"green","virtual":true},{"name":"red","virtual":true},{"name":"blue","virtual":true}]},{"name":"user_options","type":"BASE TABLE","comment":"User options table","columns":[{"name":"user_id","type":"int","nullable":false},{"name":"show_email","type":"tinyint(1)","nullable":false,"default":"0"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (user_id) USING BTREE","table":"user_options","columns":["user_id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id) USING BTREE","table":"user_options","columns":["user_id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_options_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"user_options","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]}],"def":"CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'"},{"name":"users","type":"BASE TABLE","comment":"Users table","columns":[{"name":"id","type":"int","nullable":false,"extra_def":"auto_increment"},{"name":"username","type":"varchar(50)","nullable":false},{"name":"password","type":"varchar(50)","nullable":false},{"name":"email","type":"varchar(355)","nullable":false,"comment":"ex. user@example.com"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"users","columns":["id"]},{"name":"email","def":"UNIQUE KEY email (email) USING BTREE","table":"users","columns":["email"]},{"name":"username","def":"UNIQUE KEY username (username) USING BTREE","table":"users","columns":["username"]}],"constraints":[{"name":"email","type":"UNIQUE","def":"UNIQUE KEY email (email)","table":"users","columns":["email"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"users","columns":["id"]},{"name":"username","type":"UNIQUE","def":"UNIQUE KEY username (username)","table":"users","columns":["username"]},{"name":"users_chk_1","type":"CHECK","def":"CHECK ((char_length(`username`) \u003e 4))","table":"users"}],"def":"CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`),\n  CONSTRAINT `users_chk_1` CHECK ((char_length(`username`) \u003e 4))\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'"}],"relations":[{"table":"comment_stars","columns":["comment_user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)"},{"table":"comment_stars","columns":["comment_post_id","comment_user_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["post_id","user_id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"},{"table":"comments","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (post_id) REFERENCES posts (id)"},{"table":"comments","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"posts","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"user_options","columns":["user_id"],"cardinality":"zero_or_one","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"}],"functions":[{"name":"CustomerLevel","return_type":"varchar","arguments":"credit decimal","type":"FUNCTION"},{"name":"GetAllComments","return_type":"","arguments":"","type":"PROCEDURE"}],"driver":{"name":"mysql","database_version":"8.4.4","meta":{"dict":{"Functions":"Stored procedures and functions"}}},"labels":[{"name":"sample","virtual":true},{"name":"tbls","virtual":true}]}
+{
+  "name": "testdb",
+  "desc": "Sample database document.",
+  "tables": [
+    {
+      "name": "CamelizeTable",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "comment_stars",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment_post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "comment_user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "def": "KEY comment_stars_user_id_fk (comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "def": "KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)",
+          "table": "comment_stars",
+          "referenced_table": "users",
+          "columns": [
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)",
+          "table": "comment_stars",
+          "referenced_table": "comments",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "comments",
+      "type": "BASE TABLE",
+      "comment": "Comments\nMulti-line\r\ntable\rcomment",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": false,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "post_id_desc",
+          "type": "bigint",
+          "nullable": true,
+          "extra_def": "GENERATED ALWAYS AS (`post_id` * -(1)) VIRTUAL"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comments_post_id_user_id_idx",
+          "def": "KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "def": "KEY comments_user_id_fk (user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "def": "UNIQUE KEY post_id (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comments_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (post_id) REFERENCES posts (id)",
+          "table": "comments",
+          "referenced_table": "posts",
+          "columns": [
+            "post_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "comments",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY post_id (post_id, user_id)",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint GENERATED ALWAYS AS ((`post_id` * -(1))) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`),\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"
+    },
+    {
+      "name": "hyphen-table",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "hyphen-column",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "logs",
+      "type": "BASE TABLE",
+      "comment": "Auditログ",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_star_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "payload",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `logs` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"
+    },
+    {
+      "name": "long_long_long_long_long_long_long_long_table_name",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "long_long_long_long_long_long_long_long_table_name",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "long_long_long_long_long_long_long_long_table_name",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `long_long_long_long_long_long_long_long_table_name` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "post_comments",
+      "type": "VIEW",
+      "comment": "post and comments View table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": true,
+          "default": "0",
+          "comment": "comments.id"
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled",
+          "comment": "posts.title"
+        },
+        {
+          "name": "post_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "posts.users.username"
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": true,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "comment_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "comments.users.username"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.created"
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.updated"
+        }
+      ],
+      "def": "CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))",
+      "referenced_tables": [
+        "posts",
+        "comments",
+        "users"
+      ]
+    },
+    {
+      "name": "posts",
+      "type": "BASE TABLE",
+      "comment": "Posts table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled"
+        },
+        {
+          "name": "body",
+          "type": "text",
+          "nullable": false,
+          "comment": "post body"
+        },
+        {
+          "name": "post_type",
+          "type": "enum('public','private','draft')",
+          "nullable": false,
+          "comment": "public/private/draft"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "posts_user_id_idx",
+          "def": "KEY posts_user_id_idx (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, title) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "posts_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "posts",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, title)",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_posts_updated",
+          "def": "CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"
+        }
+      ],
+      "def": "CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'",
+      "labels": [
+        {
+          "name": "green",
+          "virtual": true
+        },
+        {
+          "name": "red",
+          "virtual": true
+        },
+        {
+          "name": "blue",
+          "virtual": true
+        }
+      ]
+    },
+    {
+      "name": "user_options",
+      "type": "BASE TABLE",
+      "comment": "User options table",
+      "columns": [
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "show_email",
+          "type": "tinyint(1)",
+          "nullable": false,
+          "default": "0"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_options_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "user_options",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'"
+    },
+    {
+      "name": "users",
+      "type": "BASE TABLE",
+      "comment": "Users table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "username",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "password",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "email",
+          "type": "varchar(355)",
+          "nullable": false,
+          "comment": "ex. user@example.com"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "email",
+          "def": "UNIQUE KEY email (email) USING BTREE",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "username",
+          "def": "UNIQUE KEY username (username) USING BTREE",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "email",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY email (email)",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "username",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY username (username)",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "users_chk_1",
+          "type": "CHECK",
+          "def": "CHECK ((char_length(`username`) \u003e 4))",
+          "table": "users"
+        }
+      ],
+      "def": "CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`),\n  CONSTRAINT `users_chk_1` CHECK ((char_length(`username`) \u003e 4))\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'"
+    }
+  ],
+  "relations": [
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_post_id",
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "post_id",
+        "user_id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (post_id) REFERENCES posts (id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "posts",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "user_options",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_one",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    }
+  ],
+  "functions": [
+    {
+      "name": "CustomerLevel",
+      "return_type": "varchar",
+      "arguments": "credit decimal",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "GetAllComments",
+      "return_type": "",
+      "arguments": "",
+      "type": "PROCEDURE"
+    }
+  ],
+  "driver": {
+    "name": "mysql",
+    "database_version": "8.4.6",
+    "meta": {
+      "dict": {
+        "Functions": "Stored procedures and functions"
+      }
+    }
+  },
+  "labels": [
+    {
+      "name": "sample",
+      "virtual": true
+    },
+    {
+      "name": "tbls",
+      "virtual": true
+    }
+  ]
+}

--- a/sample/png/schema.json
+++ b/sample/png/schema.json
@@ -1,1 +1,1000 @@
-{"name":"testdb","desc":"Sample database document.","tables":[{"name":"CamelizeTable","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"CamelizeTable","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"CamelizeTable","columns":["id"]}],"def":"CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"comment_stars","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"comment_post_id","type":"bigint","nullable":false},{"name":"comment_user_id","type":"int","nullable":false},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"comment_stars_user_id_fk","def":"KEY comment_stars_user_id_fk (comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_user_id"]},{"name":"comment_stars_user_id_post_id_fk","def":"KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_post_id","comment_user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comment_stars","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"constraints":[{"name":"comment_stars_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)","table":"comment_stars","referenced_table":"users","columns":["comment_user_id"],"referenced_columns":["id"]},{"name":"comment_stars_user_id_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)","table":"comment_stars","referenced_table":"comments","columns":["comment_post_id","comment_user_id"],"referenced_columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comment_stars","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"def":"CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"comments","type":"BASE TABLE","comment":"Comments\nMulti-line\r\ntable\rcomment","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"post_id","type":"bigint","nullable":false},{"name":"user_id","type":"int","nullable":false},{"name":"comment","type":"text","nullable":false,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"post_id_desc","type":"bigint","nullable":true,"extra_def":"GENERATED ALWAYS AS (`post_id` * -(1)) VIRTUAL"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"comments_post_id_user_id_idx","def":"KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]},{"name":"comments_user_id_fk","def":"KEY comments_user_id_fk (user_id) USING BTREE","table":"comments","columns":["user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comments","columns":["id"]},{"name":"post_id","def":"UNIQUE KEY post_id (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]}],"constraints":[{"name":"comments_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (post_id) REFERENCES posts (id)","table":"comments","referenced_table":"posts","columns":["post_id"],"referenced_columns":["id"]},{"name":"comments_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"comments","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"post_id","type":"UNIQUE","def":"UNIQUE KEY post_id (post_id, user_id)","table":"comments","columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comments","columns":["id"]}],"def":"CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint GENERATED ALWAYS AS ((`post_id` * -(1))) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`),\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"},{"name":"hyphen-table","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"hyphen-column","type":"text","nullable":false},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"hyphen-table","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"hyphen-table","columns":["id"]}],"def":"CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"logs","type":"BASE TABLE","comment":"Auditログ","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"post_id","type":"bigint","nullable":true},{"name":"comment_id","type":"bigint","nullable":true},{"name":"comment_star_id","type":"bigint","nullable":true},{"name":"payload","type":"text","nullable":true},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"logs","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"logs","columns":["id"]}],"def":"CREATE TABLE `logs` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"},{"name":"long_long_long_long_long_long_long_long_table_name","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"long_long_long_long_long_long_long_long_table_name","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"long_long_long_long_long_long_long_long_table_name","columns":["id"]}],"def":"CREATE TABLE `long_long_long_long_long_long_long_long_table_name` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"post_comments","type":"VIEW","comment":"post and comments View table","columns":[{"name":"id","type":"bigint","nullable":true,"default":"0","comment":"comments.id"},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled","comment":"posts.title"},{"name":"post_user","type":"varchar(50)","nullable":true,"comment":"posts.users.username"},{"name":"comment","type":"text","nullable":true,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"comment_user","type":"varchar(50)","nullable":true,"comment":"comments.users.username"},{"name":"created","type":"datetime","nullable":true,"comment":"comments.created"},{"name":"updated","type":"datetime","nullable":true,"comment":"comments.updated"}],"def":"CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))","referenced_tables":["posts","comments","users"]},{"name":"posts","type":"BASE TABLE","comment":"Posts table","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled"},{"name":"body","type":"text","nullable":false,"comment":"post body"},{"name":"post_type","type":"enum('public','private','draft')","nullable":false,"comment":"public/private/draft"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"posts_user_id_idx","def":"KEY posts_user_id_idx (id) USING BTREE","table":"posts","columns":["id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"posts","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, title) USING BTREE","table":"posts","columns":["user_id","title"]}],"constraints":[{"name":"posts_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"posts","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"posts","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, title)","table":"posts","columns":["user_id","title"]}],"triggers":[{"name":"update_posts_updated","def":"CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"}],"def":"CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'","labels":[{"name":"green","virtual":true},{"name":"red","virtual":true},{"name":"blue","virtual":true}]},{"name":"user_options","type":"BASE TABLE","comment":"User options table","columns":[{"name":"user_id","type":"int","nullable":false},{"name":"show_email","type":"tinyint(1)","nullable":false,"default":"0"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (user_id) USING BTREE","table":"user_options","columns":["user_id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id) USING BTREE","table":"user_options","columns":["user_id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_options_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"user_options","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]}],"def":"CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'"},{"name":"users","type":"BASE TABLE","comment":"Users table","columns":[{"name":"id","type":"int","nullable":false,"extra_def":"auto_increment"},{"name":"username","type":"varchar(50)","nullable":false},{"name":"password","type":"varchar(50)","nullable":false,"labels":[{"name":"secure","virtual":true},{"name":"encrypted","virtual":true}]},{"name":"email","type":"varchar(355)","nullable":false,"labels":[{"name":"secure","virtual":true}],"comment":"ex. user@example.com"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"users","columns":["id"]},{"name":"email","def":"UNIQUE KEY email (email) USING BTREE","table":"users","columns":["email"]},{"name":"username","def":"UNIQUE KEY username (username) USING BTREE","table":"users","columns":["username"]}],"constraints":[{"name":"email","type":"UNIQUE","def":"UNIQUE KEY email (email)","table":"users","columns":["email"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"users","columns":["id"]},{"name":"username","type":"UNIQUE","def":"UNIQUE KEY username (username)","table":"users","columns":["username"]},{"name":"users_chk_1","type":"CHECK","def":"CHECK ((char_length(`username`) \u003e 4))","table":"users"}],"def":"CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`),\n  CONSTRAINT `users_chk_1` CHECK ((char_length(`username`) \u003e 4))\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'"}],"relations":[{"table":"comment_stars","columns":["comment_user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)"},{"table":"comment_stars","columns":["comment_post_id","comment_user_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["post_id","user_id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"},{"table":"comments","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (post_id) REFERENCES posts (id)"},{"table":"comments","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"posts","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"user_options","columns":["user_id"],"cardinality":"zero_or_one","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"logs","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"logs-\u003eusers","virtual":true},{"table":"logs","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"logs","columns":["comment_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"logs","columns":["comment_star_id"],"cardinality":"exactly_one","parent_table":"comment_stars","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"Additional Relation","virtual":true}],"functions":[{"name":"CustomerLevel","return_type":"varchar","arguments":"credit decimal","type":"FUNCTION"},{"name":"GetAllComments","return_type":"","arguments":"","type":"PROCEDURE"}],"driver":{"name":"mysql","database_version":"8.4.4","meta":{"dict":{"Functions":"Stored procedures and functions"}}},"labels":[{"name":"sample","virtual":true},{"name":"tbls","virtual":true}]}
+{
+  "name": "testdb",
+  "desc": "Sample database document.",
+  "tables": [
+    {
+      "name": "CamelizeTable",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "comment_stars",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment_post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "comment_user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "def": "KEY comment_stars_user_id_fk (comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "def": "KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)",
+          "table": "comment_stars",
+          "referenced_table": "users",
+          "columns": [
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)",
+          "table": "comment_stars",
+          "referenced_table": "comments",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "comments",
+      "type": "BASE TABLE",
+      "comment": "Comments\nMulti-line\r\ntable\rcomment",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": false,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "post_id_desc",
+          "type": "bigint",
+          "nullable": true,
+          "extra_def": "GENERATED ALWAYS AS (`post_id` * -(1)) VIRTUAL"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comments_post_id_user_id_idx",
+          "def": "KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "def": "KEY comments_user_id_fk (user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "def": "UNIQUE KEY post_id (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comments_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (post_id) REFERENCES posts (id)",
+          "table": "comments",
+          "referenced_table": "posts",
+          "columns": [
+            "post_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "comments",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY post_id (post_id, user_id)",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint GENERATED ALWAYS AS ((`post_id` * -(1))) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`),\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'"
+    },
+    {
+      "name": "hyphen-table",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "hyphen-column",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "logs",
+      "type": "BASE TABLE",
+      "comment": "Auditログ",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_star_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "payload",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `logs` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"
+    },
+    {
+      "name": "long_long_long_long_long_long_long_long_table_name",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "long_long_long_long_long_long_long_long_table_name",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "long_long_long_long_long_long_long_long_table_name",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `long_long_long_long_long_long_long_long_table_name` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "post_comments",
+      "type": "VIEW",
+      "comment": "post and comments View table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": true,
+          "default": "0",
+          "comment": "comments.id"
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled",
+          "comment": "posts.title"
+        },
+        {
+          "name": "post_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "posts.users.username"
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": true,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "comment_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "comments.users.username"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.created"
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.updated"
+        }
+      ],
+      "def": "CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))",
+      "referenced_tables": [
+        "posts",
+        "comments",
+        "users"
+      ]
+    },
+    {
+      "name": "posts",
+      "type": "BASE TABLE",
+      "comment": "Posts table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled"
+        },
+        {
+          "name": "body",
+          "type": "text",
+          "nullable": false,
+          "comment": "post body"
+        },
+        {
+          "name": "post_type",
+          "type": "enum('public','private','draft')",
+          "nullable": false,
+          "comment": "public/private/draft"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "posts_user_id_idx",
+          "def": "KEY posts_user_id_idx (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, title) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "posts_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "posts",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, title)",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_posts_updated",
+          "def": "CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"
+        }
+      ],
+      "def": "CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'",
+      "labels": [
+        {
+          "name": "green",
+          "virtual": true
+        },
+        {
+          "name": "red",
+          "virtual": true
+        },
+        {
+          "name": "blue",
+          "virtual": true
+        }
+      ]
+    },
+    {
+      "name": "user_options",
+      "type": "BASE TABLE",
+      "comment": "User options table",
+      "columns": [
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "show_email",
+          "type": "tinyint(1)",
+          "nullable": false,
+          "default": "0"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_options_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "user_options",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'"
+    },
+    {
+      "name": "users",
+      "type": "BASE TABLE",
+      "comment": "Users table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "username",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "password",
+          "type": "varchar(50)",
+          "nullable": false,
+          "labels": [
+            {
+              "name": "secure",
+              "virtual": true
+            },
+            {
+              "name": "encrypted",
+              "virtual": true
+            }
+          ]
+        },
+        {
+          "name": "email",
+          "type": "varchar(355)",
+          "nullable": false,
+          "labels": [
+            {
+              "name": "secure",
+              "virtual": true
+            }
+          ],
+          "comment": "ex. user@example.com"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "email",
+          "def": "UNIQUE KEY email (email) USING BTREE",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "username",
+          "def": "UNIQUE KEY username (username) USING BTREE",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "email",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY email (email)",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "username",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY username (username)",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "users_chk_1",
+          "type": "CHECK",
+          "def": "CHECK ((char_length(`username`) \u003e 4))",
+          "table": "users"
+        }
+      ],
+      "def": "CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`),\n  CONSTRAINT `users_chk_1` CHECK ((char_length(`username`) \u003e 4))\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'"
+    }
+  ],
+  "relations": [
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_post_id",
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "post_id",
+        "user_id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (post_id) REFERENCES posts (id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "posts",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "user_options",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_one",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "logs-\u003eusers",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "comment_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "comment_star_id"
+      ],
+      "cardinality": "exactly_one",
+      "parent_table": "comment_stars",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "Additional Relation",
+      "virtual": true
+    }
+  ],
+  "functions": [
+    {
+      "name": "CustomerLevel",
+      "return_type": "varchar",
+      "arguments": "credit decimal",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "GetAllComments",
+      "return_type": "",
+      "arguments": "",
+      "type": "PROCEDURE"
+    }
+  ],
+  "driver": {
+    "name": "mysql",
+    "database_version": "8.4.6",
+    "meta": {
+      "dict": {
+        "Functions": "Stored procedures and functions"
+      }
+    }
+  },
+  "labels": [
+    {
+      "name": "sample",
+      "virtual": true
+    },
+    {
+      "name": "tbls",
+      "virtual": true
+    }
+  ]
+}

--- a/sample/postgres/schema.json
+++ b/sample/postgres/schema.json
@@ -1,1 +1,1405 @@
-{"name":"testdb","desc":"Sample PostgreSQL database document.","tables":[{"name":"public.users","type":"BASE TABLE","comment":"Users table","columns":[{"name":"id","type":"integer","nullable":false,"default":"nextval('users_id_seq'::regclass)"},{"name":"username","type":"varchar(50)","nullable":false},{"name":"password","type":"varchar(50)","nullable":false},{"name":"email","type":"varchar(355)","nullable":false,"comment":"ex. user@example.com"},{"name":"created","type":"timestamp without time zone","nullable":false},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"users_pkey","def":"CREATE UNIQUE INDEX users_pkey ON public.users USING btree (id)","table":"public.users","columns":["id"]},{"name":"users_username_key","def":"CREATE UNIQUE INDEX users_username_key ON public.users USING btree (username)","table":"public.users","columns":["username"]},{"name":"users_email_key","def":"CREATE UNIQUE INDEX users_email_key ON public.users USING btree (email)","table":"public.users","columns":["email"]}],"constraints":[{"name":"users_username_check","type":"CHECK","def":"CHECK ((char_length((username)::text) \u003e 4))","table":"public.users","referenced_table":"","columns":["username"]},{"name":"users_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"public.users","referenced_table":"","columns":["id"]},{"name":"users_username_key","type":"UNIQUE","def":"UNIQUE (username)","table":"public.users","referenced_table":"","columns":["username"]},{"name":"users_email_key","type":"UNIQUE","def":"UNIQUE (email)","table":"public.users","referenced_table":"","columns":["email"]}],"triggers":[{"name":"update_users_updated","def":"CREATE TRIGGER update_users_updated AFTER INSERT OR UPDATE ON public.users FOR EACH ROW EXECUTE FUNCTION update_updated()","comment":"Update updated when users insert or update"}]},{"name":"public.user_options","type":"BASE TABLE","comment":"User options table","columns":[{"name":"user_id","type":"integer","nullable":false},{"name":"show_email","type":"boolean","nullable":false,"default":"false"},{"name":"created","type":"timestamp without time zone","nullable":false},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"user_options_pkey","def":"CREATE UNIQUE INDEX user_options_pkey ON public.user_options USING btree (user_id)","table":"public.user_options","columns":["user_id"],"comment":"PRIMARY KEY"}],"constraints":[{"name":"user_options_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE","table":"public.user_options","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"],"comment":"FK"},{"name":"user_options_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (user_id)","table":"public.user_options","referenced_table":"","columns":["user_id"]}]},{"name":"public.posts","type":"BASE TABLE","comment":"Posts table","columns":[{"name":"id","type":"bigint","nullable":false,"default":"nextval('posts_id_seq'::regclass)"},{"name":"user_id","type":"integer","nullable":false},{"name":"title","type":"varchar(255)","nullable":false,"default":"'Untitled'::character varying"},{"name":"body","type":"text","nullable":false,"comment":"post body"},{"name":"post_type","type":"post_types","nullable":false,"comment":"public/private/draft"},{"name":"labels","type":"varchar(50)[]","nullable":true},{"name":"created","type":"timestamp without time zone","nullable":false},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"posts_id_pk","def":"CREATE UNIQUE INDEX posts_id_pk ON public.posts USING btree (id)","table":"public.posts","columns":["id"]},{"name":"posts_user_id_title_key","def":"CREATE UNIQUE INDEX posts_user_id_title_key ON public.posts USING btree (user_id, title)","table":"public.posts","columns":["user_id","title"]},{"name":"posts_user_id_idx","def":"CREATE INDEX posts_user_id_idx ON public.posts USING btree (user_id)","table":"public.posts","columns":["user_id"],"comment":"posts.user_id index"}],"constraints":[{"name":"update_posts_updated","type":"TRIGGER","def":"CREATE CONSTRAINT TRIGGER update_posts_updated AFTER INSERT OR UPDATE ON public.posts NOT DEFERRABLE INITIALLY IMMEDIATE FOR EACH ROW EXECUTE FUNCTION update_updated()","table":"public.posts","referenced_table":"","columns":["tableoid","cmax","xmax","cmin","xmin","ctid","id","user_id","title","body","post_type","labels","created","updated"]},{"name":"posts_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL (user_id)","table":"public.posts","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"],"comment":"posts -\u003e users"},{"name":"posts_id_pk","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"public.posts","referenced_table":"","columns":["id"]},{"name":"posts_user_id_title_key","type":"UNIQUE","def":"UNIQUE (user_id, title)","table":"public.posts","referenced_table":"","columns":["user_id","title"]}],"triggers":[{"name":"update_posts_updated","def":"CREATE CONSTRAINT TRIGGER update_posts_updated AFTER INSERT OR UPDATE ON public.posts NOT DEFERRABLE INITIALLY IMMEDIATE FOR EACH ROW EXECUTE FUNCTION update_updated()","comment":"Update updated when posts update"}]},{"name":"public.comments","type":"BASE TABLE","comment":"Comments\nMulti-line\r\ntable\rcomment","columns":[{"name":"id","type":"bigint","nullable":false,"default":"nextval('comments_id_seq'::regclass)"},{"name":"post_id","type":"bigint","nullable":false},{"name":"user_id","type":"integer","nullable":false},{"name":"comment","type":"text","nullable":false,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"post_id_desc","type":"bigint","nullable":true,"extra_def":"GENERATED ALWAYS AS (post_id * '-1'::integer) STORED"},{"name":"created","type":"timestamp without time zone","nullable":false},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"comments_id_pk","def":"CREATE UNIQUE INDEX comments_id_pk ON public.comments USING btree (id)","table":"public.comments","columns":["id"]},{"name":"comments_post_id_user_id_key","def":"CREATE UNIQUE INDEX comments_post_id_user_id_key ON public.comments USING btree (post_id, user_id)","table":"public.comments","columns":["post_id","user_id"]},{"name":"comments_post_id_user_id_idx","def":"CREATE INDEX comments_post_id_user_id_idx ON public.comments USING btree (post_id, user_id)","table":"public.comments","columns":["post_id","user_id"]}],"constraints":[{"name":"comments_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users(id)","table":"public.comments","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"comments_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (post_id) REFERENCES posts(id)","table":"public.comments","referenced_table":"posts","columns":["post_id"],"referenced_columns":["id"]},{"name":"comments_id_pk","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"public.comments","referenced_table":"","columns":["id"]},{"name":"comments_post_id_user_id_key","type":"UNIQUE","def":"UNIQUE (post_id, user_id)","table":"public.comments","referenced_table":"","columns":["post_id","user_id"]}]},{"name":"public.comment_stars","type":"BASE TABLE","columns":[{"name":"id","type":"uuid","nullable":false,"default":"uuid_generate_v4()"},{"name":"user_id","type":"integer","nullable":false},{"name":"comment_post_id","type":"bigint","nullable":false},{"name":"comment_user_id","type":"integer","nullable":false},{"name":"created","type":"timestamp without time zone","nullable":false},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"comment_stars_user_id_comment_post_id_comment_user_id_key","def":"CREATE UNIQUE INDEX comment_stars_user_id_comment_post_id_comment_user_id_key ON public.comment_stars USING btree (user_id, comment_post_id, comment_user_id)","table":"public.comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"constraints":[{"name":"comment_stars_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_user_id) REFERENCES users(id)","table":"public.comment_stars","referenced_table":"users","columns":["comment_user_id"],"referenced_columns":["id"]},{"name":"comment_stars_user_id_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments(post_id, user_id)","table":"public.comment_stars","referenced_table":"comments","columns":["comment_post_id","comment_post_id","comment_user_id","comment_user_id"],"referenced_columns":["post_id","user_id","post_id","user_id"]},{"name":"comment_stars_user_id_comment_post_id_comment_user_id_key","type":"UNIQUE","def":"UNIQUE (user_id, comment_post_id, comment_user_id)","table":"public.comment_stars","referenced_table":"","columns":["user_id","comment_post_id","comment_user_id"]}]},{"name":"public.logs","type":"BASE TABLE","comment":"audit log table","columns":[{"name":"id","type":"uuid","nullable":false,"default":"uuid_generate_v4()"},{"name":"user_id","type":"integer","nullable":false},{"name":"post_id","type":"bigint","nullable":true},{"name":"comment_id","type":"bigint","nullable":true},{"name":"comment_star_id","type":"uuid","nullable":true},{"name":"payload","type":"text","nullable":true},{"name":"created","type":"timestamp without time zone","nullable":false}]},{"name":"public.post_comments","type":"VIEW","comment":"post and comments View table","columns":[{"name":"id","type":"bigint","nullable":true,"comment":"comments.id"},{"name":"title","type":"varchar(255)","nullable":true,"comment":"posts.title"},{"name":"post_user","type":"varchar(50)","nullable":true,"comment":"posts.users.username"},{"name":"comment","type":"text","nullable":true},{"name":"comment_user","type":"varchar(50)","nullable":true,"comment":"comments.users.username"},{"name":"created","type":"timestamp without time zone","nullable":true,"comment":"comments.created"},{"name":"updated","type":"timestamp without time zone","nullable":true,"comment":"comments.updated"}],"def":"CREATE VIEW post_comments AS (\n SELECT c.id,\n    p.title,\n    u.username AS post_user,\n    c.comment,\n    u2.username AS comment_user,\n    c.created,\n    c.updated\n   FROM (((posts p\n     LEFT JOIN comments c ON ((p.id = c.post_id)))\n     LEFT JOIN users u ON ((u.id = p.user_id)))\n     LEFT JOIN users u2 ON ((u2.id = c.user_id)))\n)","referenced_tables":["public.posts","public.comments","public.users"]},{"name":"public.post_comment_stars","type":"MATERIALIZED VIEW","columns":[{"name":"id","type":"uuid","nullable":true},{"name":"comment_user","type":"varchar(50)","nullable":true},{"name":"comment_star_user","type":"varchar(50)","nullable":true},{"name":"created","type":"timestamp without time zone","nullable":true},{"name":"updated","type":"timestamp without time zone","nullable":true}],"def":"CREATE MATERIALIZED VIEW post_comment_stars AS (\n SELECT cs.id,\n    cu.username AS comment_user,\n    csu.username AS comment_star_user,\n    cs.created,\n    cs.updated\n   FROM (((comments c\n     LEFT JOIN comment_stars cs ON (((cs.comment_post_id = c.id) AND (cs.comment_user_id = c.user_id))))\n     LEFT JOIN users cu ON ((cu.id = cs.comment_user_id)))\n     LEFT JOIN users csu ON ((csu.id = cs.user_id)))\n)","referenced_tables":["public.comments","public.comment_stars","public.users"]},{"name":"public.CamelizeTable","type":"BASE TABLE","columns":[{"name":"id","type":"uuid","nullable":false,"default":"uuid_generate_v4()"},{"name":"created","type":"timestamp without time zone","nullable":false}],"indexes":[{"name":"CamelizeTable_id_key","def":"CREATE UNIQUE INDEX \"CamelizeTable_id_key\" ON public.\"CamelizeTable\" USING btree (id)","table":"public.CamelizeTable","columns":["id"]}],"constraints":[{"name":"CamelizeTable_id_key","type":"UNIQUE","def":"UNIQUE (id)","table":"public.CamelizeTable","referenced_table":"","columns":["id"]}]},{"name":"public.hyphen-table","type":"BASE TABLE","columns":[{"name":"id","type":"uuid","nullable":false,"default":"uuid_generate_v4()"},{"name":"hyphen-column","type":"text","nullable":false},{"name":"CamelizeTableId","type":"uuid","nullable":false},{"name":"created","type":"timestamp without time zone","nullable":false}],"indexes":[{"name":"hyphen-table_hyphen-column_key","def":"CREATE UNIQUE INDEX \"hyphen-table_hyphen-column_key\" ON public.\"hyphen-table\" USING btree (\"hyphen-column\")","table":"public.hyphen-table","columns":["hyphen-column"]}],"constraints":[{"name":"hyphen-table_CamelizeTableId_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (\"CamelizeTableId\") REFERENCES \"CamelizeTable\"(id) ON DELETE CASCADE","table":"public.hyphen-table","referenced_table":"CamelizeTable","columns":["CamelizeTableId"],"referenced_columns":["id"]},{"name":"hyphen-table_hyphen-column_key","type":"UNIQUE","def":"UNIQUE (\"hyphen-column\")","table":"public.hyphen-table","referenced_table":"","columns":["hyphen-column"]}]},{"name":"administrator.blogs","type":"BASE TABLE","comment":"admin blogs","columns":[{"name":"id","type":"integer","nullable":false,"default":"nextval('administrator.blogs_id_seq'::regclass)"},{"name":"user_id","type":"integer","nullable":false},{"name":"name","type":"text","nullable":false},{"name":"description","type":"text","nullable":true},{"name":"created","type":"timestamp without time zone","nullable":false},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"blogs_pkey","def":"CREATE UNIQUE INDEX blogs_pkey ON administrator.blogs USING btree (id)","table":"administrator.blogs","columns":["id"]}],"constraints":[{"name":"blogs_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE","table":"administrator.blogs","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"blogs_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"administrator.blogs","referenced_table":"","columns":["id"]}]},{"name":"backup.blogs","type":"BASE TABLE","columns":[{"name":"id","type":"integer","nullable":false,"default":"nextval('blogs_id_seq'::regclass)"},{"name":"user_id","type":"integer","nullable":false},{"name":"dump","type":"text","nullable":false},{"name":"created","type":"timestamp without time zone","nullable":false},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"blogs_pkey","def":"CREATE UNIQUE INDEX blogs_pkey ON backup.blogs USING btree (id)","table":"backup.blogs","columns":["id"]}],"constraints":[{"name":"blogs_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"backup.blogs","referenced_table":"","columns":["id"]}]},{"name":"backup.blog_options","type":"BASE TABLE","columns":[{"name":"id","type":"integer","nullable":false,"default":"nextval('blog_options_id_seq'::regclass)"},{"name":"blog_id","type":"integer","nullable":false},{"name":"label","type":"text","nullable":true},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"blog_options_pkey","def":"CREATE UNIQUE INDEX blog_options_pkey ON backup.blog_options USING btree (id)","table":"backup.blog_options","columns":["id"]}],"constraints":[{"name":"blog_options_blog_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (blog_id) REFERENCES blogs(id) ON DELETE CASCADE","table":"backup.blog_options","referenced_table":"blogs","columns":["blog_id"],"referenced_columns":["id"]},{"name":"blog_options_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"backup.blog_options","referenced_table":"","columns":["id"]}]},{"name":"time.bar","type":"BASE TABLE","columns":[{"name":"id","type":"integer","nullable":false}],"indexes":[{"name":"bar_pkey","def":"CREATE UNIQUE INDEX bar_pkey ON \"time\".bar USING btree (id)","table":"time.bar","columns":["id"]}],"constraints":[{"name":"bar_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"time.bar","referenced_table":"","columns":["id"]}]},{"name":"time.hyphenated-table","type":"BASE TABLE","columns":[{"name":"id","type":"integer","nullable":false}],"indexes":[{"name":"hyphenated-table_pkey","def":"CREATE UNIQUE INDEX \"hyphenated-table_pkey\" ON \"time\".\"hyphenated-table\" USING btree (id)","table":"time.hyphenated-table","columns":["id"]}],"constraints":[{"name":"hyphenated-table_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"time.hyphenated-table","referenced_table":"","columns":["id"]}]},{"name":"time.referencing","type":"BASE TABLE","columns":[{"name":"id","type":"integer","nullable":false},{"name":"bar_id","type":"integer","nullable":false},{"name":"ht_id","type":"integer","nullable":false}],"indexes":[{"name":"referencing_pkey","def":"CREATE UNIQUE INDEX referencing_pkey ON \"time\".referencing USING btree (id)","table":"time.referencing","columns":["id"]}],"constraints":[{"name":"referencing_bar_id","type":"FOREIGN KEY","def":"FOREIGN KEY (bar_id) REFERENCES \"time\".bar(id)","table":"time.referencing","referenced_table":"bar","columns":["bar_id"],"referenced_columns":["id"]},{"name":"referencing_ht_id","type":"FOREIGN KEY","def":"FOREIGN KEY (ht_id) REFERENCES \"time\".\"hyphenated-table\"(id)","table":"time.referencing","referenced_table":"hyphenated-table","columns":["ht_id"],"referenced_columns":["id"]},{"name":"referencing_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"time.referencing","referenced_table":"","columns":["id"]}]}],"relations":[{"table":"public.user_options","columns":["user_id"],"cardinality":"zero_or_one","parent_table":"public.users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"},{"table":"public.posts","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"public.users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL (user_id)"},{"table":"public.comments","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"public.users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users(id)"},{"table":"public.comments","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"public.posts","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (post_id) REFERENCES posts(id)"},{"table":"public.comment_stars","columns":["comment_user_id"],"cardinality":"zero_or_more","parent_table":"public.users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_user_id) REFERENCES users(id)"},{"table":"public.comment_stars","columns":["comment_post_id","comment_user_id"],"cardinality":"zero_or_more","parent_table":"public.comments","parent_columns":["post_id","user_id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments(post_id, user_id)"},{"table":"public.hyphen-table","columns":["CamelizeTableId"],"cardinality":"zero_or_more","parent_table":"public.CamelizeTable","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (\"CamelizeTableId\") REFERENCES \"CamelizeTable\"(id) ON DELETE CASCADE"},{"table":"administrator.blogs","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"public.users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"},{"table":"backup.blog_options","columns":["blog_id"],"cardinality":"zero_or_more","parent_table":"backup.blogs","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (blog_id) REFERENCES blogs(id) ON DELETE CASCADE"},{"table":"time.referencing","columns":["bar_id"],"cardinality":"zero_or_more","parent_table":"time.bar","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (bar_id) REFERENCES \"time\".bar(id)"},{"table":"time.referencing","columns":["ht_id"],"cardinality":"zero_or_more","parent_table":"time.hyphenated-table","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (ht_id) REFERENCES \"time\".\"hyphenated-table\"(id)"},{"table":"public.logs","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"public.users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"logs-\u003eusers","virtual":true},{"table":"public.logs","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"public.posts","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"public.logs","columns":["comment_id"],"cardinality":"zero_or_more","parent_table":"public.comments","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"public.logs","columns":["comment_star_id"],"cardinality":"zero_or_more","parent_table":"public.comment_stars","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true}],"functions":[{"name":"public.uuid_nil","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_ns_dns","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_ns_url","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_ns_oid","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_ns_x500","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_generate_v1","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_generate_v1mc","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_generate_v3","return_type":"uuid","arguments":"namespace uuid, name text","type":"FUNCTION"},{"name":"public.uuid_generate_v4","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_generate_v5","return_type":"uuid","arguments":"namespace uuid, name text","type":"FUNCTION"},{"name":"public.update_updated","return_type":"trigger","arguments":"","type":"FUNCTION"},{"name":"public.reset_comment","return_type":"void","arguments":"IN comment_id integer","type":"PROCEDURE"}],"enums":[{"name":"public.post_types","values":["draft","private","public"]}],"driver":{"name":"postgres","database_version":"PostgreSQL 15.10 (Debian 15.10-1.pgdg120+1) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit","meta":{"current_schema":"public","search_paths":["postgres","public","backup"],"dict":{"Functions":"Stored procedures and functions"}}},"viewpoints":[{"name":"post","desc":"for post","tables":["public.post*"]},{"name":"administrator","desc":"administrator schema only","tables":["administrator.*"]}]}
+{
+  "name": "testdb",
+  "desc": "Sample PostgreSQL database document.",
+  "tables": [
+    {
+      "name": "public.users",
+      "type": "BASE TABLE",
+      "comment": "Users table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('users_id_seq'::regclass)"
+        },
+        {
+          "name": "username",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "password",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "email",
+          "type": "varchar(355)",
+          "nullable": false,
+          "comment": "ex. user@example.com"
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "users_pkey",
+          "def": "CREATE UNIQUE INDEX users_pkey ON public.users USING btree (id)",
+          "table": "public.users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "users_username_key",
+          "def": "CREATE UNIQUE INDEX users_username_key ON public.users USING btree (username)",
+          "table": "public.users",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "users_email_key",
+          "def": "CREATE UNIQUE INDEX users_email_key ON public.users USING btree (email)",
+          "table": "public.users",
+          "columns": [
+            "email"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "users_username_check",
+          "type": "CHECK",
+          "def": "CHECK ((char_length((username)::text) \u003e 4))",
+          "table": "public.users",
+          "referenced_table": "",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "users_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "public.users",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "users_username_key",
+          "type": "UNIQUE",
+          "def": "UNIQUE (username)",
+          "table": "public.users",
+          "referenced_table": "",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "users_email_key",
+          "type": "UNIQUE",
+          "def": "UNIQUE (email)",
+          "table": "public.users",
+          "referenced_table": "",
+          "columns": [
+            "email"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_users_updated",
+          "def": "CREATE TRIGGER update_users_updated AFTER INSERT OR UPDATE ON public.users FOR EACH ROW EXECUTE FUNCTION update_updated()",
+          "comment": "Update updated when users insert or update"
+        }
+      ]
+    },
+    {
+      "name": "public.user_options",
+      "type": "BASE TABLE",
+      "comment": "User options table",
+      "columns": [
+        {
+          "name": "user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "show_email",
+          "type": "boolean",
+          "nullable": false,
+          "default": "false"
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "user_options_pkey",
+          "def": "CREATE UNIQUE INDEX user_options_pkey ON public.user_options USING btree (user_id)",
+          "table": "public.user_options",
+          "columns": [
+            "user_id"
+          ],
+          "comment": "PRIMARY KEY"
+        }
+      ],
+      "constraints": [
+        {
+          "name": "user_options_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE",
+          "table": "public.user_options",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ],
+          "comment": "FK"
+        },
+        {
+          "name": "user_options_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (user_id)",
+          "table": "public.user_options",
+          "referenced_table": "",
+          "columns": [
+            "user_id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "public.posts",
+      "type": "BASE TABLE",
+      "comment": "Posts table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "default": "nextval('posts_id_seq'::regclass)"
+        },
+        {
+          "name": "user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "'Untitled'::character varying"
+        },
+        {
+          "name": "body",
+          "type": "text",
+          "nullable": false,
+          "comment": "post body"
+        },
+        {
+          "name": "post_type",
+          "type": "post_types",
+          "nullable": false,
+          "comment": "public/private/draft"
+        },
+        {
+          "name": "labels",
+          "type": "varchar(50)[]",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "posts_id_pk",
+          "def": "CREATE UNIQUE INDEX posts_id_pk ON public.posts USING btree (id)",
+          "table": "public.posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "posts_user_id_title_key",
+          "def": "CREATE UNIQUE INDEX posts_user_id_title_key ON public.posts USING btree (user_id, title)",
+          "table": "public.posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        },
+        {
+          "name": "posts_user_id_idx",
+          "def": "CREATE INDEX posts_user_id_idx ON public.posts USING btree (user_id)",
+          "table": "public.posts",
+          "columns": [
+            "user_id"
+          ],
+          "comment": "posts.user_id index"
+        }
+      ],
+      "constraints": [
+        {
+          "name": "update_posts_updated",
+          "type": "TRIGGER",
+          "def": "CREATE CONSTRAINT TRIGGER update_posts_updated AFTER INSERT OR UPDATE ON public.posts NOT DEFERRABLE INITIALLY IMMEDIATE FOR EACH ROW EXECUTE FUNCTION update_updated()",
+          "table": "public.posts",
+          "referenced_table": ""
+        },
+        {
+          "name": "posts_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL (user_id)",
+          "table": "public.posts",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ],
+          "comment": "posts -\u003e users"
+        },
+        {
+          "name": "posts_id_pk",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "public.posts",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "posts_user_id_title_key",
+          "type": "UNIQUE",
+          "def": "UNIQUE (user_id, title)",
+          "table": "public.posts",
+          "referenced_table": "",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_posts_updated",
+          "def": "CREATE CONSTRAINT TRIGGER update_posts_updated AFTER INSERT OR UPDATE ON public.posts NOT DEFERRABLE INITIALLY IMMEDIATE FOR EACH ROW EXECUTE FUNCTION update_updated()",
+          "comment": "Update updated when posts update"
+        }
+      ]
+    },
+    {
+      "name": "public.comments",
+      "type": "BASE TABLE",
+      "comment": "Comments\nMulti-line\r\ntable\rcomment",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "default": "nextval('comments_id_seq'::regclass)"
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": false,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "post_id_desc",
+          "type": "bigint",
+          "nullable": true,
+          "extra_def": "GENERATED ALWAYS AS (post_id * '-1'::integer) STORED"
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comments_id_pk",
+          "def": "CREATE UNIQUE INDEX comments_id_pk ON public.comments USING btree (id)",
+          "table": "public.comments",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_post_id_user_id_key",
+          "def": "CREATE UNIQUE INDEX comments_post_id_user_id_key ON public.comments USING btree (post_id, user_id)",
+          "table": "public.comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "comments_post_id_user_id_idx",
+          "def": "CREATE INDEX comments_post_id_user_id_idx ON public.comments USING btree (post_id, user_id)",
+          "table": "public.comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comments_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users(id)",
+          "table": "public.comments",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (post_id) REFERENCES posts(id)",
+          "table": "public.comments",
+          "referenced_table": "posts",
+          "columns": [
+            "post_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_id_pk",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "public.comments",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_post_id_user_id_key",
+          "type": "UNIQUE",
+          "def": "UNIQUE (post_id, user_id)",
+          "table": "public.comments",
+          "referenced_table": "",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "public.comment_stars",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "uuid",
+          "nullable": false,
+          "default": "uuid_generate_v4()"
+        },
+        {
+          "name": "user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "comment_post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "comment_user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comment_stars_user_id_comment_post_id_comment_user_id_key",
+          "def": "CREATE UNIQUE INDEX comment_stars_user_id_comment_post_id_comment_user_id_key ON public.comment_stars USING btree (user_id, comment_post_id, comment_user_id)",
+          "table": "public.comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_user_id) REFERENCES users(id)",
+          "table": "public.comment_stars",
+          "referenced_table": "users",
+          "columns": [
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments(post_id, user_id)",
+          "table": "public.comment_stars",
+          "referenced_table": "comments",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_comment_post_id_comment_user_id_key",
+          "type": "UNIQUE",
+          "def": "UNIQUE (user_id, comment_post_id, comment_user_id)",
+          "table": "public.comment_stars",
+          "referenced_table": "",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "public.logs",
+      "type": "BASE TABLE",
+      "comment": "audit log table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "uuid",
+          "nullable": false,
+          "default": "uuid_generate_v4()"
+        },
+        {
+          "name": "user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_star_id",
+          "type": "uuid",
+          "nullable": true
+        },
+        {
+          "name": "payload",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        }
+      ]
+    },
+    {
+      "name": "public.post_comments",
+      "type": "VIEW",
+      "comment": "post and comments View table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": true,
+          "comment": "comments.id"
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": true,
+          "comment": "posts.title"
+        },
+        {
+          "name": "post_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "posts.users.username"
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "comment_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "comments.users.username"
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": true,
+          "comment": "comments.created"
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true,
+          "comment": "comments.updated"
+        }
+      ],
+      "def": "CREATE VIEW post_comments AS (\n SELECT c.id,\n    p.title,\n    u.username AS post_user,\n    c.comment,\n    u2.username AS comment_user,\n    c.created,\n    c.updated\n   FROM (((posts p\n     LEFT JOIN comments c ON ((p.id = c.post_id)))\n     LEFT JOIN users u ON ((u.id = p.user_id)))\n     LEFT JOIN users u2 ON ((u2.id = c.user_id)))\n)",
+      "referenced_tables": [
+        "public.posts",
+        "public.comments",
+        "public.users"
+      ]
+    },
+    {
+      "name": "public.post_comment_stars",
+      "type": "MATERIALIZED VIEW",
+      "columns": [
+        {
+          "name": "id",
+          "type": "uuid",
+          "nullable": true
+        },
+        {
+          "name": "comment_user",
+          "type": "varchar(50)",
+          "nullable": true
+        },
+        {
+          "name": "comment_star_user",
+          "type": "varchar(50)",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": true
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "def": "CREATE MATERIALIZED VIEW post_comment_stars AS (\n SELECT cs.id,\n    cu.username AS comment_user,\n    csu.username AS comment_star_user,\n    cs.created,\n    cs.updated\n   FROM (((comments c\n     LEFT JOIN comment_stars cs ON (((cs.comment_post_id = c.id) AND (cs.comment_user_id = c.user_id))))\n     LEFT JOIN users cu ON ((cu.id = cs.comment_user_id)))\n     LEFT JOIN users csu ON ((csu.id = cs.user_id)))\n)",
+      "referenced_tables": [
+        "public.comments",
+        "public.comment_stars",
+        "public.users"
+      ]
+    },
+    {
+      "name": "public.CamelizeTable",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "uuid",
+          "nullable": false,
+          "default": "uuid_generate_v4()"
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "CamelizeTable_id_key",
+          "def": "CREATE UNIQUE INDEX \"CamelizeTable_id_key\" ON public.\"CamelizeTable\" USING btree (id)",
+          "table": "public.CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "CamelizeTable_id_key",
+          "type": "UNIQUE",
+          "def": "UNIQUE (id)",
+          "table": "public.CamelizeTable",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "public.hyphen-table",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "uuid",
+          "nullable": false,
+          "default": "uuid_generate_v4()"
+        },
+        {
+          "name": "hyphen-column",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "CamelizeTableId",
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "hyphen-table_hyphen-column_key",
+          "def": "CREATE UNIQUE INDEX \"hyphen-table_hyphen-column_key\" ON public.\"hyphen-table\" USING btree (\"hyphen-column\")",
+          "table": "public.hyphen-table",
+          "columns": [
+            "hyphen-column"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "hyphen-table_CamelizeTableId_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (\"CamelizeTableId\") REFERENCES \"CamelizeTable\"(id) ON DELETE CASCADE",
+          "table": "public.hyphen-table",
+          "referenced_table": "CamelizeTable",
+          "columns": [
+            "CamelizeTableId"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "hyphen-table_hyphen-column_key",
+          "type": "UNIQUE",
+          "def": "UNIQUE (\"hyphen-column\")",
+          "table": "public.hyphen-table",
+          "referenced_table": "",
+          "columns": [
+            "hyphen-column"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "administrator.blogs",
+      "type": "BASE TABLE",
+      "comment": "admin blogs",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('administrator.blogs_id_seq'::regclass)"
+        },
+        {
+          "name": "user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "name",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "description",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "blogs_pkey",
+          "def": "CREATE UNIQUE INDEX blogs_pkey ON administrator.blogs USING btree (id)",
+          "table": "administrator.blogs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "blogs_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE",
+          "table": "administrator.blogs",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "blogs_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "administrator.blogs",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "backup.blogs",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('blogs_id_seq'::regclass)"
+        },
+        {
+          "name": "user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "dump",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "blogs_pkey",
+          "def": "CREATE UNIQUE INDEX blogs_pkey ON backup.blogs USING btree (id)",
+          "table": "backup.blogs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "blogs_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "backup.blogs",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "backup.blog_options",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('blog_options_id_seq'::regclass)"
+        },
+        {
+          "name": "blog_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "label",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "blog_options_pkey",
+          "def": "CREATE UNIQUE INDEX blog_options_pkey ON backup.blog_options USING btree (id)",
+          "table": "backup.blog_options",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "blog_options_blog_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (blog_id) REFERENCES blogs(id) ON DELETE CASCADE",
+          "table": "backup.blog_options",
+          "referenced_table": "blogs",
+          "columns": [
+            "blog_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "blog_options_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "backup.blog_options",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "time.bar",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "bar_pkey",
+          "def": "CREATE UNIQUE INDEX bar_pkey ON \"time\".bar USING btree (id)",
+          "table": "time.bar",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "bar_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "time.bar",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "time.hyphenated-table",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "hyphenated-table_pkey",
+          "def": "CREATE UNIQUE INDEX \"hyphenated-table_pkey\" ON \"time\".\"hyphenated-table\" USING btree (id)",
+          "table": "time.hyphenated-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "hyphenated-table_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "time.hyphenated-table",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "time.referencing",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "bar_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "ht_id",
+          "type": "integer",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "referencing_pkey",
+          "def": "CREATE UNIQUE INDEX referencing_pkey ON \"time\".referencing USING btree (id)",
+          "table": "time.referencing",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "referencing_bar_id",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (bar_id) REFERENCES \"time\".bar(id)",
+          "table": "time.referencing",
+          "referenced_table": "bar",
+          "columns": [
+            "bar_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "referencing_ht_id",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (ht_id) REFERENCES \"time\".\"hyphenated-table\"(id)",
+          "table": "time.referencing",
+          "referenced_table": "hyphenated-table",
+          "columns": [
+            "ht_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "referencing_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "time.referencing",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    }
+  ],
+  "relations": [
+    {
+      "table": "public.user_options",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_one",
+      "parent_table": "public.users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"
+    },
+    {
+      "table": "public.posts",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL (user_id)"
+    },
+    {
+      "table": "public.comments",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users(id)"
+    },
+    {
+      "table": "public.comments",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (post_id) REFERENCES posts(id)"
+    },
+    {
+      "table": "public.comment_stars",
+      "columns": [
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_user_id) REFERENCES users(id)"
+    },
+    {
+      "table": "public.comment_stars",
+      "columns": [
+        "comment_post_id",
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.comments",
+      "parent_columns": [
+        "post_id",
+        "user_id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments(post_id, user_id)"
+    },
+    {
+      "table": "public.hyphen-table",
+      "columns": [
+        "CamelizeTableId"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.CamelizeTable",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (\"CamelizeTableId\") REFERENCES \"CamelizeTable\"(id) ON DELETE CASCADE"
+    },
+    {
+      "table": "administrator.blogs",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"
+    },
+    {
+      "table": "backup.blog_options",
+      "columns": [
+        "blog_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "backup.blogs",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (blog_id) REFERENCES blogs(id) ON DELETE CASCADE"
+    },
+    {
+      "table": "time.referencing",
+      "columns": [
+        "bar_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "time.bar",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (bar_id) REFERENCES \"time\".bar(id)"
+    },
+    {
+      "table": "time.referencing",
+      "columns": [
+        "ht_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "time.hyphenated-table",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (ht_id) REFERENCES \"time\".\"hyphenated-table\"(id)"
+    },
+    {
+      "table": "public.logs",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "logs-\u003eusers",
+      "virtual": true
+    },
+    {
+      "table": "public.logs",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "public.logs",
+      "columns": [
+        "comment_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.comments",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "public.logs",
+      "columns": [
+        "comment_star_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.comment_stars",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    }
+  ],
+  "functions": [
+    {
+      "name": "public.uuid_nil",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_ns_dns",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_ns_url",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_ns_oid",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_ns_x500",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_generate_v1",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_generate_v1mc",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_generate_v3",
+      "return_type": "uuid",
+      "arguments": "namespace uuid, name text",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_generate_v4",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_generate_v5",
+      "return_type": "uuid",
+      "arguments": "namespace uuid, name text",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.update_updated",
+      "return_type": "trigger",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.reset_comment",
+      "return_type": "void",
+      "arguments": "IN comment_id integer",
+      "type": "PROCEDURE"
+    }
+  ],
+  "enums": [
+    {
+      "name": "public.post_types",
+      "values": [
+        "draft",
+        "private",
+        "public"
+      ]
+    }
+  ],
+  "driver": {
+    "name": "postgres",
+    "database_version": "PostgreSQL 15.13 (Debian 15.13-1.pgdg120+1) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit",
+    "meta": {
+      "current_schema": "public",
+      "search_paths": [
+        "postgres",
+        "public",
+        "backup"
+      ],
+      "dict": {
+        "Functions": "Stored procedures and functions"
+      }
+    }
+  },
+  "viewpoints": [
+    {
+      "name": "post",
+      "desc": "for post",
+      "tables": [
+        "public.post*"
+      ]
+    },
+    {
+      "name": "administrator",
+      "desc": "administrator schema only",
+      "tables": [
+        "administrator.*"
+      ]
+    }
+  ]
+}

--- a/sample/postgres95/schema.json
+++ b/sample/postgres95/schema.json
@@ -1,1 +1,1393 @@
-{"name":"testdb","desc":"Sample PostgreSQL database document.","tables":[{"name":"public.users","type":"BASE TABLE","comment":"Users table","columns":[{"name":"id","type":"integer","nullable":false,"default":"nextval('users_id_seq'::regclass)"},{"name":"username","type":"varchar(50)","nullable":false},{"name":"password","type":"varchar(50)","nullable":false},{"name":"email","type":"varchar(355)","nullable":false,"comment":"ex. user@example.com"},{"name":"created","type":"timestamp without time zone","nullable":false},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"users_pkey","def":"CREATE UNIQUE INDEX users_pkey ON public.users USING btree (id)","table":"public.users","columns":["id"]},{"name":"users_username_key","def":"CREATE UNIQUE INDEX users_username_key ON public.users USING btree (username)","table":"public.users","columns":["username"]},{"name":"users_email_key","def":"CREATE UNIQUE INDEX users_email_key ON public.users USING btree (email)","table":"public.users","columns":["email"]}],"constraints":[{"name":"users_username_check","type":"CHECK","def":"CHECK ((char_length((username)::text) \u003e 4))","table":"public.users","referenced_table":"","columns":["username"]},{"name":"users_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"public.users","referenced_table":"","columns":["id"]},{"name":"users_username_key","type":"UNIQUE","def":"UNIQUE (username)","table":"public.users","referenced_table":"","columns":["username"]},{"name":"users_email_key","type":"UNIQUE","def":"UNIQUE (email)","table":"public.users","referenced_table":"","columns":["email"]}],"triggers":[{"name":"update_users_updated","def":"CREATE TRIGGER update_users_updated AFTER INSERT OR UPDATE ON public.users FOR EACH ROW EXECUTE PROCEDURE update_updated()","comment":"Update updated when users insert or update"}]},{"name":"public.user_options","type":"BASE TABLE","comment":"User options table","columns":[{"name":"user_id","type":"integer","nullable":false},{"name":"show_email","type":"boolean","nullable":false,"default":"false"},{"name":"created","type":"timestamp without time zone","nullable":false},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"user_options_pkey","def":"CREATE UNIQUE INDEX user_options_pkey ON public.user_options USING btree (user_id)","table":"public.user_options","columns":["user_id"],"comment":"PRIMARY KEY"}],"constraints":[{"name":"user_options_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE","table":"public.user_options","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"],"comment":"FK"},{"name":"user_options_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (user_id)","table":"public.user_options","referenced_table":"","columns":["user_id"]}]},{"name":"public.posts","type":"BASE TABLE","comment":"Posts table","columns":[{"name":"id","type":"bigint","nullable":false,"default":"nextval('posts_id_seq'::regclass)"},{"name":"user_id","type":"integer","nullable":false},{"name":"title","type":"varchar(255)","nullable":false,"default":"'Untitled'::character varying"},{"name":"body","type":"text","nullable":false,"comment":"post body"},{"name":"post_type","type":"post_types","nullable":false,"comment":"public/private/draft"},{"name":"labels","type":"varchar(50)[]","nullable":true},{"name":"created","type":"timestamp without time zone","nullable":false},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"posts_id_pk","def":"CREATE UNIQUE INDEX posts_id_pk ON public.posts USING btree (id)","table":"public.posts","columns":["id"]},{"name":"posts_user_id_title_key","def":"CREATE UNIQUE INDEX posts_user_id_title_key ON public.posts USING btree (user_id, title)","table":"public.posts","columns":["user_id","title"]},{"name":"posts_user_id_idx","def":"CREATE INDEX posts_user_id_idx ON public.posts USING btree (user_id)","table":"public.posts","columns":["user_id"],"comment":"posts.user_id index"}],"constraints":[{"name":"update_posts_updated","type":"TRIGGER","def":"CREATE CONSTRAINT TRIGGER update_posts_updated AFTER INSERT OR UPDATE ON public.posts NOT DEFERRABLE INITIALLY IMMEDIATE FOR EACH ROW EXECUTE PROCEDURE update_updated()","table":"public.posts","referenced_table":"","columns":["updated","body","post_type","labels","created","tableoid","cmax","xmax","cmin","xmin","ctid","id","user_id","title"]},{"name":"posts_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE","table":"public.posts","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"],"comment":"posts -\u003e users"},{"name":"posts_id_pk","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"public.posts","referenced_table":"","columns":["id"]},{"name":"posts_user_id_title_key","type":"UNIQUE","def":"UNIQUE (user_id, title)","table":"public.posts","referenced_table":"","columns":["user_id","title"]}],"triggers":[{"name":"update_posts_updated","def":"CREATE CONSTRAINT TRIGGER update_posts_updated AFTER INSERT OR UPDATE ON public.posts NOT DEFERRABLE INITIALLY IMMEDIATE FOR EACH ROW EXECUTE PROCEDURE update_updated()","comment":"Update updated when posts update"}]},{"name":"public.comments","type":"BASE TABLE","comment":"Comments\nMulti-line\r\ntable\rcomment","columns":[{"name":"id","type":"bigint","nullable":false,"default":"nextval('comments_id_seq'::regclass)"},{"name":"post_id","type":"bigint","nullable":false},{"name":"user_id","type":"integer","nullable":false},{"name":"comment","type":"text","nullable":false,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"created","type":"timestamp without time zone","nullable":false},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"comments_id_pk","def":"CREATE UNIQUE INDEX comments_id_pk ON public.comments USING btree (id)","table":"public.comments","columns":["id"]},{"name":"comments_post_id_user_id_key","def":"CREATE UNIQUE INDEX comments_post_id_user_id_key ON public.comments USING btree (post_id, user_id)","table":"public.comments","columns":["post_id","user_id"]},{"name":"comments_post_id_user_id_idx","def":"CREATE INDEX comments_post_id_user_id_idx ON public.comments USING btree (post_id, user_id)","table":"public.comments","columns":["post_id","user_id"]}],"constraints":[{"name":"comments_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users(id)","table":"public.comments","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"comments_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (post_id) REFERENCES posts(id)","table":"public.comments","referenced_table":"posts","columns":["post_id"],"referenced_columns":["id"]},{"name":"comments_id_pk","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"public.comments","referenced_table":"","columns":["id"]},{"name":"comments_post_id_user_id_key","type":"UNIQUE","def":"UNIQUE (post_id, user_id)","table":"public.comments","referenced_table":"","columns":["post_id","user_id"]}]},{"name":"public.comment_stars","type":"BASE TABLE","columns":[{"name":"id","type":"uuid","nullable":false,"default":"uuid_generate_v4()"},{"name":"user_id","type":"integer","nullable":false},{"name":"comment_post_id","type":"bigint","nullable":false},{"name":"comment_user_id","type":"integer","nullable":false},{"name":"created","type":"timestamp without time zone","nullable":false},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"comment_stars_user_id_comment_post_id_comment_user_id_key","def":"CREATE UNIQUE INDEX comment_stars_user_id_comment_post_id_comment_user_id_key ON public.comment_stars USING btree (user_id, comment_post_id, comment_user_id)","table":"public.comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"constraints":[{"name":"comment_stars_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_user_id) REFERENCES users(id)","table":"public.comment_stars","referenced_table":"users","columns":["comment_user_id"],"referenced_columns":["id"]},{"name":"comment_stars_user_id_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments(post_id, user_id)","table":"public.comment_stars","referenced_table":"comments","columns":["comment_user_id","comment_post_id","comment_post_id","comment_user_id"],"referenced_columns":["post_id","post_id","user_id","user_id"]},{"name":"comment_stars_user_id_comment_post_id_comment_user_id_key","type":"UNIQUE","def":"UNIQUE (user_id, comment_post_id, comment_user_id)","table":"public.comment_stars","referenced_table":"","columns":["comment_user_id","comment_post_id","user_id"]}]},{"name":"public.logs","type":"BASE TABLE","comment":"audit log table","columns":[{"name":"id","type":"uuid","nullable":false,"default":"uuid_generate_v4()"},{"name":"user_id","type":"integer","nullable":false},{"name":"post_id","type":"bigint","nullable":true},{"name":"comment_id","type":"bigint","nullable":true},{"name":"comment_star_id","type":"uuid","nullable":true},{"name":"payload","type":"text","nullable":true},{"name":"created","type":"timestamp without time zone","nullable":false}]},{"name":"public.post_comments","type":"VIEW","comment":"post and comments View table","columns":[{"name":"id","type":"bigint","nullable":true,"comment":"comments.id"},{"name":"title","type":"varchar(255)","nullable":true,"comment":"posts.title"},{"name":"post_user","type":"varchar(50)","nullable":true,"comment":"posts.users.username"},{"name":"comment","type":"text","nullable":true},{"name":"comment_user","type":"varchar(50)","nullable":true,"comment":"comments.users.username"},{"name":"created","type":"timestamp without time zone","nullable":true,"comment":"comments.created"},{"name":"updated","type":"timestamp without time zone","nullable":true,"comment":"comments.updated"}],"def":"CREATE VIEW post_comments AS (\n SELECT c.id,\n    p.title,\n    u.username AS post_user,\n    c.comment,\n    u2.username AS comment_user,\n    c.created,\n    c.updated\n   FROM (((posts p\n     LEFT JOIN comments c ON ((p.id = c.post_id)))\n     LEFT JOIN users u ON ((u.id = p.user_id)))\n     LEFT JOIN users u2 ON ((u2.id = c.user_id)))\n)","referenced_tables":["public.posts","public.comments","public.users"]},{"name":"public.post_comment_stars","type":"MATERIALIZED VIEW","columns":[{"name":"id","type":"uuid","nullable":true},{"name":"comment_user","type":"varchar(50)","nullable":true},{"name":"comment_star_user","type":"varchar(50)","nullable":true},{"name":"created","type":"timestamp without time zone","nullable":true},{"name":"updated","type":"timestamp without time zone","nullable":true}],"def":"CREATE MATERIALIZED VIEW post_comment_stars AS (\n SELECT cs.id,\n    cu.username AS comment_user,\n    csu.username AS comment_star_user,\n    cs.created,\n    cs.updated\n   FROM (((comments c\n     LEFT JOIN comment_stars cs ON (((cs.comment_post_id = c.id) AND (cs.comment_user_id = c.user_id))))\n     LEFT JOIN users cu ON ((cu.id = cs.comment_user_id)))\n     LEFT JOIN users csu ON ((csu.id = cs.user_id)))\n)","referenced_tables":["public.comments","public.comment_stars","public.users"]},{"name":"public.CamelizeTable","type":"BASE TABLE","columns":[{"name":"id","type":"uuid","nullable":false,"default":"uuid_generate_v4()"},{"name":"created","type":"timestamp without time zone","nullable":false}],"indexes":[{"name":"CamelizeTable_id_key","def":"CREATE UNIQUE INDEX \"CamelizeTable_id_key\" ON public.\"CamelizeTable\" USING btree (id)","table":"public.CamelizeTable","columns":["id"]}],"constraints":[{"name":"CamelizeTable_id_key","type":"UNIQUE","def":"UNIQUE (id)","table":"public.CamelizeTable","referenced_table":"","columns":["id"]}]},{"name":"public.hyphen-table","type":"BASE TABLE","columns":[{"name":"id","type":"uuid","nullable":false,"default":"uuid_generate_v4()"},{"name":"hyphen-column","type":"text","nullable":false},{"name":"CamelizeTableId","type":"uuid","nullable":false},{"name":"created","type":"timestamp without time zone","nullable":false}],"indexes":[{"name":"hyphen-table_hyphen-column_key","def":"CREATE UNIQUE INDEX \"hyphen-table_hyphen-column_key\" ON public.\"hyphen-table\" USING btree (\"hyphen-column\")","table":"public.hyphen-table","columns":["hyphen-column"]}],"constraints":[{"name":"hyphen-table_CamelizeTableId_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (\"CamelizeTableId\") REFERENCES \"CamelizeTable\"(id) ON DELETE CASCADE","table":"public.hyphen-table","referenced_table":"CamelizeTable","columns":["CamelizeTableId"],"referenced_columns":["id"]},{"name":"hyphen-table_hyphen-column_key","type":"UNIQUE","def":"UNIQUE (\"hyphen-column\")","table":"public.hyphen-table","referenced_table":"","columns":["hyphen-column"]}]},{"name":"administrator.blogs","type":"BASE TABLE","comment":"admin blogs","columns":[{"name":"id","type":"integer","nullable":false,"default":"nextval('administrator.blogs_id_seq'::regclass)"},{"name":"user_id","type":"integer","nullable":false},{"name":"name","type":"text","nullable":false},{"name":"description","type":"text","nullable":true},{"name":"created","type":"timestamp without time zone","nullable":false},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"blogs_pkey","def":"CREATE UNIQUE INDEX blogs_pkey ON administrator.blogs USING btree (id)","table":"administrator.blogs","columns":["id"]}],"constraints":[{"name":"blogs_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE","table":"administrator.blogs","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"blogs_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"administrator.blogs","referenced_table":"","columns":["id"]}]},{"name":"backup.blogs","type":"BASE TABLE","columns":[{"name":"id","type":"integer","nullable":false,"default":"nextval('blogs_id_seq'::regclass)"},{"name":"user_id","type":"integer","nullable":false},{"name":"dump","type":"text","nullable":false},{"name":"created","type":"timestamp without time zone","nullable":false},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"blogs_pkey","def":"CREATE UNIQUE INDEX blogs_pkey ON backup.blogs USING btree (id)","table":"backup.blogs","columns":["id"]}],"constraints":[{"name":"blogs_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"backup.blogs","referenced_table":"","columns":["id"]}]},{"name":"backup.blog_options","type":"BASE TABLE","columns":[{"name":"id","type":"integer","nullable":false,"default":"nextval('blog_options_id_seq'::regclass)"},{"name":"blog_id","type":"integer","nullable":false},{"name":"label","type":"text","nullable":true},{"name":"updated","type":"timestamp without time zone","nullable":true}],"indexes":[{"name":"blog_options_pkey","def":"CREATE UNIQUE INDEX blog_options_pkey ON backup.blog_options USING btree (id)","table":"backup.blog_options","columns":["id"]}],"constraints":[{"name":"blog_options_blog_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (blog_id) REFERENCES blogs(id) ON DELETE CASCADE","table":"backup.blog_options","referenced_table":"blogs","columns":["blog_id"],"referenced_columns":["id"]},{"name":"blog_options_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"backup.blog_options","referenced_table":"","columns":["id"]}]},{"name":"time.bar","type":"BASE TABLE","columns":[{"name":"id","type":"integer","nullable":false}],"indexes":[{"name":"bar_pkey","def":"CREATE UNIQUE INDEX bar_pkey ON \"time\".bar USING btree (id)","table":"time.bar","columns":["id"]}],"constraints":[{"name":"bar_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"time.bar","referenced_table":"","columns":["id"]}]},{"name":"time.hyphenated-table","type":"BASE TABLE","columns":[{"name":"id","type":"integer","nullable":false}],"indexes":[{"name":"hyphenated-table_pkey","def":"CREATE UNIQUE INDEX \"hyphenated-table_pkey\" ON \"time\".\"hyphenated-table\" USING btree (id)","table":"time.hyphenated-table","columns":["id"]}],"constraints":[{"name":"hyphenated-table_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"time.hyphenated-table","referenced_table":"","columns":["id"]}]},{"name":"time.referencing","type":"BASE TABLE","columns":[{"name":"id","type":"integer","nullable":false},{"name":"bar_id","type":"integer","nullable":false},{"name":"ht_id","type":"integer","nullable":false}],"indexes":[{"name":"referencing_pkey","def":"CREATE UNIQUE INDEX referencing_pkey ON \"time\".referencing USING btree (id)","table":"time.referencing","columns":["id"]}],"constraints":[{"name":"referencing_bar_id","type":"FOREIGN KEY","def":"FOREIGN KEY (bar_id) REFERENCES \"time\".bar(id)","table":"time.referencing","referenced_table":"bar","columns":["bar_id"],"referenced_columns":["id"]},{"name":"referencing_ht_id","type":"FOREIGN KEY","def":"FOREIGN KEY (ht_id) REFERENCES \"time\".\"hyphenated-table\"(id)","table":"time.referencing","referenced_table":"hyphenated-table","columns":["ht_id"],"referenced_columns":["id"]},{"name":"referencing_pkey","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"time.referencing","referenced_table":"","columns":["id"]}]}],"relations":[{"table":"public.user_options","columns":["user_id"],"cardinality":"zero_or_one","parent_table":"public.users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"},{"table":"public.posts","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"public.users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"},{"table":"public.comments","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"public.users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users(id)"},{"table":"public.comments","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"public.posts","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (post_id) REFERENCES posts(id)"},{"table":"public.comment_stars","columns":["comment_user_id"],"cardinality":"zero_or_more","parent_table":"public.users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_user_id) REFERENCES users(id)"},{"table":"public.comment_stars","columns":["comment_post_id","comment_user_id"],"cardinality":"zero_or_more","parent_table":"public.comments","parent_columns":["post_id","user_id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments(post_id, user_id)"},{"table":"public.hyphen-table","columns":["CamelizeTableId"],"cardinality":"zero_or_more","parent_table":"public.CamelizeTable","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (\"CamelizeTableId\") REFERENCES \"CamelizeTable\"(id) ON DELETE CASCADE"},{"table":"administrator.blogs","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"public.users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"},{"table":"backup.blog_options","columns":["blog_id"],"cardinality":"zero_or_more","parent_table":"backup.blogs","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (blog_id) REFERENCES blogs(id) ON DELETE CASCADE"},{"table":"time.referencing","columns":["bar_id"],"cardinality":"zero_or_more","parent_table":"time.bar","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (bar_id) REFERENCES \"time\".bar(id)"},{"table":"time.referencing","columns":["ht_id"],"cardinality":"zero_or_more","parent_table":"time.hyphenated-table","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (ht_id) REFERENCES \"time\".\"hyphenated-table\"(id)"},{"table":"public.logs","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"public.users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"logs-\u003eusers","virtual":true},{"table":"public.logs","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"public.posts","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"public.logs","columns":["comment_id"],"cardinality":"zero_or_more","parent_table":"public.comments","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"public.logs","columns":["comment_star_id"],"cardinality":"zero_or_more","parent_table":"public.comment_stars","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true}],"functions":[{"name":"public.uuid_nil","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_ns_dns","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_ns_url","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_ns_oid","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_ns_x500","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_generate_v1","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_generate_v1mc","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_generate_v3","return_type":"uuid","arguments":"namespace uuid, name text","type":"FUNCTION"},{"name":"public.uuid_generate_v4","return_type":"uuid","arguments":"","type":"FUNCTION"},{"name":"public.uuid_generate_v5","return_type":"uuid","arguments":"namespace uuid, name text","type":"FUNCTION"},{"name":"public.update_updated","return_type":"trigger","arguments":"","type":"FUNCTION"}],"enums":[{"name":"public.post_types","values":["draft","private","public"]}],"driver":{"name":"postgres","database_version":"PostgreSQL 9.5.25 on x86_64-pc-linux-gnu (Debian 9.5.25-1.pgdg90+1), compiled by gcc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516, 64-bit","meta":{"current_schema":"public","search_paths":["postgres","public","backup"],"dict":{"Functions":"Stored procedures and functions"}}},"viewpoints":[{"name":"post","desc":"for post","tables":["public.post*"]},{"name":"administrator","desc":"administrator schema only","tables":["administrator.*"]}]}
+{
+  "name": "testdb",
+  "desc": "Sample PostgreSQL database document.",
+  "tables": [
+    {
+      "name": "public.users",
+      "type": "BASE TABLE",
+      "comment": "Users table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('users_id_seq'::regclass)"
+        },
+        {
+          "name": "username",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "password",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "email",
+          "type": "varchar(355)",
+          "nullable": false,
+          "comment": "ex. user@example.com"
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "users_pkey",
+          "def": "CREATE UNIQUE INDEX users_pkey ON public.users USING btree (id)",
+          "table": "public.users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "users_username_key",
+          "def": "CREATE UNIQUE INDEX users_username_key ON public.users USING btree (username)",
+          "table": "public.users",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "users_email_key",
+          "def": "CREATE UNIQUE INDEX users_email_key ON public.users USING btree (email)",
+          "table": "public.users",
+          "columns": [
+            "email"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "users_username_check",
+          "type": "CHECK",
+          "def": "CHECK ((char_length((username)::text) \u003e 4))",
+          "table": "public.users",
+          "referenced_table": "",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "users_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "public.users",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "users_username_key",
+          "type": "UNIQUE",
+          "def": "UNIQUE (username)",
+          "table": "public.users",
+          "referenced_table": "",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "users_email_key",
+          "type": "UNIQUE",
+          "def": "UNIQUE (email)",
+          "table": "public.users",
+          "referenced_table": "",
+          "columns": [
+            "email"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_users_updated",
+          "def": "CREATE TRIGGER update_users_updated AFTER INSERT OR UPDATE ON public.users FOR EACH ROW EXECUTE PROCEDURE update_updated()",
+          "comment": "Update updated when users insert or update"
+        }
+      ]
+    },
+    {
+      "name": "public.user_options",
+      "type": "BASE TABLE",
+      "comment": "User options table",
+      "columns": [
+        {
+          "name": "user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "show_email",
+          "type": "boolean",
+          "nullable": false,
+          "default": "false"
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "user_options_pkey",
+          "def": "CREATE UNIQUE INDEX user_options_pkey ON public.user_options USING btree (user_id)",
+          "table": "public.user_options",
+          "columns": [
+            "user_id"
+          ],
+          "comment": "PRIMARY KEY"
+        }
+      ],
+      "constraints": [
+        {
+          "name": "user_options_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE",
+          "table": "public.user_options",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ],
+          "comment": "FK"
+        },
+        {
+          "name": "user_options_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (user_id)",
+          "table": "public.user_options",
+          "referenced_table": "",
+          "columns": [
+            "user_id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "public.posts",
+      "type": "BASE TABLE",
+      "comment": "Posts table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "default": "nextval('posts_id_seq'::regclass)"
+        },
+        {
+          "name": "user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "'Untitled'::character varying"
+        },
+        {
+          "name": "body",
+          "type": "text",
+          "nullable": false,
+          "comment": "post body"
+        },
+        {
+          "name": "post_type",
+          "type": "post_types",
+          "nullable": false,
+          "comment": "public/private/draft"
+        },
+        {
+          "name": "labels",
+          "type": "varchar(50)[]",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "posts_id_pk",
+          "def": "CREATE UNIQUE INDEX posts_id_pk ON public.posts USING btree (id)",
+          "table": "public.posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "posts_user_id_title_key",
+          "def": "CREATE UNIQUE INDEX posts_user_id_title_key ON public.posts USING btree (user_id, title)",
+          "table": "public.posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        },
+        {
+          "name": "posts_user_id_idx",
+          "def": "CREATE INDEX posts_user_id_idx ON public.posts USING btree (user_id)",
+          "table": "public.posts",
+          "columns": [
+            "user_id"
+          ],
+          "comment": "posts.user_id index"
+        }
+      ],
+      "constraints": [
+        {
+          "name": "update_posts_updated",
+          "type": "TRIGGER",
+          "def": "CREATE CONSTRAINT TRIGGER update_posts_updated AFTER INSERT OR UPDATE ON public.posts NOT DEFERRABLE INITIALLY IMMEDIATE FOR EACH ROW EXECUTE PROCEDURE update_updated()",
+          "table": "public.posts",
+          "referenced_table": ""
+        },
+        {
+          "name": "posts_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE",
+          "table": "public.posts",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ],
+          "comment": "posts -\u003e users"
+        },
+        {
+          "name": "posts_id_pk",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "public.posts",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "posts_user_id_title_key",
+          "type": "UNIQUE",
+          "def": "UNIQUE (user_id, title)",
+          "table": "public.posts",
+          "referenced_table": "",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_posts_updated",
+          "def": "CREATE CONSTRAINT TRIGGER update_posts_updated AFTER INSERT OR UPDATE ON public.posts NOT DEFERRABLE INITIALLY IMMEDIATE FOR EACH ROW EXECUTE PROCEDURE update_updated()",
+          "comment": "Update updated when posts update"
+        }
+      ]
+    },
+    {
+      "name": "public.comments",
+      "type": "BASE TABLE",
+      "comment": "Comments\nMulti-line\r\ntable\rcomment",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "default": "nextval('comments_id_seq'::regclass)"
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": false,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comments_id_pk",
+          "def": "CREATE UNIQUE INDEX comments_id_pk ON public.comments USING btree (id)",
+          "table": "public.comments",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_post_id_user_id_key",
+          "def": "CREATE UNIQUE INDEX comments_post_id_user_id_key ON public.comments USING btree (post_id, user_id)",
+          "table": "public.comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "comments_post_id_user_id_idx",
+          "def": "CREATE INDEX comments_post_id_user_id_idx ON public.comments USING btree (post_id, user_id)",
+          "table": "public.comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comments_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users(id)",
+          "table": "public.comments",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (post_id) REFERENCES posts(id)",
+          "table": "public.comments",
+          "referenced_table": "posts",
+          "columns": [
+            "post_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_id_pk",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "public.comments",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_post_id_user_id_key",
+          "type": "UNIQUE",
+          "def": "UNIQUE (post_id, user_id)",
+          "table": "public.comments",
+          "referenced_table": "",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "public.comment_stars",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "uuid",
+          "nullable": false,
+          "default": "uuid_generate_v4()"
+        },
+        {
+          "name": "user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "comment_post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "comment_user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comment_stars_user_id_comment_post_id_comment_user_id_key",
+          "def": "CREATE UNIQUE INDEX comment_stars_user_id_comment_post_id_comment_user_id_key ON public.comment_stars USING btree (user_id, comment_post_id, comment_user_id)",
+          "table": "public.comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_user_id) REFERENCES users(id)",
+          "table": "public.comment_stars",
+          "referenced_table": "users",
+          "columns": [
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments(post_id, user_id)",
+          "table": "public.comment_stars",
+          "referenced_table": "comments",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_comment_post_id_comment_user_id_key",
+          "type": "UNIQUE",
+          "def": "UNIQUE (user_id, comment_post_id, comment_user_id)",
+          "table": "public.comment_stars",
+          "referenced_table": "",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "public.logs",
+      "type": "BASE TABLE",
+      "comment": "audit log table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "uuid",
+          "nullable": false,
+          "default": "uuid_generate_v4()"
+        },
+        {
+          "name": "user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_star_id",
+          "type": "uuid",
+          "nullable": true
+        },
+        {
+          "name": "payload",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        }
+      ]
+    },
+    {
+      "name": "public.post_comments",
+      "type": "VIEW",
+      "comment": "post and comments View table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": true,
+          "comment": "comments.id"
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": true,
+          "comment": "posts.title"
+        },
+        {
+          "name": "post_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "posts.users.username"
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "comment_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "comments.users.username"
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": true,
+          "comment": "comments.created"
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true,
+          "comment": "comments.updated"
+        }
+      ],
+      "def": "CREATE VIEW post_comments AS (\n SELECT c.id,\n    p.title,\n    u.username AS post_user,\n    c.comment,\n    u2.username AS comment_user,\n    c.created,\n    c.updated\n   FROM (((posts p\n     LEFT JOIN comments c ON ((p.id = c.post_id)))\n     LEFT JOIN users u ON ((u.id = p.user_id)))\n     LEFT JOIN users u2 ON ((u2.id = c.user_id)))\n)",
+      "referenced_tables": [
+        "public.posts",
+        "public.comments",
+        "public.users"
+      ]
+    },
+    {
+      "name": "public.post_comment_stars",
+      "type": "MATERIALIZED VIEW",
+      "columns": [
+        {
+          "name": "id",
+          "type": "uuid",
+          "nullable": true
+        },
+        {
+          "name": "comment_user",
+          "type": "varchar(50)",
+          "nullable": true
+        },
+        {
+          "name": "comment_star_user",
+          "type": "varchar(50)",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": true
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "def": "CREATE MATERIALIZED VIEW post_comment_stars AS (\n SELECT cs.id,\n    cu.username AS comment_user,\n    csu.username AS comment_star_user,\n    cs.created,\n    cs.updated\n   FROM (((comments c\n     LEFT JOIN comment_stars cs ON (((cs.comment_post_id = c.id) AND (cs.comment_user_id = c.user_id))))\n     LEFT JOIN users cu ON ((cu.id = cs.comment_user_id)))\n     LEFT JOIN users csu ON ((csu.id = cs.user_id)))\n)",
+      "referenced_tables": [
+        "public.comments",
+        "public.comment_stars",
+        "public.users"
+      ]
+    },
+    {
+      "name": "public.CamelizeTable",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "uuid",
+          "nullable": false,
+          "default": "uuid_generate_v4()"
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "CamelizeTable_id_key",
+          "def": "CREATE UNIQUE INDEX \"CamelizeTable_id_key\" ON public.\"CamelizeTable\" USING btree (id)",
+          "table": "public.CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "CamelizeTable_id_key",
+          "type": "UNIQUE",
+          "def": "UNIQUE (id)",
+          "table": "public.CamelizeTable",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "public.hyphen-table",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "uuid",
+          "nullable": false,
+          "default": "uuid_generate_v4()"
+        },
+        {
+          "name": "hyphen-column",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "CamelizeTableId",
+          "type": "uuid",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "hyphen-table_hyphen-column_key",
+          "def": "CREATE UNIQUE INDEX \"hyphen-table_hyphen-column_key\" ON public.\"hyphen-table\" USING btree (\"hyphen-column\")",
+          "table": "public.hyphen-table",
+          "columns": [
+            "hyphen-column"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "hyphen-table_CamelizeTableId_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (\"CamelizeTableId\") REFERENCES \"CamelizeTable\"(id) ON DELETE CASCADE",
+          "table": "public.hyphen-table",
+          "referenced_table": "CamelizeTable",
+          "columns": [
+            "CamelizeTableId"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "hyphen-table_hyphen-column_key",
+          "type": "UNIQUE",
+          "def": "UNIQUE (\"hyphen-column\")",
+          "table": "public.hyphen-table",
+          "referenced_table": "",
+          "columns": [
+            "hyphen-column"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "administrator.blogs",
+      "type": "BASE TABLE",
+      "comment": "admin blogs",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('administrator.blogs_id_seq'::regclass)"
+        },
+        {
+          "name": "user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "name",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "description",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "blogs_pkey",
+          "def": "CREATE UNIQUE INDEX blogs_pkey ON administrator.blogs USING btree (id)",
+          "table": "administrator.blogs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "blogs_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE",
+          "table": "administrator.blogs",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "blogs_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "administrator.blogs",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "backup.blogs",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('blogs_id_seq'::regclass)"
+        },
+        {
+          "name": "user_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "dump",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp without time zone",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "blogs_pkey",
+          "def": "CREATE UNIQUE INDEX blogs_pkey ON backup.blogs USING btree (id)",
+          "table": "backup.blogs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "blogs_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "backup.blogs",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "backup.blog_options",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false,
+          "default": "nextval('blog_options_id_seq'::regclass)"
+        },
+        {
+          "name": "blog_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "label",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "updated",
+          "type": "timestamp without time zone",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "blog_options_pkey",
+          "def": "CREATE UNIQUE INDEX blog_options_pkey ON backup.blog_options USING btree (id)",
+          "table": "backup.blog_options",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "blog_options_blog_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (blog_id) REFERENCES blogs(id) ON DELETE CASCADE",
+          "table": "backup.blog_options",
+          "referenced_table": "blogs",
+          "columns": [
+            "blog_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "blog_options_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "backup.blog_options",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "time.bar",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "bar_pkey",
+          "def": "CREATE UNIQUE INDEX bar_pkey ON \"time\".bar USING btree (id)",
+          "table": "time.bar",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "bar_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "time.bar",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "time.hyphenated-table",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "hyphenated-table_pkey",
+          "def": "CREATE UNIQUE INDEX \"hyphenated-table_pkey\" ON \"time\".\"hyphenated-table\" USING btree (id)",
+          "table": "time.hyphenated-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "hyphenated-table_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "time.hyphenated-table",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "time.referencing",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "bar_id",
+          "type": "integer",
+          "nullable": false
+        },
+        {
+          "name": "ht_id",
+          "type": "integer",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "referencing_pkey",
+          "def": "CREATE UNIQUE INDEX referencing_pkey ON \"time\".referencing USING btree (id)",
+          "table": "time.referencing",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "referencing_bar_id",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (bar_id) REFERENCES \"time\".bar(id)",
+          "table": "time.referencing",
+          "referenced_table": "bar",
+          "columns": [
+            "bar_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "referencing_ht_id",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (ht_id) REFERENCES \"time\".\"hyphenated-table\"(id)",
+          "table": "time.referencing",
+          "referenced_table": "hyphenated-table",
+          "columns": [
+            "ht_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "referencing_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "time.referencing",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    }
+  ],
+  "relations": [
+    {
+      "table": "public.user_options",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_one",
+      "parent_table": "public.users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"
+    },
+    {
+      "table": "public.posts",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"
+    },
+    {
+      "table": "public.comments",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users(id)"
+    },
+    {
+      "table": "public.comments",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (post_id) REFERENCES posts(id)"
+    },
+    {
+      "table": "public.comment_stars",
+      "columns": [
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_user_id) REFERENCES users(id)"
+    },
+    {
+      "table": "public.comment_stars",
+      "columns": [
+        "comment_post_id",
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.comments",
+      "parent_columns": [
+        "post_id",
+        "user_id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments(post_id, user_id)"
+    },
+    {
+      "table": "public.hyphen-table",
+      "columns": [
+        "CamelizeTableId"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.CamelizeTable",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (\"CamelizeTableId\") REFERENCES \"CamelizeTable\"(id) ON DELETE CASCADE"
+    },
+    {
+      "table": "administrator.blogs",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"
+    },
+    {
+      "table": "backup.blog_options",
+      "columns": [
+        "blog_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "backup.blogs",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (blog_id) REFERENCES blogs(id) ON DELETE CASCADE"
+    },
+    {
+      "table": "time.referencing",
+      "columns": [
+        "bar_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "time.bar",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (bar_id) REFERENCES \"time\".bar(id)"
+    },
+    {
+      "table": "time.referencing",
+      "columns": [
+        "ht_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "time.hyphenated-table",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (ht_id) REFERENCES \"time\".\"hyphenated-table\"(id)"
+    },
+    {
+      "table": "public.logs",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "logs-\u003eusers",
+      "virtual": true
+    },
+    {
+      "table": "public.logs",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "public.logs",
+      "columns": [
+        "comment_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.comments",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "public.logs",
+      "columns": [
+        "comment_star_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.comment_stars",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    }
+  ],
+  "functions": [
+    {
+      "name": "public.uuid_nil",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_ns_dns",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_ns_url",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_ns_oid",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_ns_x500",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_generate_v1",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_generate_v1mc",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_generate_v3",
+      "return_type": "uuid",
+      "arguments": "namespace uuid, name text",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_generate_v4",
+      "return_type": "uuid",
+      "arguments": "",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.uuid_generate_v5",
+      "return_type": "uuid",
+      "arguments": "namespace uuid, name text",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "public.update_updated",
+      "return_type": "trigger",
+      "arguments": "",
+      "type": "FUNCTION"
+    }
+  ],
+  "enums": [
+    {
+      "name": "public.post_types",
+      "values": [
+        "draft",
+        "private",
+        "public"
+      ]
+    }
+  ],
+  "driver": {
+    "name": "postgres",
+    "database_version": "PostgreSQL 9.5.25 on x86_64-pc-linux-gnu (Debian 9.5.25-1.pgdg90+1), compiled by gcc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516, 64-bit",
+    "meta": {
+      "current_schema": "public",
+      "search_paths": [
+        "postgres",
+        "public",
+        "backup"
+      ],
+      "dict": {
+        "Functions": "Stored procedures and functions"
+      }
+    }
+  },
+  "viewpoints": [
+    {
+      "name": "post",
+      "desc": "for post",
+      "tables": [
+        "public.post*"
+      ]
+    },
+    {
+      "name": "administrator",
+      "desc": "administrator schema only",
+      "tables": [
+        "administrator.*"
+      ]
+    }
+  ]
+}

--- a/sample/sqlite/schema.json
+++ b/sample/sqlite/schema.json
@@ -1,1 +1,977 @@
-{"name":"testdb.sqlite3","desc":"Sample database document.","tables":[{"name":"users","type":"table","columns":[{"name":"id","type":"INTEGER","nullable":true},{"name":"username","type":"TEXT","nullable":false},{"name":"password","type":"TEXT","nullable":false,"labels":[{"name":"secure","virtual":true},{"name":"encrypted","virtual":true}]},{"name":"email","type":"TEXT","nullable":false,"labels":[{"name":"secure","virtual":true}]},{"name":"created","type":"NUMERIC","nullable":false},{"name":"updated","type":"NUMERIC","nullable":true}],"indexes":[{"name":"users_username_key","def":"CREATE UNIQUE INDEX users_username_key ON users(username)","table":"users","columns":["username"]},{"name":"sqlite_autoindex_users_2","def":"UNIQUE (email)","table":"users","columns":["email"]},{"name":"sqlite_autoindex_users_1","def":"UNIQUE (username)","table":"users","columns":["username"]}],"constraints":[{"name":"id","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"users","columns":["id"]},{"name":"sqlite_autoindex_users_2","type":"UNIQUE","def":"UNIQUE (email)","table":"users","columns":["email"]},{"name":"sqlite_autoindex_users_1","type":"UNIQUE","def":"UNIQUE (username)","table":"users","columns":["username"]},{"name":"-","type":"CHECK","def":"CHECK(length(username) \u003e 4)","table":"users","columns":["username"]}],"def":"CREATE TABLE users (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  username TEXT UNIQUE NOT NULL CHECK(length(username) \u003e 4),\n  password TEXT NOT NULL,\n  email TEXT UNIQUE NOT NULL,\n  created NUMERIC NOT NULL,\n  updated NUMERIC\n)"},{"name":"user_options","type":"table","columns":[{"name":"user_id","type":"INTEGER","nullable":true},{"name":"show_email","type":"INTEGER","nullable":false,"default":"0"},{"name":"created","type":"NUMERIC","nullable":false},{"name":"updated","type":"NUMERIC","nullable":true}],"constraints":[{"name":"user_id","type":"PRIMARY KEY","def":"PRIMARY KEY (user_id)","table":"user_options","columns":["user_id"]},{"name":"- (Foreign key ID: 0)","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id) ON UPDATE NO ACTION ON DELETE CASCADE MATCH NONE","table":"user_options","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]}],"def":"CREATE TABLE user_options (\n  user_id INTEGER PRIMARY KEY,\n  show_email INTEGER NOT NULL DEFAULT 0,\n  created NUMERIC NOT NULL,\n  updated NUMERIC,\n  CONSTRAINT user_options_user_id_fk FOREIGN KEY(user_id) REFERENCES users(id) MATCH NONE ON UPDATE NO ACTION ON DELETE CASCADE\n)"},{"name":"posts","type":"table","columns":[{"name":"id","type":"INTEGER","nullable":true},{"name":"user_id","type":"INTEGER","nullable":false},{"name":"title","type":"TEXT","nullable":false},{"name":"body","type":"TEXT","nullable":false,"comment":"post body"},{"name":"created","type":"NUMERIC","nullable":false},{"name":"updated","type":"NUMERIC","nullable":true}],"indexes":[{"name":"posts_user_id_idx","def":"CREATE INDEX posts_user_id_idx ON posts(user_id)","table":"posts","columns":["user_id"]}],"constraints":[{"name":"id","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"posts","columns":["id"]},{"name":"- (Foreign key ID: 0)","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id) ON UPDATE NO ACTION ON DELETE CASCADE MATCH NONE","table":"posts","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]}],"triggers":[{"name":"update_posts_updated","def":"CREATE TRIGGER update_posts_updated AFTER UPDATE ON posts FOR EACH ROW\nBEGIN\n  UPDATE posts SET updated = current_timestamp WHERE id = OLD.id;\nEND"}],"def":"CREATE TABLE posts (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  user_id INTEGER NOT NULL,\n  title TEXT NOT NULL,\n  body TEXT NOT NULL,\n  created NUMERIC NOT NULL,\n  updated NUMERIC,\n  CONSTRAINT posts_user_id_fk FOREIGN KEY(user_id) REFERENCES users(id) MATCH NONE ON UPDATE NO ACTION ON DELETE CASCADE\n)","labels":[{"name":"green","virtual":true},{"name":"red","virtual":true},{"name":"blue","virtual":true}]},{"name":"comments","type":"table","columns":[{"name":"id","type":"INTEGER","nullable":true},{"name":"post_id","type":"INTEGER","nullable":false},{"name":"user_id","type":"INTEGER","nullable":false},{"name":"comment","type":"TEXT","nullable":false},{"name":"created","type":"NUMERIC","nullable":false},{"name":"updated","type":"NUMERIC","nullable":true}],"indexes":[{"name":"comments_post_id_user_id_idx","def":"CREATE INDEX comments_post_id_user_id_idx ON comments(post_id, user_id)","table":"comments","columns":["post_id","user_id"]},{"name":"sqlite_autoindex_comments_1","def":"UNIQUE (post_id, user_id)","table":"comments","columns":["post_id","user_id"]}],"constraints":[{"name":"id","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comments","columns":["id"]},{"name":"- (Foreign key ID: 0)","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id) ON UPDATE NO ACTION ON DELETE NO ACTION MATCH NONE","table":"comments","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"- (Foreign key ID: 1)","type":"FOREIGN KEY","def":"FOREIGN KEY (post_id) REFERENCES posts (id) ON UPDATE NO ACTION ON DELETE NO ACTION MATCH NONE","table":"comments","referenced_table":"posts","columns":["post_id"],"referenced_columns":["id"]},{"name":"sqlite_autoindex_comments_1","type":"UNIQUE","def":"UNIQUE (post_id, user_id)","table":"comments","columns":["post_id","user_id"]}],"def":"CREATE TABLE comments (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  post_id INTEGER NOT NULL,\n  user_id INTEGER NOT NULL,\n  comment TEXT NOT NULL,\n  created NUMERIC NOT NULL,\n  updated NUMERIC,\n  CONSTRAINT comments_post_id_fk FOREIGN KEY(post_id) REFERENCES posts(id),\n  CONSTRAINT comments_user_id_fk FOREIGN KEY(user_id) REFERENCES users(id),\n  UNIQUE(post_id, user_id)\n)"},{"name":"comment_stars","type":"table","columns":[{"name":"id","type":"INTEGER","nullable":true},{"name":"user_id","type":"INTEGER","nullable":false},{"name":"comment_post_id","type":"INTEGER","nullable":false},{"name":"comment_user_id","type":"INTEGER","nullable":false},{"name":"created","type":"NUMERIC","nullable":false},{"name":"updated","type":"NUMERIC","nullable":true}],"indexes":[{"name":"sqlite_autoindex_comment_stars_1","def":"UNIQUE (user_id, comment_post_id, comment_user_id)","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"constraints":[{"name":"id","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comment_stars","columns":["id"]},{"name":"- (Foreign key ID: 0)","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id) ON UPDATE NO ACTION ON DELETE NO ACTION MATCH NONE","table":"comment_stars","referenced_table":"users","columns":["comment_user_id"],"referenced_columns":["id"]},{"name":"- (Foreign key ID: 1)","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id) ON UPDATE NO ACTION ON DELETE NO ACTION MATCH NONE","table":"comment_stars","referenced_table":"comments","columns":["comment_post_id","comment_user_id"],"referenced_columns":["post_id","user_id"]},{"name":"sqlite_autoindex_comment_stars_1","type":"UNIQUE","def":"UNIQUE (user_id, comment_post_id, comment_user_id)","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"def":"CREATE TABLE comment_stars (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  user_id INTEGER NOT NULL,\n  comment_post_id INTEGER NOT NULL,\n  comment_user_id INTEGER NOT NULL,\n  created NUMERIC NOT NULL,\n  updated NUMERIC,\n  CONSTRAINT comment_stars_user_id_post_id_fk FOREIGN KEY(comment_post_id, comment_user_id) REFERENCES comments(post_id, user_id),\n  CONSTRAINT comment_stars_user_id_fk FOREIGN KEY(comment_user_id) REFERENCES users(id),\n  UNIQUE(user_id, comment_post_id, comment_user_id)\n)"},{"name":"logs","type":"table","columns":[{"name":"id","type":"INTEGER","nullable":true},{"name":"user_id","type":"INTEGER","nullable":false},{"name":"post_id","type":"INTEGER","nullable":true},{"name":"comment_id","type":"INTEGER","nullable":true},{"name":"comment_star_id","type":"INTEGER","nullable":true},{"name":"payload","type":"TEXT","nullable":true},{"name":"created","type":"NUMERIC","nullable":false}],"constraints":[{"name":"id","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"logs","columns":["id"]}],"def":"CREATE TABLE logs (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  user_id INTEGER NOT NULL,\n  post_id INTEGER,\n  comment_id INTEGER,\n  comment_star_id INTEGER,\n  payload TEXT,\n  created NUMERIC NOT NULL\n)"},{"name":"post_comments","type":"view","comment":"post and comments View table","columns":[{"name":"id","type":"INTEGER","nullable":true,"comment":"comments.id"},{"name":"title","type":"TEXT","nullable":true,"comment":"posts.title"},{"name":"post_user","type":"TEXT","nullable":true,"comment":"posts.users.username"},{"name":"comment","type":"TEXT","nullable":true},{"name":"comment_user","type":"TEXT","nullable":true,"comment":"comments.users.username"},{"name":"created","type":"NUMERIC","nullable":true,"comment":"comments.created"},{"name":"updated","type":"NUMERIC","nullable":true,"comment":"comments.updated"}],"def":"CREATE VIEW post_comments AS\n  SELECT c.id, p.title, u2.username AS post_user, c.comment, u2.username AS comment_user, c.created, c.updated\n  FROM posts AS p\n  LEFT JOIN comments AS c on p.id = c.post_id\n  LEFT JOIN users AS u on u.id = p.user_id\n  LEFT JOIN users AS u2 on u2.id = c.user_id","referenced_tables":["posts","comments","users"]},{"name":"CamelizeTable","type":"table","columns":[{"name":"id","type":"INTEGER","nullable":true},{"name":"created","type":"NUMERIC","nullable":false}],"constraints":[{"name":"id","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"CamelizeTable","columns":["id"]}],"def":"CREATE TABLE CamelizeTable (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  created NUMERIC NOT NULL\n)"},{"name":"hyphen-table","type":"table","columns":[{"name":"id","type":"INTEGER","nullable":true},{"name":"hyphen-column","type":"TEXT","nullable":false},{"name":"created","type":"NUMERIC","nullable":false}],"constraints":[{"name":"id","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"hyphen-table","columns":["id"]}],"def":"CREATE TABLE 'hyphen-table' (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  'hyphen-column' TEXT NOT NULL,\n  created NUMERIC NOT NULL\n)"},{"name":"check_constraints","type":"table","columns":[{"name":"id","type":"INTEGER","nullable":true},{"name":"col","type":"TEXT","nullable":true},{"name":"brackets","type":"TEXT","nullable":false},{"name":"checkcheck","type":"TEXT","nullable":false},{"name":"downcase","type":"TEXT","nullable":false},{"name":"nl","type":"TEXT","nullable":false}],"indexes":[{"name":"sqlite_autoindex_check_constraints_4","def":"UNIQUE (nl)","table":"check_constraints","columns":["nl"]},{"name":"sqlite_autoindex_check_constraints_3","def":"UNIQUE (downcase)","table":"check_constraints","columns":["downcase"]},{"name":"sqlite_autoindex_check_constraints_2","def":"UNIQUE (checkcheck)","table":"check_constraints","columns":["checkcheck"]},{"name":"sqlite_autoindex_check_constraints_1","def":"UNIQUE (brackets)","table":"check_constraints","columns":["brackets"]}],"constraints":[{"name":"id","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"check_constraints","columns":["id"]},{"name":"sqlite_autoindex_check_constraints_4","type":"UNIQUE","def":"UNIQUE (nl)","table":"check_constraints","columns":["nl"]},{"name":"sqlite_autoindex_check_constraints_3","type":"UNIQUE","def":"UNIQUE (downcase)","table":"check_constraints","columns":["downcase"]},{"name":"sqlite_autoindex_check_constraints_2","type":"UNIQUE","def":"UNIQUE (checkcheck)","table":"check_constraints","columns":["checkcheck"]},{"name":"sqlite_autoindex_check_constraints_1","type":"UNIQUE","def":"UNIQUE (brackets)","table":"check_constraints","columns":["brackets"]},{"name":"-","type":"CHECK","def":"CHECK(length(col) \u003e 4)","table":"check_constraints","columns":["col"]},{"name":"-","type":"CHECK","def":"CHECK(((length(brackets) \u003e 4)))","table":"check_constraints","columns":["brackets"]},{"name":"-","type":"CHECK","def":"CHECK(length(checkcheck) \u003e 4)","table":"check_constraints","columns":["checkcheck"]},{"name":"-","type":"CHECK","def":"check(length(downcase) \u003e 4)","table":"check_constraints","columns":["downcase"]},{"name":"-","type":"CHECK","def":"check(length(nl) \u003e 4 OR nl != 'ln')","table":"check_constraints","columns":["nl"]}],"def":"CREATE TABLE check_constraints (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  col TEXT CHECK(length(col) \u003e 4),\n  brackets TEXT UNIQUE NOT NULL CHECK(((length(brackets) \u003e 4))),\n  checkcheck TEXT UNIQUE NOT NULL CHECK(length(checkcheck) \u003e 4),\n  downcase TEXT UNIQUE NOT NULL check(length(downcase) \u003e 4),\n  nl TEXT UNIQUE NOT\n    NULL check(length(nl) \u003e 4 OR\n      nl != 'ln')\n)"},{"name":"syslog","type":"virtual table","columns":[{"name":"logs","type":"","nullable":true}],"def":"CREATE VIRTUAL TABLE syslog USING fts3(logs)"},{"name":"access_log","type":"virtual table","columns":[{"name":"logs","type":"","nullable":true}],"def":"CREATE VIRTUAL TABLE access_log USING fts4(logs)"}],"relations":[{"table":"user_options","columns":["user_id"],"cardinality":"zero_or_one","parent_table":"users","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"FOREIGN KEY (user_id) REFERENCES users (id) ON UPDATE NO ACTION ON DELETE CASCADE MATCH NONE"},{"table":"posts","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id) ON UPDATE NO ACTION ON DELETE CASCADE MATCH NONE"},{"table":"comments","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id) ON UPDATE NO ACTION ON DELETE NO ACTION MATCH NONE"},{"table":"comments","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (post_id) REFERENCES posts (id) ON UPDATE NO ACTION ON DELETE NO ACTION MATCH NONE"},{"table":"comment_stars","columns":["comment_user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id) ON UPDATE NO ACTION ON DELETE NO ACTION MATCH NONE"},{"table":"comment_stars","columns":["comment_post_id","comment_user_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["post_id","user_id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id) ON UPDATE NO ACTION ON DELETE NO ACTION MATCH NONE"},{"table":"logs","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"logs-\u003eusers","virtual":true},{"table":"logs","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"logs","columns":["comment_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"logs","columns":["comment_star_id"],"cardinality":"exactly_one","parent_table":"comment_stars","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"Additional Relation","virtual":true}],"driver":{"name":"sqlite","database_version":"3.46.1"},"labels":[{"name":"sample","virtual":true},{"name":"tbls","virtual":true}]}
+{
+  "name": "testdb.sqlite3",
+  "desc": "Sample database document.",
+  "tables": [
+    {
+      "name": "users",
+      "type": "table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "INTEGER",
+          "nullable": true
+        },
+        {
+          "name": "username",
+          "type": "TEXT",
+          "nullable": false
+        },
+        {
+          "name": "password",
+          "type": "TEXT",
+          "nullable": false,
+          "labels": [
+            {
+              "name": "secure",
+              "virtual": true
+            },
+            {
+              "name": "encrypted",
+              "virtual": true
+            }
+          ]
+        },
+        {
+          "name": "email",
+          "type": "TEXT",
+          "nullable": false,
+          "labels": [
+            {
+              "name": "secure",
+              "virtual": true
+            }
+          ]
+        },
+        {
+          "name": "created",
+          "type": "NUMERIC",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "NUMERIC",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "users_username_key",
+          "def": "CREATE UNIQUE INDEX users_username_key ON users(username)",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "sqlite_autoindex_users_2",
+          "def": "UNIQUE (email)",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "sqlite_autoindex_users_1",
+          "def": "UNIQUE (username)",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "id",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "sqlite_autoindex_users_2",
+          "type": "UNIQUE",
+          "def": "UNIQUE (email)",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "sqlite_autoindex_users_1",
+          "type": "UNIQUE",
+          "def": "UNIQUE (username)",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "-",
+          "type": "CHECK",
+          "def": "CHECK(length(username) \u003e 4)",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE users (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  username TEXT UNIQUE NOT NULL CHECK(length(username) \u003e 4),\n  password TEXT NOT NULL,\n  email TEXT UNIQUE NOT NULL,\n  created NUMERIC NOT NULL,\n  updated NUMERIC\n)"
+    },
+    {
+      "name": "user_options",
+      "type": "table",
+      "columns": [
+        {
+          "name": "user_id",
+          "type": "INTEGER",
+          "nullable": true
+        },
+        {
+          "name": "show_email",
+          "type": "INTEGER",
+          "nullable": false,
+          "default": "0"
+        },
+        {
+          "name": "created",
+          "type": "NUMERIC",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "NUMERIC",
+          "nullable": true
+        }
+      ],
+      "constraints": [
+        {
+          "name": "user_id",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "- (Foreign key ID: 0)",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id) ON UPDATE NO ACTION ON DELETE CASCADE MATCH NONE",
+          "table": "user_options",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE user_options (\n  user_id INTEGER PRIMARY KEY,\n  show_email INTEGER NOT NULL DEFAULT 0,\n  created NUMERIC NOT NULL,\n  updated NUMERIC,\n  CONSTRAINT user_options_user_id_fk FOREIGN KEY(user_id) REFERENCES users(id) MATCH NONE ON UPDATE NO ACTION ON DELETE CASCADE\n)"
+    },
+    {
+      "name": "posts",
+      "type": "table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "INTEGER",
+          "nullable": true
+        },
+        {
+          "name": "user_id",
+          "type": "INTEGER",
+          "nullable": false
+        },
+        {
+          "name": "title",
+          "type": "TEXT",
+          "nullable": false
+        },
+        {
+          "name": "body",
+          "type": "TEXT",
+          "nullable": false,
+          "comment": "post body"
+        },
+        {
+          "name": "created",
+          "type": "NUMERIC",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "NUMERIC",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "posts_user_id_idx",
+          "def": "CREATE INDEX posts_user_id_idx ON posts(user_id)",
+          "table": "posts",
+          "columns": [
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "id",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "- (Foreign key ID: 0)",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id) ON UPDATE NO ACTION ON DELETE CASCADE MATCH NONE",
+          "table": "posts",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_posts_updated",
+          "def": "CREATE TRIGGER update_posts_updated AFTER UPDATE ON posts FOR EACH ROW\nBEGIN\n  UPDATE posts SET updated = current_timestamp WHERE id = OLD.id;\nEND"
+        }
+      ],
+      "def": "CREATE TABLE posts (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  user_id INTEGER NOT NULL,\n  title TEXT NOT NULL,\n  body TEXT NOT NULL,\n  created NUMERIC NOT NULL,\n  updated NUMERIC,\n  CONSTRAINT posts_user_id_fk FOREIGN KEY(user_id) REFERENCES users(id) MATCH NONE ON UPDATE NO ACTION ON DELETE CASCADE\n)",
+      "labels": [
+        {
+          "name": "green",
+          "virtual": true
+        },
+        {
+          "name": "red",
+          "virtual": true
+        },
+        {
+          "name": "blue",
+          "virtual": true
+        }
+      ]
+    },
+    {
+      "name": "comments",
+      "type": "table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "INTEGER",
+          "nullable": true
+        },
+        {
+          "name": "post_id",
+          "type": "INTEGER",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "INTEGER",
+          "nullable": false
+        },
+        {
+          "name": "comment",
+          "type": "TEXT",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "NUMERIC",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "NUMERIC",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comments_post_id_user_id_idx",
+          "def": "CREATE INDEX comments_post_id_user_id_idx ON comments(post_id, user_id)",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "sqlite_autoindex_comments_1",
+          "def": "UNIQUE (post_id, user_id)",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "id",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "- (Foreign key ID: 0)",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id) ON UPDATE NO ACTION ON DELETE NO ACTION MATCH NONE",
+          "table": "comments",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "- (Foreign key ID: 1)",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (post_id) REFERENCES posts (id) ON UPDATE NO ACTION ON DELETE NO ACTION MATCH NONE",
+          "table": "comments",
+          "referenced_table": "posts",
+          "columns": [
+            "post_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "sqlite_autoindex_comments_1",
+          "type": "UNIQUE",
+          "def": "UNIQUE (post_id, user_id)",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE comments (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  post_id INTEGER NOT NULL,\n  user_id INTEGER NOT NULL,\n  comment TEXT NOT NULL,\n  created NUMERIC NOT NULL,\n  updated NUMERIC,\n  CONSTRAINT comments_post_id_fk FOREIGN KEY(post_id) REFERENCES posts(id),\n  CONSTRAINT comments_user_id_fk FOREIGN KEY(user_id) REFERENCES users(id),\n  UNIQUE(post_id, user_id)\n)"
+    },
+    {
+      "name": "comment_stars",
+      "type": "table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "INTEGER",
+          "nullable": true
+        },
+        {
+          "name": "user_id",
+          "type": "INTEGER",
+          "nullable": false
+        },
+        {
+          "name": "comment_post_id",
+          "type": "INTEGER",
+          "nullable": false
+        },
+        {
+          "name": "comment_user_id",
+          "type": "INTEGER",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "NUMERIC",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "NUMERIC",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "sqlite_autoindex_comment_stars_1",
+          "def": "UNIQUE (user_id, comment_post_id, comment_user_id)",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "id",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "- (Foreign key ID: 0)",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id) ON UPDATE NO ACTION ON DELETE NO ACTION MATCH NONE",
+          "table": "comment_stars",
+          "referenced_table": "users",
+          "columns": [
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "- (Foreign key ID: 1)",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id) ON UPDATE NO ACTION ON DELETE NO ACTION MATCH NONE",
+          "table": "comment_stars",
+          "referenced_table": "comments",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "sqlite_autoindex_comment_stars_1",
+          "type": "UNIQUE",
+          "def": "UNIQUE (user_id, comment_post_id, comment_user_id)",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE comment_stars (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  user_id INTEGER NOT NULL,\n  comment_post_id INTEGER NOT NULL,\n  comment_user_id INTEGER NOT NULL,\n  created NUMERIC NOT NULL,\n  updated NUMERIC,\n  CONSTRAINT comment_stars_user_id_post_id_fk FOREIGN KEY(comment_post_id, comment_user_id) REFERENCES comments(post_id, user_id),\n  CONSTRAINT comment_stars_user_id_fk FOREIGN KEY(comment_user_id) REFERENCES users(id),\n  UNIQUE(user_id, comment_post_id, comment_user_id)\n)"
+    },
+    {
+      "name": "logs",
+      "type": "table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "INTEGER",
+          "nullable": true
+        },
+        {
+          "name": "user_id",
+          "type": "INTEGER",
+          "nullable": false
+        },
+        {
+          "name": "post_id",
+          "type": "INTEGER",
+          "nullable": true
+        },
+        {
+          "name": "comment_id",
+          "type": "INTEGER",
+          "nullable": true
+        },
+        {
+          "name": "comment_star_id",
+          "type": "INTEGER",
+          "nullable": true
+        },
+        {
+          "name": "payload",
+          "type": "TEXT",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "NUMERIC",
+          "nullable": false
+        }
+      ],
+      "constraints": [
+        {
+          "name": "id",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE logs (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  user_id INTEGER NOT NULL,\n  post_id INTEGER,\n  comment_id INTEGER,\n  comment_star_id INTEGER,\n  payload TEXT,\n  created NUMERIC NOT NULL\n)"
+    },
+    {
+      "name": "post_comments",
+      "type": "view",
+      "comment": "post and comments View table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "INTEGER",
+          "nullable": true,
+          "comment": "comments.id"
+        },
+        {
+          "name": "title",
+          "type": "TEXT",
+          "nullable": true,
+          "comment": "posts.title"
+        },
+        {
+          "name": "post_user",
+          "type": "TEXT",
+          "nullable": true,
+          "comment": "posts.users.username"
+        },
+        {
+          "name": "comment",
+          "type": "TEXT",
+          "nullable": true
+        },
+        {
+          "name": "comment_user",
+          "type": "TEXT",
+          "nullable": true,
+          "comment": "comments.users.username"
+        },
+        {
+          "name": "created",
+          "type": "NUMERIC",
+          "nullable": true,
+          "comment": "comments.created"
+        },
+        {
+          "name": "updated",
+          "type": "NUMERIC",
+          "nullable": true,
+          "comment": "comments.updated"
+        }
+      ],
+      "def": "CREATE VIEW post_comments AS\n  SELECT c.id, p.title, u2.username AS post_user, c.comment, u2.username AS comment_user, c.created, c.updated\n  FROM posts AS p\n  LEFT JOIN comments AS c on p.id = c.post_id\n  LEFT JOIN users AS u on u.id = p.user_id\n  LEFT JOIN users AS u2 on u2.id = c.user_id",
+      "referenced_tables": [
+        "posts",
+        "comments",
+        "users"
+      ]
+    },
+    {
+      "name": "CamelizeTable",
+      "type": "table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "INTEGER",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "NUMERIC",
+          "nullable": false
+        }
+      ],
+      "constraints": [
+        {
+          "name": "id",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE CamelizeTable (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  created NUMERIC NOT NULL\n)"
+    },
+    {
+      "name": "hyphen-table",
+      "type": "table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "INTEGER",
+          "nullable": true
+        },
+        {
+          "name": "hyphen-column",
+          "type": "TEXT",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "NUMERIC",
+          "nullable": false
+        }
+      ],
+      "constraints": [
+        {
+          "name": "id",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE 'hyphen-table' (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  'hyphen-column' TEXT NOT NULL,\n  created NUMERIC NOT NULL\n)"
+    },
+    {
+      "name": "check_constraints",
+      "type": "table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "INTEGER",
+          "nullable": true
+        },
+        {
+          "name": "col",
+          "type": "TEXT",
+          "nullable": true
+        },
+        {
+          "name": "brackets",
+          "type": "TEXT",
+          "nullable": false
+        },
+        {
+          "name": "checkcheck",
+          "type": "TEXT",
+          "nullable": false
+        },
+        {
+          "name": "downcase",
+          "type": "TEXT",
+          "nullable": false
+        },
+        {
+          "name": "nl",
+          "type": "TEXT",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "sqlite_autoindex_check_constraints_4",
+          "def": "UNIQUE (nl)",
+          "table": "check_constraints",
+          "columns": [
+            "nl"
+          ]
+        },
+        {
+          "name": "sqlite_autoindex_check_constraints_3",
+          "def": "UNIQUE (downcase)",
+          "table": "check_constraints",
+          "columns": [
+            "downcase"
+          ]
+        },
+        {
+          "name": "sqlite_autoindex_check_constraints_2",
+          "def": "UNIQUE (checkcheck)",
+          "table": "check_constraints",
+          "columns": [
+            "checkcheck"
+          ]
+        },
+        {
+          "name": "sqlite_autoindex_check_constraints_1",
+          "def": "UNIQUE (brackets)",
+          "table": "check_constraints",
+          "columns": [
+            "brackets"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "id",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "check_constraints",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "sqlite_autoindex_check_constraints_4",
+          "type": "UNIQUE",
+          "def": "UNIQUE (nl)",
+          "table": "check_constraints",
+          "columns": [
+            "nl"
+          ]
+        },
+        {
+          "name": "sqlite_autoindex_check_constraints_3",
+          "type": "UNIQUE",
+          "def": "UNIQUE (downcase)",
+          "table": "check_constraints",
+          "columns": [
+            "downcase"
+          ]
+        },
+        {
+          "name": "sqlite_autoindex_check_constraints_2",
+          "type": "UNIQUE",
+          "def": "UNIQUE (checkcheck)",
+          "table": "check_constraints",
+          "columns": [
+            "checkcheck"
+          ]
+        },
+        {
+          "name": "sqlite_autoindex_check_constraints_1",
+          "type": "UNIQUE",
+          "def": "UNIQUE (brackets)",
+          "table": "check_constraints",
+          "columns": [
+            "brackets"
+          ]
+        },
+        {
+          "name": "-",
+          "type": "CHECK",
+          "def": "CHECK(length(col) \u003e 4)",
+          "table": "check_constraints",
+          "columns": [
+            "col"
+          ]
+        },
+        {
+          "name": "-",
+          "type": "CHECK",
+          "def": "CHECK(((length(brackets) \u003e 4)))",
+          "table": "check_constraints",
+          "columns": [
+            "brackets"
+          ]
+        },
+        {
+          "name": "-",
+          "type": "CHECK",
+          "def": "CHECK(length(checkcheck) \u003e 4)",
+          "table": "check_constraints",
+          "columns": [
+            "checkcheck"
+          ]
+        },
+        {
+          "name": "-",
+          "type": "CHECK",
+          "def": "check(length(downcase) \u003e 4)",
+          "table": "check_constraints",
+          "columns": [
+            "downcase"
+          ]
+        },
+        {
+          "name": "-",
+          "type": "CHECK",
+          "def": "check(length(nl) \u003e 4 OR nl != 'ln')",
+          "table": "check_constraints",
+          "columns": [
+            "nl"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE check_constraints (\n  id INTEGER PRIMARY KEY AUTOINCREMENT,\n  col TEXT CHECK(length(col) \u003e 4),\n  brackets TEXT UNIQUE NOT NULL CHECK(((length(brackets) \u003e 4))),\n  checkcheck TEXT UNIQUE NOT NULL CHECK(length(checkcheck) \u003e 4),\n  downcase TEXT UNIQUE NOT NULL check(length(downcase) \u003e 4),\n  nl TEXT UNIQUE NOT\n    NULL check(length(nl) \u003e 4 OR\n      nl != 'ln')\n)"
+    },
+    {
+      "name": "syslog",
+      "type": "virtual table",
+      "columns": [
+        {
+          "name": "logs",
+          "type": "",
+          "nullable": true
+        }
+      ],
+      "def": "CREATE VIRTUAL TABLE syslog USING fts3(logs)"
+    },
+    {
+      "name": "access_log",
+      "type": "virtual table",
+      "columns": [
+        {
+          "name": "logs",
+          "type": "",
+          "nullable": true
+        }
+      ],
+      "def": "CREATE VIRTUAL TABLE access_log USING fts4(logs)"
+    }
+  ],
+  "relations": [
+    {
+      "table": "user_options",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_one",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id) ON UPDATE NO ACTION ON DELETE CASCADE MATCH NONE"
+    },
+    {
+      "table": "posts",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id) ON UPDATE NO ACTION ON DELETE CASCADE MATCH NONE"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id) ON UPDATE NO ACTION ON DELETE NO ACTION MATCH NONE"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (post_id) REFERENCES posts (id) ON UPDATE NO ACTION ON DELETE NO ACTION MATCH NONE"
+    },
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id) ON UPDATE NO ACTION ON DELETE NO ACTION MATCH NONE"
+    },
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_post_id",
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "post_id",
+        "user_id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id) ON UPDATE NO ACTION ON DELETE NO ACTION MATCH NONE"
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "logs-\u003eusers",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "comment_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "comment_star_id"
+      ],
+      "cardinality": "exactly_one",
+      "parent_table": "comment_stars",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "Additional Relation",
+      "virtual": true
+    }
+  ],
+  "driver": {
+    "name": "sqlite",
+    "database_version": "3.50.3"
+  },
+  "labels": [
+    {
+      "name": "sample",
+      "virtual": true
+    },
+    {
+      "name": "tbls",
+      "virtual": true
+    }
+  ]
+}

--- a/sample/viewpoints/schema.json
+++ b/sample/viewpoints/schema.json
@@ -1,1 +1,1082 @@
-{"name":"testdb","desc":"Sample database document.","tables":[{"name":"CamelizeTable","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"CamelizeTable","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"CamelizeTable","columns":["id"]}],"def":"CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"comment_stars","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false,"labels":[{"name":"user","virtual":true}]},{"name":"comment_post_id","type":"bigint","nullable":false},{"name":"comment_user_id","type":"int","nullable":false},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"comment_stars_user_id_fk","def":"KEY comment_stars_user_id_fk (comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_user_id"]},{"name":"comment_stars_user_id_post_id_fk","def":"KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["comment_post_id","comment_user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comment_stars","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"constraints":[{"name":"comment_stars_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)","table":"comment_stars","referenced_table":"users","columns":["comment_user_id"],"referenced_columns":["id"]},{"name":"comment_stars_user_id_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)","table":"comment_stars","referenced_table":"comments","columns":["comment_post_id","comment_user_id"],"referenced_columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comment_stars","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)","table":"comment_stars","columns":["user_id","comment_post_id","comment_user_id"]}],"def":"CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci","labels":[{"name":"content","virtual":true}]},{"name":"comments","type":"BASE TABLE","comment":"Comments\nMulti-line\r\ntable\rcomment","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"post_id","type":"bigint","nullable":false},{"name":"user_id","type":"int","nullable":false,"labels":[{"name":"user","virtual":true}]},{"name":"comment","type":"text","nullable":false,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"post_id_desc","type":"bigint","nullable":true,"extra_def":"GENERATED ALWAYS AS (`post_id` * -(1)) VIRTUAL"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"comments_post_id_user_id_idx","def":"KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]},{"name":"comments_user_id_fk","def":"KEY comments_user_id_fk (user_id) USING BTREE","table":"comments","columns":["user_id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"comments","columns":["id"]},{"name":"post_id","def":"UNIQUE KEY post_id (post_id, user_id) USING BTREE","table":"comments","columns":["post_id","user_id"]}],"constraints":[{"name":"comments_post_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (post_id) REFERENCES posts (id)","table":"comments","referenced_table":"posts","columns":["post_id"],"referenced_columns":["id"]},{"name":"comments_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"comments","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"post_id","type":"UNIQUE","def":"UNIQUE KEY post_id (post_id, user_id)","table":"comments","columns":["post_id","user_id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"comments","columns":["id"]}],"def":"CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint GENERATED ALWAYS AS ((`post_id` * -(1))) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`),\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'","labels":[{"name":"content","virtual":true}]},{"name":"hyphen-table","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"hyphen-column","type":"text","nullable":false},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"hyphen-table","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"hyphen-table","columns":["id"]}],"def":"CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"logs","type":"BASE TABLE","comment":"Auditログ","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false},{"name":"post_id","type":"bigint","nullable":true},{"name":"comment_id","type":"bigint","nullable":true},{"name":"comment_star_id","type":"bigint","nullable":true},{"name":"payload","type":"text","nullable":true},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"logs","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"logs","columns":["id"]}],"def":"CREATE TABLE `logs` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"},{"name":"long_long_long_long_long_long_long_long_table_name","type":"BASE TABLE","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"created","type":"datetime","nullable":false}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"long_long_long_long_long_long_long_long_table_name","columns":["id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"long_long_long_long_long_long_long_long_table_name","columns":["id"]}],"def":"CREATE TABLE `long_long_long_long_long_long_long_long_table_name` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"},{"name":"post_comments","type":"VIEW","comment":"post and comments View table","columns":[{"name":"id","type":"bigint","nullable":true,"default":"0","comment":"comments.id"},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled","comment":"posts.title"},{"name":"post_user","type":"varchar(50)","nullable":true,"comment":"posts.users.username"},{"name":"comment","type":"text","nullable":true,"comment":"Comment\nMulti-line\r\ncolumn\rcomment"},{"name":"comment_user","type":"varchar(50)","nullable":true,"comment":"comments.users.username"},{"name":"created","type":"datetime","nullable":true,"comment":"comments.created"},{"name":"updated","type":"datetime","nullable":true,"comment":"comments.updated"}],"def":"CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))","labels":[{"name":"content","virtual":true}],"referenced_tables":["posts","comments","users"]},{"name":"posts","type":"BASE TABLE","comment":"Posts table","columns":[{"name":"id","type":"bigint","nullable":false,"extra_def":"auto_increment"},{"name":"user_id","type":"int","nullable":false,"labels":[{"name":"user","virtual":true}]},{"name":"title","type":"varchar(255)","nullable":false,"default":"Untitled"},{"name":"body","type":"text","nullable":false,"comment":"post body"},{"name":"post_type","type":"enum('public','private','draft')","nullable":false,"comment":"public/private/draft"},{"name":"created","type":"datetime","nullable":false},{"name":"updated","type":"datetime","nullable":true}],"indexes":[{"name":"posts_user_id_idx","def":"KEY posts_user_id_idx (id) USING BTREE","table":"posts","columns":["id"]},{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"posts","columns":["id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id, title) USING BTREE","table":"posts","columns":["user_id","title"]}],"constraints":[{"name":"posts_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"posts","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"posts","columns":["id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id, title)","table":"posts","columns":["user_id","title"]}],"triggers":[{"name":"update_posts_updated","def":"CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"}],"def":"CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'","labels":[{"name":"content","virtual":true}]},{"name":"user_options","type":"BASE TABLE","comment":"User options table","columns":[{"name":"user_id","type":"int","nullable":false},{"name":"show_email","type":"tinyint(1)","nullable":false,"default":"0"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (user_id) USING BTREE","table":"user_options","columns":["user_id"]},{"name":"user_id","def":"UNIQUE KEY user_id (user_id) USING BTREE","table":"user_options","columns":["user_id"]}],"constraints":[{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_id","type":"UNIQUE","def":"UNIQUE KEY user_id (user_id)","table":"user_options","columns":["user_id"]},{"name":"user_options_user_id_fk","type":"FOREIGN KEY","def":"FOREIGN KEY (user_id) REFERENCES users (id)","table":"user_options","referenced_table":"users","columns":["user_id"],"referenced_columns":["id"]}],"def":"CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'","labels":[{"name":"user","virtual":true}]},{"name":"users","type":"BASE TABLE","comment":"Users table","columns":[{"name":"id","type":"int","nullable":false,"extra_def":"auto_increment"},{"name":"username","type":"varchar(50)","nullable":false},{"name":"password","type":"varchar(50)","nullable":false,"labels":[{"name":"secure","virtual":true},{"name":"encrypted","virtual":true}]},{"name":"email","type":"varchar(355)","nullable":false,"labels":[{"name":"secure","virtual":true}],"comment":"ex. user@example.com"},{"name":"created","type":"timestamp","nullable":false},{"name":"updated","type":"timestamp","nullable":true}],"indexes":[{"name":"PRIMARY","def":"PRIMARY KEY (id) USING BTREE","table":"users","columns":["id"]},{"name":"email","def":"UNIQUE KEY email (email) USING BTREE","table":"users","columns":["email"]},{"name":"username","def":"UNIQUE KEY username (username) USING BTREE","table":"users","columns":["username"]}],"constraints":[{"name":"email","type":"UNIQUE","def":"UNIQUE KEY email (email)","table":"users","columns":["email"]},{"name":"PRIMARY","type":"PRIMARY KEY","def":"PRIMARY KEY (id)","table":"users","columns":["id"]},{"name":"username","type":"UNIQUE","def":"UNIQUE KEY username (username)","table":"users","columns":["username"]},{"name":"users_chk_1","type":"CHECK","def":"CHECK ((char_length(`username`) \u003e 4))","table":"users"}],"def":"CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`),\n  CONSTRAINT `users_chk_1` CHECK ((char_length(`username`) \u003e 4))\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'","labels":[{"name":"user","virtual":true}]}],"relations":[{"table":"comment_stars","columns":["comment_user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_user_id) REFERENCES users (id)"},{"table":"comment_stars","columns":["comment_post_id","comment_user_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["post_id","user_id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"},{"table":"comments","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (post_id) REFERENCES posts (id)"},{"table":"comments","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"posts","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"user_options","columns":["user_id"],"cardinality":"zero_or_one","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"FOREIGN KEY (user_id) REFERENCES users (id)"},{"table":"logs","columns":["user_id"],"cardinality":"zero_or_more","parent_table":"users","parent_columns":["id"],"parent_cardinality":"exactly_one","def":"logs-\u003eusers","virtual":true},{"table":"logs","columns":["post_id"],"cardinality":"zero_or_more","parent_table":"posts","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"logs","columns":["comment_id"],"cardinality":"zero_or_more","parent_table":"comments","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true},{"table":"logs","columns":["comment_star_id"],"cardinality":"zero_or_more","parent_table":"comment_stars","parent_columns":["id"],"parent_cardinality":"zero_or_one","def":"Additional Relation","virtual":true}],"functions":[{"name":"CustomerLevel","return_type":"varchar","arguments":"credit decimal","type":"FUNCTION"},{"name":"GetAllComments","return_type":"","arguments":"","type":"PROCEDURE"}],"driver":{"name":"mysql","database_version":"8.4.4","meta":{"dict":{"Functions":"Stored procedures and functions"}}},"labels":[{"name":"sample","virtual":true},{"name":"tbls","virtual":true}],"viewpoints":[{"name":"Content","desc":"Content as an asset for blogging services","labels":["content"]},{"name":"Ops","desc":"Tables to be referenced during operation","tables":["logs","users","posts"]},{"name":"Around the users table","desc":"Tables related to the users table","tables":["users"],"distance":1,"groups":[{"name":"Content","desc":"Content as an asset for blogging services","labels":["content"]}]},{"name":"Secure data","desc":"Tables with secure data","labels":["secure"]}]}
+{
+  "name": "testdb",
+  "desc": "Sample database document.",
+  "tables": [
+    {
+      "name": "CamelizeTable",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "CamelizeTable",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `CamelizeTable` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "comment_stars",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false,
+          "labels": [
+            {
+              "name": "user",
+              "virtual": true
+            }
+          ]
+        },
+        {
+          "name": "comment_post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "comment_user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "def": "KEY comment_stars_user_id_fk (comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "def": "KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id) USING BTREE",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comment_stars_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)",
+          "table": "comment_stars",
+          "referenced_table": "users",
+          "columns": [
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comment_stars_user_id_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)",
+          "table": "comment_stars",
+          "referenced_table": "comments",
+          "columns": [
+            "comment_post_id",
+            "comment_user_id"
+          ],
+          "referenced_columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comment_stars",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, comment_post_id, comment_user_id)",
+          "table": "comment_stars",
+          "columns": [
+            "user_id",
+            "comment_post_id",
+            "comment_user_id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comment_stars` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `comment_post_id` bigint NOT NULL,\n  `comment_user_id` int NOT NULL,\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_post_id_fk` (`comment_post_id`,`comment_user_id`),\n  KEY `comment_stars_user_id_fk` (`comment_user_id`),\n  CONSTRAINT `comment_stars_user_id_fk` FOREIGN KEY (`comment_user_id`) REFERENCES `users` (`id`),\n  CONSTRAINT `comment_stars_user_id_post_id_fk` FOREIGN KEY (`comment_post_id`, `comment_user_id`) REFERENCES `comments` (`post_id`, `user_id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci",
+      "labels": [
+        {
+          "name": "content",
+          "virtual": true
+        }
+      ]
+    },
+    {
+      "name": "comments",
+      "type": "BASE TABLE",
+      "comment": "Comments\nMulti-line\r\ntable\rcomment",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": false
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false,
+          "labels": [
+            {
+              "name": "user",
+              "virtual": true
+            }
+          ]
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": false,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "post_id_desc",
+          "type": "bigint",
+          "nullable": true,
+          "extra_def": "GENERATED ALWAYS AS (`post_id` * -(1)) VIRTUAL"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "comments_post_id_user_id_idx",
+          "def": "KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "def": "KEY comments_user_id_fk (user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "def": "UNIQUE KEY post_id (post_id, user_id) USING BTREE",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "comments_post_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (post_id) REFERENCES posts (id)",
+          "table": "comments",
+          "referenced_table": "posts",
+          "columns": [
+            "post_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "comments_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "comments",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "post_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY post_id (post_id, user_id)",
+          "table": "comments",
+          "columns": [
+            "post_id",
+            "user_id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "comments",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `comments` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `post_id` bigint NOT NULL,\n  `user_id` int NOT NULL,\n  `comment` text NOT NULL COMMENT 'Comment\\nMulti-line\\r\\ncolumn\\rcomment',\n  `post_id_desc` bigint GENERATED ALWAYS AS ((`post_id` * -(1))) VIRTUAL,\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `post_id` (`post_id`,`user_id`),\n  KEY `comments_user_id_fk` (`user_id`),\n  KEY `comments_post_id_user_id_idx` (`post_id`,`user_id`),\n  CONSTRAINT `comments_post_id_fk` FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`),\n  CONSTRAINT `comments_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Comments\\nMulti-line\\r\\ntable\\rcomment'",
+      "labels": [
+        {
+          "name": "content",
+          "virtual": true
+        }
+      ]
+    },
+    {
+      "name": "hyphen-table",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "hyphen-column",
+          "type": "text",
+          "nullable": false
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "hyphen-table",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `hyphen-table` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `hyphen-column` text NOT NULL,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "logs",
+      "type": "BASE TABLE",
+      "comment": "Auditログ",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "post_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "comment_star_id",
+          "type": "bigint",
+          "nullable": true
+        },
+        {
+          "name": "payload",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "logs",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `logs` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `post_id` bigint DEFAULT NULL,\n  `comment_id` bigint DEFAULT NULL,\n  `comment_star_id` bigint DEFAULT NULL,\n  `payload` text,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Auditログ'"
+    },
+    {
+      "name": "long_long_long_long_long_long_long_long_table_name",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "long_long_long_long_long_long_long_long_table_name",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "long_long_long_long_long_long_long_long_table_name",
+          "columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `long_long_long_long_long_long_long_long_table_name` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `created` datetime NOT NULL,\n  PRIMARY KEY (`id`)\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci"
+    },
+    {
+      "name": "post_comments",
+      "type": "VIEW",
+      "comment": "post and comments View table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": true,
+          "default": "0",
+          "comment": "comments.id"
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled",
+          "comment": "posts.title"
+        },
+        {
+          "name": "post_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "posts.users.username"
+        },
+        {
+          "name": "comment",
+          "type": "text",
+          "nullable": true,
+          "comment": "Comment\nMulti-line\r\ncolumn\rcomment"
+        },
+        {
+          "name": "comment_user",
+          "type": "varchar(50)",
+          "nullable": true,
+          "comment": "comments.users.username"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.created"
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true,
+          "comment": "comments.updated"
+        }
+      ],
+      "def": "CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2`.`username` AS `post_user`,`c`.`comment` AS `comment`,`u2`.`username` AS `comment_user`,`c`.`created` AS `created`,`c`.`updated` AS `updated` from (((`testdb`.`posts` `p` left join `testdb`.`comments` `c` on((`p`.`id` = `c`.`post_id`))) left join `testdb`.`users` `u` on((`u`.`id` = `p`.`user_id`))) left join `testdb`.`users` `u2` on((`u2`.`id` = `c`.`user_id`))))",
+      "labels": [
+        {
+          "name": "content",
+          "virtual": true
+        }
+      ],
+      "referenced_tables": [
+        "posts",
+        "comments",
+        "users"
+      ]
+    },
+    {
+      "name": "posts",
+      "type": "BASE TABLE",
+      "comment": "Posts table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false,
+          "labels": [
+            {
+              "name": "user",
+              "virtual": true
+            }
+          ]
+        },
+        {
+          "name": "title",
+          "type": "varchar(255)",
+          "nullable": false,
+          "default": "Untitled"
+        },
+        {
+          "name": "body",
+          "type": "text",
+          "nullable": false,
+          "comment": "post body"
+        },
+        {
+          "name": "post_type",
+          "type": "enum('public','private','draft')",
+          "nullable": false,
+          "comment": "public/private/draft"
+        },
+        {
+          "name": "created",
+          "type": "datetime",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "datetime",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "posts_user_id_idx",
+          "def": "KEY posts_user_id_idx (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id, title) USING BTREE",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "posts_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "posts",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "posts",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id, title)",
+          "table": "posts",
+          "columns": [
+            "user_id",
+            "title"
+          ]
+        }
+      ],
+      "triggers": [
+        {
+          "name": "update_posts_updated",
+          "def": "CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts\nFOR EACH ROW\nSET NEW.updated = CURRENT_TIMESTAMP()"
+        }
+      ],
+      "def": "CREATE TABLE `posts` (\n  `id` bigint NOT NULL AUTO_INCREMENT,\n  `user_id` int NOT NULL,\n  `title` varchar(255) NOT NULL DEFAULT 'Untitled',\n  `body` text NOT NULL,\n  `post_type` enum('public','private','draft') NOT NULL COMMENT 'public/private/draft',\n  `created` datetime NOT NULL,\n  `updated` datetime DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `user_id` (`user_id`,`title`),\n  KEY `posts_user_id_idx` (`id`) USING BTREE,\n  CONSTRAINT `posts_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Posts table'",
+      "labels": [
+        {
+          "name": "content",
+          "virtual": true
+        }
+      ]
+    },
+    {
+      "name": "user_options",
+      "type": "BASE TABLE",
+      "comment": "User options table",
+      "columns": [
+        {
+          "name": "user_id",
+          "type": "int",
+          "nullable": false
+        },
+        {
+          "name": "show_email",
+          "type": "tinyint(1)",
+          "nullable": false,
+          "default": "0"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "def": "UNIQUE KEY user_id (user_id) USING BTREE",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_id",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY user_id (user_id)",
+          "table": "user_options",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
+          "name": "user_options_user_id_fk",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (user_id) REFERENCES users (id)",
+          "table": "user_options",
+          "referenced_table": "users",
+          "columns": [
+            "user_id"
+          ],
+          "referenced_columns": [
+            "id"
+          ]
+        }
+      ],
+      "def": "CREATE TABLE `user_options` (\n  `user_id` int NOT NULL,\n  `show_email` tinyint(1) NOT NULL DEFAULT '0',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`user_id`),\n  UNIQUE KEY `user_id` (`user_id`),\n  CONSTRAINT `user_options_user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='User options table'",
+      "labels": [
+        {
+          "name": "user",
+          "virtual": true
+        }
+      ]
+    },
+    {
+      "name": "users",
+      "type": "BASE TABLE",
+      "comment": "Users table",
+      "columns": [
+        {
+          "name": "id",
+          "type": "int",
+          "nullable": false,
+          "extra_def": "auto_increment"
+        },
+        {
+          "name": "username",
+          "type": "varchar(50)",
+          "nullable": false
+        },
+        {
+          "name": "password",
+          "type": "varchar(50)",
+          "nullable": false,
+          "labels": [
+            {
+              "name": "secure",
+              "virtual": true
+            },
+            {
+              "name": "encrypted",
+              "virtual": true
+            }
+          ]
+        },
+        {
+          "name": "email",
+          "type": "varchar(355)",
+          "nullable": false,
+          "labels": [
+            {
+              "name": "secure",
+              "virtual": true
+            }
+          ],
+          "comment": "ex. user@example.com"
+        },
+        {
+          "name": "created",
+          "type": "timestamp",
+          "nullable": false
+        },
+        {
+          "name": "updated",
+          "type": "timestamp",
+          "nullable": true
+        }
+      ],
+      "indexes": [
+        {
+          "name": "PRIMARY",
+          "def": "PRIMARY KEY (id) USING BTREE",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "email",
+          "def": "UNIQUE KEY email (email) USING BTREE",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "username",
+          "def": "UNIQUE KEY username (username) USING BTREE",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "email",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY email (email)",
+          "table": "users",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "PRIMARY",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "users",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "username",
+          "type": "UNIQUE",
+          "def": "UNIQUE KEY username (username)",
+          "table": "users",
+          "columns": [
+            "username"
+          ]
+        },
+        {
+          "name": "users_chk_1",
+          "type": "CHECK",
+          "def": "CHECK ((char_length(`username`) \u003e 4))",
+          "table": "users"
+        }
+      ],
+      "def": "CREATE TABLE `users` (\n  `id` int NOT NULL AUTO_INCREMENT,\n  `username` varchar(50) NOT NULL,\n  `password` varchar(50) NOT NULL,\n  `email` varchar(355) NOT NULL COMMENT 'ex. user@example.com',\n  `created` timestamp NOT NULL,\n  `updated` timestamp NULL DEFAULT NULL,\n  PRIMARY KEY (`id`),\n  UNIQUE KEY `username` (`username`),\n  UNIQUE KEY `email` (`email`),\n  CONSTRAINT `users_chk_1` CHECK ((char_length(`username`) \u003e 4))\n) ENGINE=InnoDB AUTO_INCREMENT=[Redacted by tbls] DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='Users table'",
+      "labels": [
+        {
+          "name": "user",
+          "virtual": true
+        }
+      ]
+    }
+  ],
+  "relations": [
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "comment_stars",
+      "columns": [
+        "comment_post_id",
+        "comment_user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "post_id",
+        "user_id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (post_id) REFERENCES posts (id)"
+    },
+    {
+      "table": "comments",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "posts",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "user_options",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_one",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (user_id) REFERENCES users (id)"
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "user_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "users",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "logs-\u003eusers",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "post_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "posts",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "comment_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comments",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    },
+    {
+      "table": "logs",
+      "columns": [
+        "comment_star_id"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "comment_stars",
+      "parent_columns": [
+        "id"
+      ],
+      "parent_cardinality": "zero_or_one",
+      "def": "Additional Relation",
+      "virtual": true
+    }
+  ],
+  "functions": [
+    {
+      "name": "CustomerLevel",
+      "return_type": "varchar",
+      "arguments": "credit decimal",
+      "type": "FUNCTION"
+    },
+    {
+      "name": "GetAllComments",
+      "return_type": "",
+      "arguments": "",
+      "type": "PROCEDURE"
+    }
+  ],
+  "driver": {
+    "name": "mysql",
+    "database_version": "8.4.6",
+    "meta": {
+      "dict": {
+        "Functions": "Stored procedures and functions"
+      }
+    }
+  },
+  "labels": [
+    {
+      "name": "sample",
+      "virtual": true
+    },
+    {
+      "name": "tbls",
+      "virtual": true
+    }
+  ],
+  "viewpoints": [
+    {
+      "name": "Content",
+      "desc": "Content as an asset for blogging services",
+      "labels": [
+        "content"
+      ]
+    },
+    {
+      "name": "Ops",
+      "desc": "Tables to be referenced during operation",
+      "tables": [
+        "logs",
+        "users",
+        "posts"
+      ]
+    },
+    {
+      "name": "Around the users table",
+      "desc": "Tables related to the users table",
+      "tables": [
+        "users"
+      ],
+      "distance": 1,
+      "groups": [
+        {
+          "name": "Content",
+          "desc": "Content as an asset for blogging services",
+          "labels": [
+            "content"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Secure data",
+      "desc": "Tables with secure data",
+      "labels": [
+        "secure"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Changes to JSON formatting:

* Updated the `json.New` call in `cmd/doc.go` to use compact JSON formatting (`false` parameter), reducing unnecessary whitespace in the output.