### PR TITLE
Fix databricks top level arrays

### DIFF
--- a/drivers/databricks/databricks_test.go
+++ b/drivers/databricks/databricks_test.go
@@ -240,7 +240,7 @@ func TestBuildConstraintDefinition(t *testing.T) {
 	}
 }
 
-func TestHasStructColumns(t *testing.T) {
+func TestHasComplexColumns(t *testing.T) {
 	tests := []struct {
 		name    string
 		columns []*schema.Column
@@ -349,9 +349,9 @@ func TestHasStructColumns(t *testing.T) {
 	dbx := &Databricks{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := dbx.hasStructColumns(tt.columns)
+			got := dbx.hasComplexColumns(tt.columns)
 			if got != tt.want {
-				t.Errorf("hasStructColumns() = %v, want %v", got, tt.want)
+				t.Errorf("hasComplexColumns() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
An error was present in the handling of top level array fields for Databricks tables, where the element type wasn't being correctly identified, so `ARRAY` was documented as the field type rather than `ARRAY(STRING)`. More seriously if the array member was a struct the struct wasn't expanded, so only the array field was listed, any struct members were missing.

This behaviour was actually captured in[ an existing unit test](https://github.com/k1LoW/tbls/compare/main...Ewan-Keith:tbls:fix-databricks-top-level-arrays?expand=1#diff-111af079bb8789c99868fb4ee5f9c9d8ecae6908ad3bc57c7b1d8cc19eb29a0fL588), I just missed that it wasn't the desired behaviour when implementing previously.

This PR simply fixes this issue, so that top level arrays have their element types reported, and if a struct or map is a member these are expanded properly. The issue was a slightly different structure to the JSON data returned by the API when capturing this information for top level fields compared to nested ones.

The fact that this behaviour was encoded in a test and I missed it suggests the implementation was a little too complex, so I've taken the opportunity to refactor it out a bit and expand unit test coverage around this case, most of this PR is refactor and test additions. The key functional changes are:
* `hasStructColumns` is now `hasComplexColumns` ([link](https://github.com/k1LoW/tbls/compare/main...Ewan-Keith:tbls:fix-databricks-top-level-arrays?expand=1#diff-d31b731ea894ba21ecb1e264075fc7192edf6a977dcf1f7db71775c2ff44e1aaR587)), the code needs to investigate Arrays and Maps as it did for structs.
* When handling Array types we now handle both forms of JSON data that can be returned from the DBx API ([link](https://github.com/k1LoW/tbls/compare/main...Ewan-Keith:tbls:fix-databricks-top-level-arrays?expand=1#diff-d31b731ea894ba21ecb1e264075fc7192edf6a977dcf1f7db71775c2ff44e1aaR802-R809)).