### PR TITLE
feat: add viewpoint id and tbls out --viewpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1097,6 +1097,7 @@ You can also define groups of tables within viewpoints.
 
 viewpoints:
   -
+    id: comments-on-post
     name: comments on post
     desc: Users can comment on each post multiple times and put a star on each comment.
     tables:
@@ -1122,6 +1123,8 @@ viewpoints:
           - post_comment_stars
 
 ```
+
+`id` is optional. When set, it is used as the suffix of the viewpoint output file name (e.g. `viewpoint-comments-on-post.md`) instead of the index, so the file name stays stable regardless of the viewpoint order. `id` must be unique. It is also used to specify the viewpoint in `tbls out --viewpoint`.
 
 ## Output formats
 
@@ -1155,6 +1158,14 @@ $ tbls out -t mermaid -o schema.mmd
 
 ```console
 $ tbls out -t svg --table users --distance 2 -o users.svg
+```
+
+**Viewpoint:**
+
+Output only the schema of a specific viewpoint by specifying its `id` (or index).
+
+```console
+$ tbls out -t svg --viewpoint comments-on-post -o comments-on-post.svg
 ```
 
 **JSON:**

--- a/README.md
+++ b/README.md
@@ -1124,7 +1124,7 @@ viewpoints:
 
 ```
 
