### PR TITLE
feat: add --verbose and --skip-partitions flags for doc/out commands

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 
+	"github.com/k1LoW/tbls/cmdutil"
 	"github.com/k1LoW/tbls/config"
 	"github.com/k1LoW/tbls/datasource"
 	"github.com/k1LoW/tbls/schema"
@@ -10,6 +11,7 @@ import (
 
 func getSchemaFromJSONorDSN(c *config.Config) (*schema.Schema, error) {
 	if _, err := os.Stat(c.SchemaFilePath()); err == nil {
+		cmdutil.Verbosef("Reading schema from existing JSON file: %s", c.SchemaFilePath())
 		s, err := datasource.AnalyzeJSONStringOrFile(c.SchemaFilePath())
 		if err != nil {
 			return nil, err
@@ -17,12 +19,15 @@ func getSchemaFromJSONorDSN(c *config.Config) (*schema.Schema, error) {
 		if err := c.FilterTables(s); err != nil {
 			return nil, err
 		}
+		cmdutil.Verbosef("Schema loaded from JSON: %d tables", len(s.Tables))
 		return s, nil
 	}
+	cmdutil.Verbosef("Analyzing database schema from DSN")
 	s, err := datasource.Analyze(c.DSN)
 	if err != nil {
 		return nil, err
 	}
+	cmdutil.Verbosef("Schema analysis complete: %d tables found", len(s.Tables))
 	if err := c.ModifySchema(s); err != nil {
 		return nil, err
 	}

--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -38,8 +38,10 @@ import (
 )
 
 var (
-	withoutER bool
-	rmDist    bool
+	withoutER      bool
+	rmDist         bool
+	verbose        bool
+	skipPartitions bool
 )
 
 // docCmd represents the doc command.
@@ -48,6 +50,10 @@ var docCmd = &cobra.Command{
 	Short: "document a database",
 	Long:  `'tbls doc' analyzes a database and generate document in GitHub Friendly Markdown format.`,
 	RunE: func(_ *cobra.Command, args []string) error {
+		cmdutil.SetVerbose(verbose)
+		cmdutil.SetSkipPartitions(skipPartitions)
+		cmdutil.Verbosef("Starting tbls doc")
+
 		if allow, err := cmdutil.IsAllowedToExecute(when); !allow || err != nil {
 			if err != nil {
 				return err
@@ -55,6 +61,7 @@ var docCmd = &cobra.Command{
 			return nil
 		}
 
+		cmdutil.Verbosef("Loading configuration")
 		c, err := config.New()
 		if err != nil {
 			return err
@@ -68,12 +75,16 @@ var docCmd = &cobra.Command{
 		if err := c.Load(configPath, options...); err != nil {
 			return err
 		}
+		cmdutil.Verbosef("Configuration loaded (DSN: %s)", cmdutil.MaskDSN(c.DSN.URL))
 
+		cmdutil.Verbosef("Analyzing database schema")
 		s, err := datasource.Analyze(c.DSN)
 		if err != nil {
 			return err
 		}
+		cmdutil.Verbosef("Schema analysis complete: %d tables found", len(s.Tables))
 
+		cmdutil.Verbosef("Modifying schema with config options")
 		if err := c.ModifySchema(s); err != nil {
 			return err
 		}
@@ -93,22 +104,28 @@ var docCmd = &cobra.Command{
 		}
 
 		if c.NeedToGenerateERImages() {
+			cmdutil.Verbosef("Generating ER diagrams")
 			if err := gviz.Output(s, c, force); err != nil {
 				return err
 			}
+			cmdutil.Verbosef("ER diagrams complete")
 		}
 
+		cmdutil.Verbosef("Generating markdown documentation")
 		if err := md.Output(s, c, force); err != nil {
 			return err
 		}
+		cmdutil.Verbosef("Markdown documentation complete")
 
 		// output schema.json
 		if !c.DisableOutputSchema {
+			cmdutil.Verbosef("Writing schema.json")
 			if err := withSchemaFile(s, c); err != nil {
 				return err
 			}
 		}
 
+		cmdutil.Verbosef("Done")
 		return nil
 	},
 }
@@ -177,6 +194,8 @@ func init() {
 	docCmd.Flags().StringSliceVarP(&includes, "include", "", []string{}, "tables to include")
 	docCmd.Flags().StringSliceVarP(&excludes, "exclude", "", []string{}, "tables to exclude")
 	docCmd.Flags().StringSliceVarP(&labels, "label", "", []string{}, "table labels to be included")
+	docCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
+	docCmd.Flags().BoolVarP(&skipPartitions, "skip-partitions", "", false, "skip table partitions (PostgreSQL)")
 
 	if err := docCmd.MarkZshCompPositionalArgumentFile(2); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "%s\n", err)

--- a/cmd/out.go
+++ b/cmd/out.go
@@ -53,6 +53,10 @@ var outCmd = &cobra.Command{
 	Short: "analyzes a database and output",
 	Long:  `'tbls out' analyzes a database and output.`,
 	RunE: func(_ *cobra.Command, args []string) error {
+		cmdutil.SetVerbose(verbose)
+		cmdutil.SetSkipPartitions(skipPartitions)
+		cmdutil.Verbosef("Starting tbls out")
+
 		if allow, err := cmdutil.IsAllowedToExecute(when); !allow || err != nil {
 			if err != nil {
 				return err
@@ -60,6 +64,7 @@ var outCmd = &cobra.Command{
 			return nil
 		}
 
+		cmdutil.Verbosef("Loading configuration")
 		c, err := config.New()
 		if err != nil {
 			return err
@@ -168,4 +173,6 @@ func init() {
 	outCmd.Flags().StringSliceVarP(&labels, "label", "", []string{}, "table labels to be included")
 	outCmd.Flags().IntVarP(&distance, "distance", "", 0, "distance between related tables to be displayed")
 	outCmd.Flags().StringVarP(&when, "when", "", "", "command execute condition")
+	outCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
+	outCmd.Flags().BoolVarP(&skipPartitions, "skip-partitions", "", false, "skip table partitions (PostgreSQL)")
 }

--- a/cmdutil/verbose.go
+++ b/cmdutil/verbose.go
@@ -1,0 +1,73 @@
+package cmdutil
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"regexp"
+	"time"
+)
+
+var verbose bool
+var startTime time.Time
+var skipPartitions bool
+
+// SetVerbose enables or disables verbose logging.
+func SetVerbose(v bool) {
+	verbose = v
+	if v {
+		startTime = time.Now()
+	}
+}
+
+// IsVerbose returns whether verbose logging is enabled.
+func IsVerbose() bool {
+	return verbose
+}
+
+// Verbosef prints a verbose message with elapsed time if verbose mode is enabled.
+func Verbosef(format string, args ...interface{}) {
+	if !verbose {
+		return
+	}
+	elapsed := time.Since(startTime)
+	msg := fmt.Sprintf(format, args...)
+	fmt.Fprintf(os.Stderr, "[%7.2fs] %s\n", elapsed.Seconds(), msg)
+}
+
+// SetSkipPartitions enables or disables skipping table partitions.
+func SetSkipPartitions(v bool) {
+	skipPartitions = v
+}
+
+// SkipPartitions returns whether to skip table partitions.
+func SkipPartitions() bool {
+	return skipPartitions
+}
+
+// MaskDSN masks the password in a DSN URL for safe logging.
+func MaskDSN(dsn string) string {
+	// Try to parse as URL first
+	u, err := url.Parse(dsn)
+	if err == nil && u.User != nil {
+		if _, hasPassword := u.User.Password(); hasPassword {
+			// Rebuild manually to avoid URL encoding of ****
+			masked := u.Scheme + "://" + u.User.Username() + ":****@" + u.Host + u.Path
+			if u.RawQuery != "" {
+				masked += "?" + u.RawQuery
+			}
+			return masked
+		}
+		return dsn
+	}
+
+	// Fallback: use regex for various DSN formats
+	// Matches patterns like user:password@ or password=secret
+	re := regexp.MustCompile(`(://[^:]+:)[^@]+(@)`)
+	masked := re.ReplaceAllString(dsn, "${1}****${2}")
+
+	re2 := regexp.MustCompile(`(password=)[^\s&]+`)
+	masked = re2.ReplaceAllString(masked, "${1}****")
+
+	return masked
+}

--- a/datasource/datasource.go
+++ b/datasource/datasource.go
@@ -18,6 +18,7 @@ import (
 	"github.com/k1LoW/errors"
 	"github.com/k1LoW/ghfs"
 	"github.com/k1LoW/go-github-client/v67/factory"
+	"github.com/k1LoW/tbls/cmdutil"
 	"github.com/k1LoW/tbls/config"
 	"github.com/k1LoW/tbls/drivers"
 	"github.com/k1LoW/tbls/drivers/clickhouse"
@@ -109,6 +110,7 @@ func Analyze(dsn config.DSN) (_ *schema.Schema, err error) {
 		urlstr = u.String()
 	}
 
+	cmdutil.Verbosef("Opening database connection")
 	db, err := dburl.Open(urlstr)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -116,9 +118,11 @@ func Analyze(dsn config.DSN) (_ *schema.Schema, err error) {
 	defer func() {
 		_ = db.Close()
 	}()
+	cmdutil.Verbosef("Pinging database")
 	if err := db.Ping(); err != nil {
 		return nil, errors.WithStack(err)
 	}
+	cmdutil.Verbosef("Database connection established")
 
 	var driver drivers.Driver
 
@@ -155,10 +159,12 @@ func Analyze(dsn config.DSN) (_ *schema.Schema, err error) {
 	default:
 		return s, fmt.Errorf("unsupported driver '%s'", u.Driver)
 	}
+	cmdutil.Verbosef("Running driver analysis for %s", u.Driver)
 	err = driver.Analyze(s)
 	if err != nil {
 		return nil, err
 	}
+	cmdutil.Verbosef("Driver analysis complete")
 	return s, nil
 }
 

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aquasecurity/go-version/pkg/version"
 	"github.com/k1LoW/errors"
+	"github.com/k1LoW/tbls/cmdutil"
 	"github.com/k1LoW/tbls/ddl"
 	"github.com/k1LoW/tbls/dict"
 	"github.com/k1LoW/tbls/schema"
@@ -36,13 +37,16 @@ func (p *Postgres) Analyze(s *schema.Schema) (err error) {
 	defer func() {
 		err = errors.WithStack(err)
 	}()
+	cmdutil.Verbosef("Fetching database version info")
 	d, err := p.Info()
 	if err != nil {
 		return errors.WithStack(err)
 	}
 	s.Driver = d
+	cmdutil.Verbosef("Database version: %s", d.DatabaseVersion)
 
 	// current schema
+	cmdutil.Verbosef("Querying current schema")
 	var currentSchema sql.NullString
 	schemaRows, err := p.db.Query(`SELECT current_schema()`)
 	if err != nil {
@@ -98,24 +102,8 @@ func (p *Postgres) Analyze(s *schema.Schema) (err error) {
 	fullTableNames := []string{}
 
 	// tables
-	tableRows, err := p.db.Query(`
-SELECT
-    cls.oid AS oid,
-    cls.relname AS table_name,
-    CASE
-        WHEN cls.relkind IN ('r', 'p') THEN 'BASE TABLE'
-        WHEN cls.relkind = 'v' THEN 'VIEW'
-        WHEN cls.relkind = 'm' THEN 'MATERIALIZED VIEW'
-        WHEN cls.relkind = 'f' THEN 'FOREIGN TABLE'
-    END AS table_type,
-    ns.nspname AS table_schema,
-    descr.description AS table_comment
-FROM pg_class AS cls
-INNER JOIN pg_namespace AS ns ON cls.relnamespace = ns.oid
-LEFT JOIN pg_description AS descr ON cls.oid = descr.objoid AND descr.objsubid = 0
-WHERE ns.nspname NOT IN ('pg_catalog', 'information_schema')
-AND cls.relkind IN ('r', 'p', 'v', 'f', 'm')
-ORDER BY oid`)
+	cmdutil.Verbosef("Querying tables")
+	tableRows, err := p.db.Query(p.queryForTables())
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -138,6 +126,7 @@ ORDER BY oid`)
 		}
 
 		name := fmt.Sprintf("%s.%s", tableSchema, tableName)
+		cmdutil.Verbosef("Processing table: %s (%s)", name, tableType)
 
 		fullTableNames = append(fullTableNames, name)
 
@@ -323,27 +312,55 @@ ORDER BY tgrelid
 		tables = append(tables, table)
 	}
 
+	cmdutil.Verbosef("Querying functions and procedures")
 	functions, err := p.getFunctions()
 	if err != nil {
 		return err
 	}
 	s.Functions = functions
+	cmdutil.Verbosef("Found %d functions/procedures", len(functions))
 
 	// Enums
+	cmdutil.Verbosef("Querying enums")
 	enums, err := p.getEnums()
 	if err != nil {
 		return err
 	}
 	s.Enums = enums
+	cmdutil.Verbosef("Found %d enums", len(enums))
 
 	s.Tables = tables
+	cmdutil.Verbosef("Found %d tables total", len(tables))
 
 	// Relations
+	cmdutil.Verbosef("Processing %d relations", len(relations))
+	validRelations := []*schema.Relation{}
+	skippedRelations := 0
 	for _, r := range relations {
 		strColumns, strParentTable, strParentColumns, err := parseFK(r.Def)
 		if err != nil {
 			return err
 		}
+
+		dn, err := detectFullTableName(strParentTable, s.Driver.Meta.SearchPaths, fullTableNames)
+		if err != nil {
+			if cmdutil.SkipPartitions() {
+				// Skip relations referencing tables not in our list (likely skipped partitions)
+				skippedRelations++
+				continue
+			}
+			return err
+		}
+		strParentTable = dn
+		parentTable, err := s.FindTableByName(strParentTable)
+		if err != nil {
+			if cmdutil.SkipPartitions() {
+				skippedRelations++
+				continue
+			}
+			return err
+		}
+
 		for _, c := range strColumns {
 			column, err := r.Table.FindColumnByName(c)
 			if err != nil {
@@ -353,15 +370,6 @@ ORDER BY tgrelid
 			column.ParentRelations = append(column.ParentRelations, r)
 		}
 
-		dn, err := detectFullTableName(strParentTable, s.Driver.Meta.SearchPaths, fullTableNames)
-		if err != nil {
-			return err
-		}
-		strParentTable = dn
-		parentTable, err := s.FindTableByName(strParentTable)
-		if err != nil {
-			return err
-		}
 		r.ParentTable = parentTable
 		for _, c := range strParentColumns {
 			column, err := parentTable.FindColumnByName(c)
@@ -371,9 +379,13 @@ ORDER BY tgrelid
 			r.ParentColumns = append(r.ParentColumns, column)
 			column.ChildRelations = append(column.ChildRelations, r)
 		}
+		validRelations = append(validRelations, r)
 	}
 
-	s.Relations = relations
+	if skippedRelations > 0 {
+		cmdutil.Verbosef("Skipped %d relations referencing excluded tables", skippedRelations)
+	}
+	s.Relations = validRelations
 
 	// referenced tables of view
 	for _, t := range s.Tables {
@@ -709,6 +721,42 @@ LEFT JOIN pg_description AS descr ON idx.indexrelid = descr.objoid
 WHERE idx.indrelid = $1::oid
 GROUP BY cls.relname, idx.indexrelid, descr.description
 ORDER BY idx.indexrelid`
+}
+
+func (p *Postgres) queryForTables() string {
+	baseQuery := `
+SELECT
+    cls.oid AS oid,
+    cls.relname AS table_name,
+    CASE
+        WHEN cls.relkind IN ('r', 'p') THEN 'BASE TABLE'
+        WHEN cls.relkind = 'v' THEN 'VIEW'
+        WHEN cls.relkind = 'm' THEN 'MATERIALIZED VIEW'
+        WHEN cls.relkind = 'f' THEN 'FOREIGN TABLE'
+    END AS table_type,
+    ns.nspname AS table_schema,
+    descr.description AS table_comment
+FROM pg_class AS cls
+INNER JOIN pg_namespace AS ns ON cls.relnamespace = ns.oid
+LEFT JOIN pg_description AS descr ON cls.oid = descr.objoid AND descr.objsubid = 0
+WHERE ns.nspname NOT IN ('pg_catalog', 'information_schema')
+AND cls.relkind IN ('r', 'p', 'v', 'f', 'm')`
+
+	if cmdutil.SkipPartitions() {
+		// Exclude tables that are partitions of a partitioned table
+		baseQuery += `
+AND NOT EXISTS (
+    SELECT 1 FROM pg_inherits inh
+    INNER JOIN pg_class parent ON inh.inhparent = parent.oid
+    WHERE inh.inhrelid = cls.oid
+    AND parent.relkind = 'p'
+)`
+		cmdutil.Verbosef("Skipping table partitions")
+	}
+
+	baseQuery += `
+ORDER BY oid`
+	return baseQuery
 }
 
 func detectFullTableName(name string, searchPaths, fullTableNames []string) (_ string, err error) {


### PR DESCRIPTION
NOTE: I used Claude Code for these changes.

If this is desirable, I'm happy to split out the `--skip-partitions` changes and the `--verbose` changes into two PRs (or drop the verbose one if not desired).

## Summary

- Add `--verbose`/`-v` flag to show progress with elapsed timestamps during database analysis
- Add `--skip-partitions` flag to skip PostgreSQL table partitions (useful for databases with many partitions)
- Skip relations referencing excluded partition tables when `--skip-partitions` is enabled
- Mask passwords in DSN URLs when verbose logging is enabled
- Add verbose logging throughout datasource connection and postgres driver to help diagnose slow operations

## Motivation

When running `tbls doc` against a PostgreSQL database through a proxy (e.g., Aurora), the command can appear to hang with no feedback. These changes help users:

1. See real-time progress to identify where time is spent
2. Skip partition tables that can significantly slow down analysis (each partition requires separate queries for columns, indexes, constraints, etc.)

## Example output

```
[   0.00s] Starting tbls doc
[   0.00s] Loading configuration
[   0.00s] Configuration loaded (DSN: postgres://user:****@host:5432/db)
[   0.00s] Analyzing database schema
[   0.00s] Opening database connection
[   5.32s] Pinging database
[  10.45s] Database connection established
[  10.45s] Running driver analysis for postgres
[  10.46s] Fetching database version info
[  10.52s] Querying tables
[  10.53s] Skipping table partitions
[  12.30s] Processing table: public.users (BASE TABLE)
...
```

## Test plan

- [x] Verified `--verbose` shows progress with SQLite test database
- [x] Verified `--skip-partitions` excludes partition tables
- [x] Verified password masking in verbose output
- [x] Verified `tbls out` command also supports both flags
- [x] Tested against real Aurora PostgreSQL with partitioned tables