### PR TITLE
feat: add --verbose flag for doc/out commands

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 
+	"github.com/k1LoW/tbls/cmdutil"
 	"github.com/k1LoW/tbls/config"
 	"github.com/k1LoW/tbls/datasource"
 	"github.com/k1LoW/tbls/schema"
@@ -10,6 +11,7 @@ import (
 
 func getSchemaFromJSONorDSN(c *config.Config) (*schema.Schema, error) {
 	if _, err := os.Stat(c.SchemaFilePath()); err == nil {
+		cmdutil.Verbosef("Reading schema from existing JSON file: %s", c.SchemaFilePath())
 		s, err := datasource.AnalyzeJSONStringOrFile(c.SchemaFilePath())
 		if err != nil {
 			return nil, err
@@ -17,12 +19,15 @@ func getSchemaFromJSONorDSN(c *config.Config) (*schema.Schema, error) {
 		if err := c.FilterTables(s); err != nil {
 			return nil, err
 		}
+		cmdutil.Verbosef("Schema loaded from JSON: %d tables", len(s.Tables))
 		return s, nil
 	}
+	cmdutil.Verbosef("Analyzing database schema from DSN")
 	s, err := datasource.Analyze(c.DSN)
 	if err != nil {
 		return nil, err
 	}
+	cmdutil.Verbosef("Schema analysis complete: %d tables found", len(s.Tables))
 	if err := c.ModifySchema(s); err != nil {
 		return nil, err
 	}

--- a/cmd/doc.go
+++ b/cmd/doc.go
@@ -40,6 +40,7 @@ import (
 var (
 	withoutER bool
 	rmDist    bool
+	verbose   bool
 )
 
 // docCmd represents the doc command.
@@ -48,6 +49,9 @@ var docCmd = &cobra.Command{
 	Short: "document a database",
 	Long:  `'tbls doc' analyzes a database and generate document in GitHub Friendly Markdown format.`,
 	RunE: func(_ *cobra.Command, args []string) error {
+		cmdutil.SetVerbose(verbose)
+		cmdutil.Verbosef("Starting tbls doc")
+
 		if allow, err := cmdutil.IsAllowedToExecute(when); !allow || err != nil {
 			if err != nil {
 				return err
@@ -55,6 +59,7 @@ var docCmd = &cobra.Command{
 			return nil
 		}
 
+		cmdutil.Verbosef("Loading configuration")
 		c, err := config.New()
 		if err != nil {
 			return err
@@ -68,12 +73,16 @@ var docCmd = &cobra.Command{
 		if err := c.Load(configPath, options...); err != nil {
 			return err
 		}
+		cmdutil.Verbosef("Configuration loaded (DSN: %s)", cmdutil.MaskDSN(c.DSN.URL))
 
+		cmdutil.Verbosef("Analyzing database schema")
 		s, err := datasource.Analyze(c.DSN)
 		if err != nil {
 			return err
 		}
+		cmdutil.Verbosef("Schema analysis complete: %d tables found", len(s.Tables))
 
+		cmdutil.Verbosef("Modifying schema with config options")
 		if err := c.ModifySchema(s); err != nil {
 			return err
 		}
@@ -93,22 +102,28 @@ var docCmd = &cobra.Command{
 		}
 
 		if c.NeedToGenerateERImages() {
+			cmdutil.Verbosef("Generating ER diagrams")
 			if err := gviz.Output(s, c, force); err != nil {
 				return err
 			}
+			cmdutil.Verbosef("ER diagrams complete")
 		}
 
+		cmdutil.Verbosef("Generating markdown documentation")
 		if err := md.Output(s, c, force); err != nil {
 			return err
 		}
+		cmdutil.Verbosef("Markdown documentation complete")
 
 		// output schema.json
 		if !c.DisableOutputSchema {
+			cmdutil.Verbosef("Writing schema.json")
 			if err := withSchemaFile(s, c); err != nil {
 				return err
 			}
 		}
 
+		cmdutil.Verbosef("Done")
 		return nil
 	},
 }
@@ -177,6 +192,7 @@ func init() {
 	docCmd.Flags().StringSliceVarP(&includes, "include", "", []string{}, "tables to include")
 	docCmd.Flags().StringSliceVarP(&excludes, "exclude", "", []string{}, "tables to exclude")
 	docCmd.Flags().StringSliceVarP(&labels, "label", "", []string{}, "table labels to be included")
+	docCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 
 	if err := docCmd.MarkZshCompPositionalArgumentFile(2); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "%s\n", err)

--- a/cmd/out.go
+++ b/cmd/out.go
@@ -53,6 +53,9 @@ var outCmd = &cobra.Command{
 	Short: "analyzes a database and output",
 	Long:  `'tbls out' analyzes a database and output.`,
 	RunE: func(_ *cobra.Command, args []string) error {
+		cmdutil.SetVerbose(verbose)
+		cmdutil.Verbosef("Starting tbls out")
+
 		if allow, err := cmdutil.IsAllowedToExecute(when); !allow || err != nil {
 			if err != nil {
 				return err
@@ -60,6 +63,7 @@ var outCmd = &cobra.Command{
 			return nil
 		}
 
+		cmdutil.Verbosef("Loading configuration")
 		c, err := config.New()
 		if err != nil {
 			return err
@@ -168,4 +172,5 @@ func init() {
 	outCmd.Flags().StringSliceVarP(&labels, "label", "", []string{}, "table labels to be included")
 	outCmd.Flags().IntVarP(&distance, "distance", "", 0, "distance between related tables to be displayed")
 	outCmd.Flags().StringVarP(&when, "when", "", "", "command execute condition")
+	outCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
 }

--- a/cmdutil/verbose.go
+++ b/cmdutil/verbose.go
@@ -1,0 +1,62 @@
+package cmdutil
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"regexp"
+	"time"
+)
+
+var verbose bool
+var startTime time.Time
+
+// SetVerbose enables or disables verbose logging.
+func SetVerbose(v bool) {
+	verbose = v
+	if v {
+		startTime = time.Now()
+	}
+}
+
+// IsVerbose returns whether verbose logging is enabled.
+func IsVerbose() bool {
+	return verbose
+}
+
+// Verbosef prints a verbose message with elapsed time if verbose mode is enabled.
+func Verbosef(format string, args ...interface{}) {
+	if !verbose {
+		return
+	}
+	elapsed := time.Since(startTime)
+	msg := fmt.Sprintf(format, args...)
+	fmt.Fprintf(os.Stderr, "[%7.2fs] %s\n", elapsed.Seconds(), msg)
+}
+
+// MaskDSN masks the password in a DSN URL for safe logging.
+func MaskDSN(dsn string) string {
+	// Try to parse as URL first
+	u, err := url.Parse(dsn)
+	if err == nil && u.User != nil {
+		if _, hasPassword := u.User.Password(); hasPassword {
+			// Rebuild manually to avoid URL encoding of ****
+			masked := u.Scheme + "://" + u.User.Username() + ":****@" + u.Host + u.Path
+			if u.RawQuery != "" {
+				masked += "?" + u.RawQuery
+			}
+			return masked
+		}
+		return dsn
+	}
+
+	// Fallback: use regex for various DSN formats
+	// Matches patterns like user:password@ or password=secret
+	re := regexp.MustCompile(`(://[^:]+:)[^@]+(@)`)
+	masked := re.ReplaceAllString(dsn, "${1}****${2}")
+
+	re2 := regexp.MustCompile(`(password=)[^\s&]+`)
+	masked = re2.ReplaceAllString(masked, "${1}****")
+
+	return masked
+}

--- a/cmdutil/verbose_test.go
+++ b/cmdutil/verbose_test.go
@@ -1,0 +1,43 @@
+package cmdutil
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMaskDSN(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"postgres url with password", "postgres://user:secret@host:5432/db", "postgres://user:****@host:5432/db"},
+		{"postgres url with query", "postgres://user:secret@host/db?sslmode=disable", "postgres://user:****@host/db?sslmode=disable"},
+		{"url without password", "postgres://user@host/db", "postgres://user@host/db"},
+		{"no credentials", "postgres://host/db", "postgres://host/db"},
+		{"key-value dsn", "host=h user=u password=secret dbname=d", "host=h user=u password=**** dbname=d"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MaskDSN(tt.in)
+			if got != tt.want {
+				t.Errorf("MaskDSN(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+			if strings.Contains(got, "secret") {
+				t.Errorf("MaskDSN(%q) leaked password: %q", tt.in, got)
+			}
+		})
+	}
+}
+
+func TestSetVerboseAndIsVerbose(t *testing.T) {
+	t.Cleanup(func() { SetVerbose(false) })
+	SetVerbose(false)
+	if IsVerbose() {
+		t.Error("IsVerbose() = true after SetVerbose(false)")
+	}
+	SetVerbose(true)
+	if !IsVerbose() {
+		t.Error("IsVerbose() = false after SetVerbose(true)")
+	}
+}

--- a/datasource/datasource.go
+++ b/datasource/datasource.go
@@ -18,6 +18,7 @@ import (
 	"github.com/k1LoW/errors"
 	"github.com/k1LoW/ghfs"
 	"github.com/k1LoW/go-github-client/v67/factory"
+	"github.com/k1LoW/tbls/cmdutil"
 	"github.com/k1LoW/tbls/config"
 	"github.com/k1LoW/tbls/drivers"
 	"github.com/k1LoW/tbls/drivers/clickhouse"
@@ -109,6 +110,7 @@ func Analyze(dsn config.DSN) (_ *schema.Schema, err error) {
 		urlstr = u.String()
 	}
 
+	cmdutil.Verbosef("Opening database connection")
 	db, err := dburl.Open(urlstr)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -116,9 +118,11 @@ func Analyze(dsn config.DSN) (_ *schema.Schema, err error) {
 	defer func() {
 		_ = db.Close()
 	}()
+	cmdutil.Verbosef("Pinging database")
 	if err := db.Ping(); err != nil {
 		return nil, errors.WithStack(err)
 	}
+	cmdutil.Verbosef("Database connection established")
 
 	var driver drivers.Driver
 
@@ -155,10 +159,12 @@ func Analyze(dsn config.DSN) (_ *schema.Schema, err error) {
 	default:
 		return s, fmt.Errorf("unsupported driver '%s'", u.Driver)
 	}
+	cmdutil.Verbosef("Running driver analysis for %s", u.Driver)
 	err = driver.Analyze(s)
 	if err != nil {
 		return nil, err
 	}
+	cmdutil.Verbosef("Driver analysis complete")
 	return s, nil
 }
 

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/aquasecurity/go-version/pkg/version"
 	"github.com/k1LoW/errors"
+	"github.com/k1LoW/tbls/cmdutil"
 	"github.com/k1LoW/tbls/ddl"
 	"github.com/k1LoW/tbls/dict"
 	"github.com/k1LoW/tbls/schema"
@@ -36,13 +37,16 @@ func (p *Postgres) Analyze(s *schema.Schema) (err error) {
 	defer func() {
 		err = errors.WithStack(err)
 	}()
+	cmdutil.Verbosef("Fetching database version info")
 	d, err := p.Info()
 	if err != nil {
 		return errors.WithStack(err)
 	}
 	s.Driver = d
+	cmdutil.Verbosef("Database version: %s", d.DatabaseVersion)
 
 	// current schema
+	cmdutil.Verbosef("Querying current schema")
 	var currentSchema sql.NullString
 	schemaRows, err := p.db.Query(`SELECT current_schema()`)
 	if err != nil {
@@ -98,24 +102,8 @@ func (p *Postgres) Analyze(s *schema.Schema) (err error) {
 	fullTableNames := []string{}
 
 	// tables
-	tableRows, err := p.db.Query(`
-SELECT
-    cls.oid AS oid,
-    cls.relname AS table_name,
-    CASE
-        WHEN cls.relkind IN ('r', 'p') THEN 'BASE TABLE'
-        WHEN cls.relkind = 'v' THEN 'VIEW'
-        WHEN cls.relkind = 'm' THEN 'MATERIALIZED VIEW'
-        WHEN cls.relkind = 'f' THEN 'FOREIGN TABLE'
-    END AS table_type,
-    ns.nspname AS table_schema,
-    descr.description AS table_comment
-FROM pg_class AS cls
-INNER JOIN pg_namespace AS ns ON cls.relnamespace = ns.oid
-LEFT JOIN pg_description AS descr ON cls.oid = descr.objoid AND descr.objsubid = 0
-WHERE ns.nspname NOT IN ('pg_catalog', 'information_schema')
-AND cls.relkind IN ('r', 'p', 'v', 'f', 'm')
-ORDER BY oid`)
+	cmdutil.Verbosef("Querying tables")
+	tableRows, err := p.db.Query(p.queryForTables())
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -138,6 +126,7 @@ ORDER BY oid`)
 		}
 
 		name := fmt.Sprintf("%s.%s", tableSchema, tableName)
+		cmdutil.Verbosef("Processing table: %s (%s)", name, tableType)
 
 		fullTableNames = append(fullTableNames, name)
 
@@ -323,22 +312,28 @@ ORDER BY tgrelid
 		tables = append(tables, table)
 	}
 
+	cmdutil.Verbosef("Querying functions and procedures")
 	functions, err := p.getFunctions()
 	if err != nil {
 		return err
 	}
 	s.Functions = functions
+	cmdutil.Verbosef("Found %d functions/procedures", len(functions))
 
 	// Enums
+	cmdutil.Verbosef("Querying enums")
 	enums, err := p.getEnums()
 	if err != nil {
 		return err
 	}
 	s.Enums = enums
+	cmdutil.Verbosef("Found %d enums", len(enums))
 
 	s.Tables = tables
+	cmdutil.Verbosef("Found %d tables total", len(tables))
 
 	// Relations
+	cmdutil.Verbosef("Processing %d relations", len(relations))
 	for _, r := range relations {
 		strColumns, strParentTable, strParentColumns, err := parseFK(r.Def)
 		if err != nil {
@@ -710,6 +705,27 @@ LEFT JOIN pg_description AS descr ON idx.indexrelid = descr.objoid
 WHERE idx.indrelid = $1::oid
 GROUP BY cls.relname, idx.indexrelid, descr.description
 ORDER BY idx.indexrelid`
+}
+
+func (p *Postgres) queryForTables() string {
+	return `
+SELECT
+    cls.oid AS oid,
+    cls.relname AS table_name,
+    CASE
+        WHEN cls.relkind IN ('r', 'p') THEN 'BASE TABLE'
+        WHEN cls.relkind = 'v' THEN 'VIEW'
+        WHEN cls.relkind = 'm' THEN 'MATERIALIZED VIEW'
+        WHEN cls.relkind = 'f' THEN 'FOREIGN TABLE'
+    END AS table_type,
+    ns.nspname AS table_schema,
+    descr.description AS table_comment
+FROM pg_class AS cls
+INNER JOIN pg_namespace AS ns ON cls.relnamespace = ns.oid
+LEFT JOIN pg_description AS descr ON cls.oid = descr.objoid AND descr.objsubid = 0
+WHERE ns.nspname NOT IN ('pg_catalog', 'information_schema')
+AND cls.relkind IN ('r', 'p', 'v', 'f', 'm')
+ORDER BY oid`
 }
 
 func detectFullTableName(name string, searchPaths, fullTableNames []string) (_ string, err error) {


### PR DESCRIPTION
## Summary

Splits #802 into two focused PRs. This PR adds the `--verbose` / `-v` flag to `tbls doc` and `tbls out`.

- Adds `--verbose/-v` flag printing progress with elapsed timestamps to stderr
- Masks passwords in DSN when verbose logging
- Adds verbose logging to datasource connection and the postgres driver
- Extracts the postgres tables query into a `queryForTables()` helper (pure refactor)

The companion PR adds `--skip-partitions` on top of this one.

## Test plan

- [ ] `tbls doc -v <dsn> <path>` prints timestamped progress lines
- [ ] `tbls out -v -t json <dsn>` prints timestamped progress lines
- [ ] DSN password is masked in the logged output
- [ ] Without `-v`, output is unchanged
