### PR TITLE
fix: resolve golangci-lint errors (gosec, revive, staticcheck)

### DIFF
--- a/coverage/coverage.go
+++ b/coverage/coverage.go
@@ -1,4 +1,4 @@
-package coverage
+package coverage //nolint:revive
 
 import (
 	"math"

--- a/coverage/coverage_test.go
+++ b/coverage/coverage_test.go
@@ -1,4 +1,4 @@
-package coverage
+package coverage //nolint:revive
 
 import (
 	"database/sql"

--- a/datasource/datasource.go
+++ b/datasource/datasource.go
@@ -176,7 +176,7 @@ func AnalyzeHTTPResource(dsn config.DSN) (_ *schema.Schema, err error) {
 		req.Header.Add(k, v)
 	}
 	client := &http.Client{Timeout: time.Duration(10) * time.Second}
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) //nolint:gosec
 	if err != nil {
 		return nil, err
 	}

--- a/datasource/gcp.go
+++ b/datasource/gcp.go
@@ -64,7 +64,9 @@ func NewBigqueryClient(ctx context.Context, urlstr string) (*bigquery.Client, st
 	}
 
 	if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") == "" && os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON") != "" {
-		creds, err := google.CredentialsFromJSON(ctx, []byte(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON")), bigquery.Scope)
+		creds, err := google.CredentialsFromJSONWithTypeAndParams(ctx, []byte(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON")), google.ServiceAccount, google.CredentialsParams{
+			Scopes: []string{bigquery.Scope},
+		})
 		if err != nil {
 			return nil, "", "", err
 		}
@@ -136,7 +138,9 @@ func NewSpannerClient(ctx context.Context, urlstr string) (*cloudspanner.Client,
 	}
 
 	if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS") == "" && os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON") != "" {
-		creds, err := google.CredentialsFromJSON(ctx, []byte(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON")), cloudspanner.Scope)
+		creds, err := google.CredentialsFromJSONWithTypeAndParams(ctx, []byte(os.Getenv("GOOGLE_APPLICATION_CREDENTIALS_JSON")), google.ServiceAccount, google.CredentialsParams{
+			Scopes: []string{cloudspanner.Scope},
+		})
 		if err != nil {
 			return nil, "", err
 		}

--- a/output/xlsx/xlsx.go
+++ b/output/xlsx/xlsx.go
@@ -54,7 +54,7 @@ func (x *Xlsx) OutputSchema(wr io.Writer, s *schema.Schema) (e error) {
 	if err != nil {
 		return err
 	}
-	b, err := os.ReadFile(filepath.Clean(path))
+	b, err := os.ReadFile(filepath.Clean(path)) //nolint:gosec
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func (x *Xlsx) OutputTable(wr io.Writer, t *schema.Table) (e error) {
 	if err != nil {
 		return err
 	}
-	b, err := os.ReadFile(filepath.Clean(path))
+	b, err := os.ReadFile(filepath.Clean(path)) //nolint:gosec
 	if err != nil {
 		return err
 	}

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
-package version
+package version //nolint:revive
 
 // Name for this.
 const Name string = "tbls"


### PR DESCRIPTION
## Summary
- Add `//nolint:gosec` for G704 (SSRF false positive in `datasource/datasource.go`) and G703 (path traversal false positive in `output/xlsx/xlsx.go`)
- Add `//nolint:revive` for var-naming warnings on `coverage` and `version` packages that conflict with Go standard library names
- Replace deprecated `google.CredentialsFromJSON` with `google.CredentialsFromJSONWithTypeAndParams` in `datasource/gcp.go`
