### PR TITLE
fix(mysql): stabilize constraint introspection order

### DIFF
--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -396,7 +396,8 @@ ON kcu.constraint_name = sub.constraint_name
   AND kcu.table_name = sub.table_name
   AND (kcu.referenced_table_name = sub.referenced_table_name OR (kcu.referenced_table_name IS NULL AND sub.referenced_table_name IS NULL))
 WHERE kcu.table_schema= ?
-GROUP BY kcu.table_name, kcu.constraint_name, sub.constraint_type, kcu.referenced_table_name`, s.Name)
+GROUP BY kcu.table_name, kcu.constraint_name, sub.constraint_type, kcu.referenced_table_name
+ORDER BY kcu.table_name, kcu.constraint_name, sub.constraint_type, kcu.referenced_table_name`, s.Name)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -459,6 +460,7 @@ SELECT
 FROM information_schema.check_constraints AS c
 JOIN information_schema.table_constraints AS t ON c.constraint_schema = t.constraint_schema AND c.constraint_name = t.constraint_name
 WHERE t.table_schema = ?
+ORDER BY t.table_name, c.constraint_name
 `, s.Name)
 		if err != nil {
 			return errors.WithStack(err)

--- a/drivers/mysql/mysql_test.go
+++ b/drivers/mysql/mysql_test.go
@@ -84,3 +84,51 @@ func TestInfo(t *testing.T) {
 		t.Errorf("got not empty string.")
 	}
 }
+
+func TestCheckConstraintsOrder(t *testing.T) {
+	if _, err := db.Exec(`DROP TABLE IF EXISTS tbls_check_order`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`
+CREATE TABLE tbls_check_order (
+  a int,
+  b int,
+  CONSTRAINT chk_tbls_check_order_b CHECK (b > 0),
+  CONSTRAINT chk_tbls_check_order_a CHECK (a > 0)
+)`); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_, _ = db.Exec(`DROP TABLE IF EXISTS tbls_check_order`)
+	}()
+
+	driver, err := New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sc := &schema.Schema{Name: "testdb"}
+	if err := driver.Analyze(sc); err != nil {
+		t.Fatal(err)
+	}
+
+	tbl, err := sc.FindTableByName("tbls_check_order")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	for _, c := range tbl.Constraints {
+		if c.Type == "CHECK" {
+			got = append(got, c.Name)
+		}
+	}
+	want := []string{"chk_tbls_check_order_a", "chk_tbls_check_order_b"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v\nwant %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got %v\nwant %v", got, want)
+			break
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR makes MySQL constraint introspection deterministic by adding explicit `ORDER BY` clauses to constraint queries.

It stabilizes:

- CHECK constraint order by table name and constraint name
- PK/UNIQUE/FK constraint row order by table name, constraint name, constraint type, and referenced table

This prevents unnecessary diffs in generated docs when MySQL returns `information_schema` rows in a different order.

Closes #829

## Testing

```sh
go test ./drivers/mysql
go test -tags mysql ./drivers/mysql
```
