### PR TITLE
Ensure consistent column ordering for ClickHouse

### DIFF
--- a/drivers/clickhouse/clickhouse.go
+++ b/drivers/clickhouse/clickhouse.go
@@ -151,6 +151,8 @@ WHERE database = ?
 	}
 
 	// columns
+	// Order by table, position so columns appear in declaration order;
+	// system.columns has no guaranteed default ordering.
 	columnRows, err := ch.db.Query(`
 SELECT
     table,
@@ -165,7 +167,7 @@ SELECT
     comment
 FROM system.columns
 WHERE database = ?
-ORDER BY table
+ORDER BY table, position
 `, s.Name)
 	if err != nil {
 		return errors.WithStack(err)


### PR DESCRIPTION
When running `tbls` against a ClickHouse instance, I noticed that sometimes it would randomly change the order of the columns in the rendered Markdown table.

By adding `position` to the `ORDER BY` clause, we ensure that the column list is always returned in the same order. 