-`id` is optional. When set, it is used as the suffix of the viewpoint output file name (e.g. `viewpoint-comments-on-post.md`) instead of the index, so the file name stays stable regardless of the viewpoint order. `id` must be unique. It is also used to specify the viewpoint in `tbls out --viewpoint`.
+`id` is optional. When set, it is used as the suffix of the viewpoint output file name (e.g. `viewpoint-comments-on-post.md`) instead of the index, so the file name stays stable regardless of the viewpoint order. `id` must be unique and must not contain path separators (`/` or `\`). It is also used to specify the viewpoint in `tbls out --viewpoint`.
 
 ## Output formats
 

--- a/README.md
+++ b/README.md
@@ -1168,6 +1168,12 @@ Output only the schema of a specific viewpoint by specifying its `id` (or index)
 $ tbls out -t svg --viewpoint comments-on-post -o comments-on-post.svg
 ```
 
+With `-t md`, the viewpoint document (including groups and the ER diagram inlined as Mermaid) is generated instead of a plain schema document.
+
+```console
+$ tbls out -t md --viewpoint comments-on-post -o comments-on-post.md
+```
+
 **JSON:**
 
 ```console

--- a/cmd/out.go
+++ b/cmd/out.go
@@ -42,9 +42,10 @@ import (
 )
 
 var (
-	format   string
-	outPath  string
-	distance int
+	format    string
+	outPath   string
+	distance  int
+	viewpoint string
 )
 
 // outCmd represents the doc command.
@@ -77,6 +78,14 @@ var outCmd = &cobra.Command{
 		s, err := getSchemaFromJSONorDSN(c)
 		if err != nil {
 			return err
+		}
+
+		if viewpoint != "" {
+			v, err := s.FindViewpoint(viewpoint)
+			if err != nil {
+				return err
+			}
+			s = v.Schema
 		}
 
 		var o output.Output
@@ -167,5 +176,6 @@ func init() {
 	outCmd.Flags().StringSliceVarP(&excludes, "exclude", "", []string{}, "tables to exclude")
 	outCmd.Flags().StringSliceVarP(&labels, "label", "", []string{}, "table labels to be included")
 	outCmd.Flags().IntVarP(&distance, "distance", "", 0, "distance between related tables to be displayed")
+	outCmd.Flags().StringVarP(&viewpoint, "viewpoint", "", "", "output only the schema of the specified viewpoint (by id, or by index)")
 	outCmd.Flags().StringVarP(&when, "when", "", "", "command execute condition")
 }

--- a/cmd/out.go
+++ b/cmd/out.go
@@ -38,6 +38,7 @@ import (
 	"github.com/k1LoW/tbls/output/plantuml"
 	"github.com/k1LoW/tbls/output/xlsx"
 	"github.com/k1LoW/tbls/output/yaml"
+	"github.com/k1LoW/tbls/schema"
 	"github.com/spf13/cobra"
 )
 
@@ -80,11 +81,15 @@ var outCmd = &cobra.Command{
 			return err
 		}
 
+		var vp *schema.Viewpoint
+		var vpIndex int
 		if viewpoint != "" {
-			v, err := s.FindViewpoint(viewpoint)
+			v, i, err := s.FindViewpoint(viewpoint)
 			if err != nil {
 				return err
 			}
+			vp = v
+			vpIndex = i
 			s = v.Schema
 		}
 
@@ -131,6 +136,18 @@ var outCmd = &cobra.Command{
 			wr = file
 		} else {
 			wr = os.Stdout
+		}
+
+		// For Markdown, output the dedicated viewpoint document (ER + groups) instead of
+		// the plain filtered schema. The ER diagram is inlined as Mermaid so the single
+		// output file stays self-contained without a separate image file.
+		if vp != nil && format == "md" {
+			c.ER.Skip = false
+			c.ER.Format = "mermaid"
+			if err := md.New(c).OutputViewpoint(wr, vpIndex, vp); err != nil {
+				return err
+			}
+			return nil
 		}
 
 		if err := o.OutputSchema(wr, s); err != nil {

--- a/cmd/out.go
+++ b/cmd/out.go
@@ -193,6 +193,6 @@ func init() {
 	outCmd.Flags().StringSliceVarP(&excludes, "exclude", "", []string{}, "tables to exclude")
 	outCmd.Flags().StringSliceVarP(&labels, "label", "", []string{}, "table labels to be included")
 	outCmd.Flags().IntVarP(&distance, "distance", "", 0, "distance between related tables to be displayed")
-	outCmd.Flags().StringVarP(&viewpoint, "viewpoint", "", "", "output only the schema of the specified viewpoint (by id, or by index)")
+	outCmd.Flags().StringVarP(&viewpoint, "viewpoint", "", "", "output only the specified viewpoint (by id, or by index); with -t md the viewpoint document (groups + ER) is generated")
 	outCmd.Flags().StringVarP(&when, "when", "", "", "command execute condition")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -323,6 +323,7 @@ func (c *Config) validate() error {
 		return fmt.Errorf("unsupported ER format: %s", c.ER.Format)
 	}
 	seenViewpointIDs := map[string]int{}
+	seenViewpointNames := map[string]int{}
 	for i, v := range c.Viewpoints {
 		if v.Name == "" {
 			return fmt.Errorf("viewpoints[%d] name is required", i)
@@ -341,6 +342,14 @@ func (c *Config) validate() error {
 			}
 			seenViewpointIDs[v.ID] = i
 		}
+		// An id-based name and an index-based name can collide (e.g. viewpoints[0] without id
+		// produces viewpoint-0, and viewpoints[1] with id "0" produces viewpoint-0 too), which
+		// would silently overwrite output files. Reject such conflicts on the derived name.
+		name := schema.ViewpointName(v.ID, i)
+		if j, ok := seenViewpointNames[name]; ok {
+			return fmt.Errorf("viewpoints[%d] output name '%s' conflicts with viewpoints[%d]", i, name, j)
+		}
+		seenViewpointNames[name] = i
 		for j, g := range v.Groups {
 			if g.Name == "" {
 				return fmt.Errorf("viewpoints[%d].groups[%d] name is required", i, j)

--- a/config/config.go
+++ b/config/config.go
@@ -322,12 +322,19 @@ func (c *Config) validate() error {
 	if !lo.Contains(SupportERFormat, c.ER.Format) {
 		return fmt.Errorf("unsupported ER format: %s", c.ER.Format)
 	}
+	seenViewpointIDs := map[string]int{}
 	for i, v := range c.Viewpoints {
 		if v.Name == "" {
 			return fmt.Errorf("viewpoints[%d] name is required", i)
 		}
 		if v.Desc == "" {
 			return fmt.Errorf("viewpoints[%d] description is required", i)
+		}
+		if v.ID != "" {
+			if j, ok := seenViewpointIDs[v.ID]; ok {
+				return fmt.Errorf("viewpoints[%d] id '%s' is duplicated with viewpoints[%d]", i, v.ID, j)
+			}
+			seenViewpointIDs[v.ID] = i
 		}
 		for j, g := range v.Groups {
 			if g.Name == "" {
@@ -492,6 +499,7 @@ func (c *Config) ModifySchema(s *schema.Schema) error {
 			tables = left
 		}
 		s.Viewpoints = s.Viewpoints.Merge(&schema.Viewpoint{
+			ID:       v.ID,
 			Name:     v.Name,
 			Desc:     v.Desc,
 			Labels:   v.Labels,
@@ -528,6 +536,7 @@ func (c *Config) ModifySchema(s *schema.Schema) error {
 			for _, tt := range ts {
 				tt.Viewpoints = append(tt.Viewpoints, &schema.TableViewpoint{
 					Index: vi,
+					ID:    v.ID,
 					Name:  v.Name,
 					Desc:  v.Desc,
 				})

--- a/config/config.go
+++ b/config/config.go
@@ -331,6 +331,11 @@ func (c *Config) validate() error {
 			return fmt.Errorf("viewpoints[%d] description is required", i)
 		}
 		if v.ID != "" {
+			// id is embedded into output file paths (e.g. viewpoint-<id>.md), so path
+			// separators would allow writing outside the intended output directory.
+			if strings.ContainsAny(v.ID, `/\`) {
+				return fmt.Errorf("viewpoints[%d] id '%s' must not contain path separators ('/' or '\\')", i, v.ID)
+			}
 			if j, ok := seenViewpointIDs[v.ID]; ok {
 				return fmt.Errorf("viewpoints[%d] id '%s' is duplicated with viewpoints[%d]", i, v.ID, j)
 			}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -596,6 +596,79 @@ func TestValidate(t *testing.T) {
 	}
 }
 
+func TestValidateViewpointIDUniqueness(t *testing.T) {
+	tests := []struct {
+		name       string
+		viewpoints []Viewpoint
+		wantErr    bool
+	}{
+		{"no id", []Viewpoint{{Name: "A", Desc: "a"}, {Name: "B", Desc: "b"}}, false},
+		{"unique ids", []Viewpoint{{ID: "a", Name: "A", Desc: "a"}, {ID: "b", Name: "B", Desc: "b"}}, false},
+		{"empty ids are not duplicated", []Viewpoint{{Name: "A", Desc: "a"}, {Name: "B", Desc: "b"}, {Name: "C", Desc: "c"}}, false},
+		{"duplicated ids", []Viewpoint{{ID: "a", Name: "A", Desc: "a"}, {ID: "a", Name: "B", Desc: "b"}}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			c.Viewpoints = tt.viewpoints
+			if err := c.validate(); err != nil {
+				if !tt.wantErr {
+					t.Errorf("got error: %s", err)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Error("want error")
+			}
+		})
+	}
+}
+
+func TestModifySchemaViewpointID(t *testing.T) {
+	c, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Viewpoints = []Viewpoint{
+		{ID: "users-overview", Name: "Users", Desc: "users overview", Tables: []string{"users"}},
+		{Name: "Posts", Desc: "posts", Tables: []string{"posts"}},
+	}
+	s := newTestSchemaViaJSON(t)
+	if err := c.ModifySchema(s); err != nil {
+		t.Fatal(err)
+	}
+
+	// ID is propagated to schema viewpoint.
+	if got := s.Viewpoints[0].ID; got != "users-overview" {
+		t.Errorf("viewpoint[0].ID = %q, want %q", got, "users-overview")
+	}
+	if got := s.Viewpoints[1].ID; got != "" {
+		t.Errorf("viewpoint[1].ID = %q, want empty", got)
+	}
+
+	// ID is propagated to table viewpoint.
+	tb, err := s.FindTableByName("users")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, tv := range tb.Viewpoints {
+		if tv.Name != "Users" {
+			continue
+		}
+		found = true
+		if tv.ID != "users-overview" {
+			t.Errorf("table viewpoint ID = %q, want %q", tv.ID, "users-overview")
+		}
+	}
+	if !found {
+		t.Error("users table viewpoint 'Users' not found")
+	}
+}
+
 func TestCheckVersion(t *testing.T) {
 	tests := []struct {
 		v    string

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -596,7 +596,7 @@ func TestValidate(t *testing.T) {
 	}
 }
 
-func TestValidateViewpointIDUniqueness(t *testing.T) {
+func TestValidateViewpointID(t *testing.T) {
 	tests := []struct {
 		name       string
 		viewpoints []Viewpoint
@@ -606,6 +606,9 @@ func TestValidateViewpointIDUniqueness(t *testing.T) {
 		{"unique ids", []Viewpoint{{ID: "a", Name: "A", Desc: "a"}, {ID: "b", Name: "B", Desc: "b"}}, false},
 		{"empty ids are not duplicated", []Viewpoint{{Name: "A", Desc: "a"}, {Name: "B", Desc: "b"}, {Name: "C", Desc: "c"}}, false},
 		{"duplicated ids", []Viewpoint{{ID: "a", Name: "A", Desc: "a"}, {ID: "a", Name: "B", Desc: "b"}}, true},
+		{"id with slash", []Viewpoint{{ID: "../../pwned", Name: "A", Desc: "a"}}, true},
+		{"id with backslash", []Viewpoint{{ID: `a\b`, Name: "A", Desc: "a"}}, true},
+		{"id with nested slash", []Viewpoint{{ID: "a/b", Name: "A", Desc: "a"}}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -609,6 +609,8 @@ func TestValidateViewpointID(t *testing.T) {
 		{"id with slash", []Viewpoint{{ID: "../../pwned", Name: "A", Desc: "a"}}, true},
 		{"id with backslash", []Viewpoint{{ID: `a\b`, Name: "A", Desc: "a"}}, true},
 		{"id with nested slash", []Viewpoint{{ID: "a/b", Name: "A", Desc: "a"}}, true},
+		{"id collides with index-based name", []Viewpoint{{Name: "A", Desc: "a"}, {ID: "0", Name: "B", Desc: "b"}}, true},
+		{"id matching own index is fine", []Viewpoint{{ID: "0", Name: "A", Desc: "a"}, {Name: "B", Desc: "b"}}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/config/viewpoints.go
+++ b/config/viewpoints.go
@@ -1,6 +1,7 @@
 package config
 
 type Viewpoint struct {
+	ID       string           `yaml:"id,omitempty"`
 	Name     string           `yaml:"name,omitempty"`
 	Desc     string           `yaml:"desc,omitempty"`
 	Labels   []string         `yaml:"labels,omitempty"`

--- a/output/gviz/gviz.go
+++ b/output/gviz/gviz.go
@@ -142,7 +142,7 @@ func Output(s *schema.Schema, c *config.Config, force bool) (e error) {
 
 	// viewpoints
 	for i, v := range s.Viewpoints {
-		fn := fmt.Sprintf("viewpoint-%d.%s", i, erFormat)
+		fn := fmt.Sprintf("%s.%s", schema.ViewpointName(v.ID, i), erFormat)
 		fmt.Printf("%s\n", filepath.Join(outputPath, fn))
 		f, err := os.OpenFile(filepath.Join(fullPath, fn), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644) // #nosec
 		if err != nil {
@@ -227,8 +227,8 @@ func outputErExists(s *schema.Schema, erFormat, path string) bool {
 		}
 	}
 	// viewpoints
-	for i := range s.Viewpoints {
-		fn := fmt.Sprintf("viewpoint-%d.%s", i, erFormat)
+	for i, v := range s.Viewpoints {
+		fn := fmt.Sprintf("%s.%s", schema.ViewpointName(v.ID, i), erFormat)
 		if _, err := os.Lstat(filepath.Join(path, fn)); err == nil {
 			return true
 		}

--- a/output/md/md.go
+++ b/output/md/md.go
@@ -122,7 +122,7 @@ func (m *Md) OutputViewpoint(wr io.Writer, i int, v *schema.Viewpoint) error {
 		}
 		templateData["erDiagram"] = fmt.Sprintf("```mermaid\n%s```", buf.String())
 	default:
-		templateData["erDiagram"] = fmt.Sprintf("![er](%s%s.%s)", m.config.BaseURL, schema.ViewpointName(v.ID, i), m.config.ER.Format)
+		templateData["erDiagram"] = fmt.Sprintf("![er](%s%s.%s)", m.config.BaseURL, mdurl.Encode(schema.ViewpointName(v.ID, i)), m.config.ER.Format)
 	}
 	if err := tmpl.Execute(wr, templateData); err != nil {
 		return errors.WithStack(err)
@@ -609,7 +609,7 @@ func (m *Md) makeTableTemplateData(t *schema.Table) map[string]interface{} {
 			desc = output.ShowOnlyFirstParagraph(desc)
 		}
 		data := []string{
-			fmt.Sprintf("[%s](%s.md)", v.Name, schema.ViewpointName(v.ID, v.Index)),
+			fmt.Sprintf("[%s](%s.md)", v.Name, mdurl.Encode(schema.ViewpointName(v.ID, v.Index))),
 			desc,
 		}
 
@@ -925,7 +925,7 @@ func (m *Md) viewpointsData(viewpoints []*schema.Viewpoint, number, adjust, show
 			desc = output.ShowOnlyFirstParagraph(desc)
 		}
 		d := []string{
-			fmt.Sprintf("[%s](%s%s.md)", v.Name, m.config.BaseURL, schema.ViewpointName(v.ID, i)),
+			fmt.Sprintf("[%s](%s%s.md)", v.Name, m.config.BaseURL, mdurl.Encode(schema.ViewpointName(v.ID, i))),
 			desc,
 		}
 		data = append(data, d)

--- a/output/md/md.go
+++ b/output/md/md.go
@@ -122,7 +122,7 @@ func (m *Md) OutputViewpoint(wr io.Writer, i int, v *schema.Viewpoint) error {
 		}
 		templateData["erDiagram"] = fmt.Sprintf("```mermaid\n%s```", buf.String())
 	default:
-		templateData["erDiagram"] = fmt.Sprintf("![er](%sviewpoint-%d.%s)", m.config.BaseURL, i, m.config.ER.Format)
+		templateData["erDiagram"] = fmt.Sprintf("![er](%s%s.%s)", m.config.BaseURL, schema.ViewpointName(v.ID, i), m.config.ER.Format)
 	}
 	if err := tmpl.Execute(wr, templateData); err != nil {
 		return errors.WithStack(err)
@@ -184,7 +184,7 @@ func Output(s *schema.Schema, c *config.Config, force bool) (e error) {
 
 	// viewpoints
 	for i, v := range s.Viewpoints {
-		fn := fmt.Sprintf("viewpoint-%d.md", i)
+		fn := fmt.Sprintf("%s.md", schema.ViewpointName(v.ID, i))
 		f, err := os.Create(filepath.Clean(filepath.Join(fullPath, fn)))
 		if err != nil {
 			_ = f.Close()
@@ -393,8 +393,8 @@ func DiffSchemaAndDocs(docPath string, s *schema.Schema, c *config.Config) (stri
 	// viewpoints
 	for i, v := range s.Viewpoints {
 		buf := new(bytes.Buffer)
-		n := fmt.Sprintf("viewpoint-%d", i)
-		fn := fmt.Sprintf("viewpoint-%d.md", i)
+		n := schema.ViewpointName(v.ID, i)
+		fn := fmt.Sprintf("%s.md", n)
 		to := fmt.Sprintf("%s %s", mdsn, n)
 		if err := md.OutputViewpoint(buf, i, v); err != nil {
 			return "", errors.WithStack(err)
@@ -609,7 +609,7 @@ func (m *Md) makeTableTemplateData(t *schema.Table) map[string]interface{} {
 			desc = output.ShowOnlyFirstParagraph(desc)
 		}
 		data := []string{
-			fmt.Sprintf("[%s](viewpoint-%d.md)", v.Name, v.Index),
+			fmt.Sprintf("[%s](%s.md)", v.Name, schema.ViewpointName(v.ID, v.Index)),
 			desc,
 		}
 
@@ -925,7 +925,7 @@ func (m *Md) viewpointsData(viewpoints []*schema.Viewpoint, number, adjust, show
 			desc = output.ShowOnlyFirstParagraph(desc)
 		}
 		d := []string{
-			fmt.Sprintf("[%s](%sviewpoint-%d.md)", v.Name, m.config.BaseURL, i),
+			fmt.Sprintf("[%s](%s%s.md)", v.Name, m.config.BaseURL, schema.ViewpointName(v.ID, i)),
 			desc,
 		}
 		data = append(data, d)

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	wildcard "github.com/IGLOU-EU/go-wildcard/v2"
@@ -52,6 +53,7 @@ func (labels Labels) Contains(name string) bool {
 
 // Viewpoint is the struct for viewpoint information.
 type Viewpoint struct {
+	ID       string            `json:"id,omitempty"`
 	Name     string            `json:"name"`
 	Desc     string            `json:"desc"`
 	Labels   []string          `json:"labels,omitempty"`
@@ -80,6 +82,28 @@ func (vs Viewpoints) Merge(in *Viewpoint) Viewpoints {
 		}
 	}
 	return append(vs, in)
+}
+
+// ViewpointName returns the basename (without extension) used for the viewpoint output file.
+// When id is set it is used to keep the name stable regardless of viewpoint order, otherwise the index is used.
+func ViewpointName(id string, index int) string {
+	if id != "" {
+		return fmt.Sprintf("viewpoint-%s", id)
+	}
+	return fmt.Sprintf("viewpoint-%d", index)
+}
+
+// FindViewpoint finds a viewpoint by id, falling back to index when locator is a number.
+func (s *Schema) FindViewpoint(locator string) (*Viewpoint, error) {
+	for _, v := range s.Viewpoints {
+		if v.ID != "" && v.ID == locator {
+			return v, nil
+		}
+	}
+	if index, err := strconv.Atoi(locator); err == nil && index >= 0 && index < len(s.Viewpoints) {
+		return s.Viewpoints[index], nil
+	}
+	return nil, fmt.Errorf("viewpoint not found: %s", locator)
 }
 
 // Index is the struct for database index.
@@ -130,6 +154,7 @@ type Column struct {
 
 type TableViewpoint struct {
 	Index int    `json:"index"`
+	ID    string `json:"id,omitempty"`
 	Name  string `json:"name"`
 	Desc  string `json:"desc"`
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -94,16 +94,17 @@ func ViewpointName(id string, index int) string {
 }
 
 // FindViewpoint finds a viewpoint by id, falling back to index when locator is a number.
-func (s *Schema) FindViewpoint(locator string) (*Viewpoint, error) {
-	for _, v := range s.Viewpoints {
+// It also returns the index of the viewpoint.
+func (s *Schema) FindViewpoint(locator string) (*Viewpoint, int, error) {
+	for i, v := range s.Viewpoints {
 		if v.ID != "" && v.ID == locator {
-			return v, nil
+			return v, i, nil
 		}
 	}
 	if index, err := strconv.Atoi(locator); err == nil && index >= 0 && index < len(s.Viewpoints) {
-		return s.Viewpoints[index], nil
+		return s.Viewpoints[index], index, nil
 	}
-	return nil, fmt.Errorf("viewpoint not found: %s", locator)
+	return nil, 0, fmt.Errorf("viewpoint not found: %s", locator)
 }
 
 // Index is the struct for database index.

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -86,8 +86,10 @@ func (vs Viewpoints) Merge(in *Viewpoint) Viewpoints {
 
 // ViewpointName returns the basename (without extension) used for the viewpoint output file.
 // When id is set it is used to keep the name stable regardless of viewpoint order, otherwise the index is used.
+// Config validation rejects ids with path separators, but schemas loaded directly (e.g. json://) bypass it,
+// so fall back to the index-based name to keep the result safe to embed in file paths.
 func ViewpointName(id string, index int) string {
-	if id != "" {
+	if id != "" && !strings.ContainsAny(id, `/\`) {
 		return fmt.Sprintf("viewpoint-%s", id)
 	}
 	return fmt.Sprintf("viewpoint-%d", index)

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -494,19 +494,20 @@ func TestFindViewpoint(t *testing.T) {
 		},
 	}
 	tests := []struct {
-		locator string
-		wantErr bool
-		want    string
+		locator   string
+		wantErr   bool
+		want      string
+		wantIndex int
 	}{
-		{"overview", false, "Overview"}, // by id
-		{"0", false, "Overview"},        // by index
-		{"1", false, "No ID"},           // by index
-		{"unknown", true, ""},           // unknown id and not a number
-		{"2", true, ""},                 // index out of range
-		{"-1", true, ""},                // negative index
+		{"overview", false, "Overview", 0}, // by id
+		{"0", false, "Overview", 0},         // by index
+		{"1", false, "No ID", 1},            // by index
+		{"unknown", true, "", 0},            // unknown id and not a number
+		{"2", true, "", 0},                  // index out of range
+		{"-1", true, "", 0},                 // negative index
 	}
 	for _, tt := range tests {
-		v, err := s.FindViewpoint(tt.locator)
+		v, index, err := s.FindViewpoint(tt.locator)
 		if tt.wantErr {
 			if err == nil {
 				t.Errorf("FindViewpoint(%q) expected error, got nil", tt.locator)
@@ -519,6 +520,9 @@ func TestFindViewpoint(t *testing.T) {
 		}
 		if v.Name != tt.want {
 			t.Errorf("FindViewpoint(%q) = %q, want %q", tt.locator, v.Name, tt.want)
+		}
+		if index != tt.wantIndex {
+			t.Errorf("FindViewpoint(%q) index = %d, want %d", tt.locator, index, tt.wantIndex)
 		}
 	}
 }

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -467,3 +467,58 @@ func TestViewpointsMerge(t *testing.T) {
 		}
 	})
 }
+
+func TestViewpointName(t *testing.T) {
+	tests := []struct {
+		id    string
+		index int
+		want  string
+	}{
+		{"", 0, "viewpoint-0"},
+		{"", 3, "viewpoint-3"},
+		{"overview", 0, "viewpoint-overview"},
+		{"概要", 1, "viewpoint-概要"},
+	}
+	for _, tt := range tests {
+		if got := ViewpointName(tt.id, tt.index); got != tt.want {
+			t.Errorf("ViewpointName(%q, %d) = %q, want %q", tt.id, tt.index, got, tt.want)
+		}
+	}
+}
+
+func TestFindViewpoint(t *testing.T) {
+	s := &Schema{
+		Viewpoints: Viewpoints{
+			&Viewpoint{ID: "overview", Name: "Overview"},
+			&Viewpoint{Name: "No ID"},
+		},
+	}
+	tests := []struct {
+		locator string
+		wantErr bool
+		want    string
+	}{
+		{"overview", false, "Overview"}, // by id
+		{"0", false, "Overview"},        // by index
+		{"1", false, "No ID"},           // by index
+		{"unknown", true, ""},           // unknown id and not a number
+		{"2", true, ""},                 // index out of range
+		{"-1", true, ""},                // negative index
+	}
+	for _, tt := range tests {
+		v, err := s.FindViewpoint(tt.locator)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("FindViewpoint(%q) expected error, got nil", tt.locator)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("FindViewpoint(%q) unexpected error: %v", tt.locator, err)
+			continue
+		}
+		if v.Name != tt.want {
+			t.Errorf("FindViewpoint(%q) = %q, want %q", tt.locator, v.Name, tt.want)
+		}
+	}
+}

--- a/schema/schema_test.go
+++ b/schema/schema_test.go
@@ -478,6 +478,8 @@ func TestViewpointName(t *testing.T) {
 		{"", 3, "viewpoint-3"},
 		{"overview", 0, "viewpoint-overview"},
 		{"概要", 1, "viewpoint-概要"},
+		{"../../pwned", 2, "viewpoint-2"}, // path separators fall back to index
+		{`a\b`, 4, "viewpoint-4"},         // backslash falls back to index
 	}
 	for _, tt := range tests {
 		if got := ViewpointName(tt.id, tt.index); got != tt.want {

--- a/spec/tbls.schema.json_schema.json
+++ b/spec/tbls.schema.json_schema.json
@@ -399,6 +399,9 @@
     },
     "Viewpoint": {
       "properties": {
+        "id": {
+          "type": "string"
+        },
         "name": {
           "type": "string"
         },


### PR DESCRIPTION
## Summary

Add an optional `id` to viewpoints and a `--viewpoint` flag to `tbls out`.

`id` gives each viewpoint a stable, human-usable handle. It is used as the suffix of the output file name (`viewpoint-<id>.md` / `.svg`), the ER image reference and cross-links, and as the selector for `tbls out --viewpoint`. When `id` is unset, behavior is unchanged (index-based names), so this stays zero-config and backward compatible.

This also reconsiders #591: viewpoint output files were named purely by index (`viewpoint-0.md`, ...), so reordering viewpoints in `.tbls.yml` silently changed every downstream file name and link. The same gap blocked referencing a viewpoint from the CLI, because there was no stable identifier to select one. `id` solves both at once.

## Changes

- **config/viewpoints.go, schema/schema.go**: Add optional `id` to `Viewpoint` (and propagate it to `TableViewpoint`). Add `ViewpointName(id, index)` for the file basename and `(*Schema).FindViewpoint(locator)` which resolves an `id` first, then a numeric index.
- **config/config.go**: Propagate `id` into the schema viewpoints and table viewpoints, and validate that `id` values are unique.
- **output/md, output/gviz**: Derive viewpoint file names / ER references from `ViewpointName` instead of the raw index, so an `id` keeps them stable.
- **cmd/out.go**: Add `--viewpoint <id|index>`. It outputs only that viewpoint's filtered schema in any format. For `-t md` it renders the dedicated viewpoint document (groups + ER diagram inlined as Mermaid) rather than a plain filtered schema, so a single self-contained file matches what `tbls doc` produces per viewpoint.
- **spec/tbls.schema.json_schema.json**: Regenerated to include `id`.
- **README.md**: Document the `id` field and the `--viewpoint` usage.

## Motivation

Naming viewpoint files by index is fragile: inserting or sorting viewpoints rewrites unrelated file names and breaks bookmarks / links. Giving a viewpoint an `id` makes its document address stable and, as a side benefit, gives `tbls out` a clean way to select a single viewpoint. Keeping `id` optional preserves the current zero-config experience.

## Test Plan

- `go test ./schema/... ./config/... ./output/md/... ./output/gviz/...` — added unit tests for `ViewpointName`, `FindViewpoint` (id / index / errors), `id` uniqueness validation, and `id` propagation to schema/table viewpoints.
- Manually verified against `json://sample/viewpoints/schema.json`:
  - `tbls out --viewpoint 1` and `--viewpoint <id>` both narrow the schema to that viewpoint.
  - Unknown locator returns `viewpoint not found: ...`; duplicate `id` fails config load.
  - `tbls doc` writes `viewpoint-<id>.md` / `.svg` for viewpoints with an `id` and the index-based name otherwise, with table cross-links pointing at the right file.
  - `tbls out -t md --viewpoint <id>` emits groups + inline Mermaid ER; plain `tbls out -t md` is unchanged.

Closes #591