### PR TITLE
fix: escape pipe characters in column cells of Markdown table output

### DIFF
--- a/output/md/md.go
+++ b/output/md/md.go
@@ -579,9 +579,9 @@ func (m *Md) makeTableTemplateData(t *schema.Table) map[string]interface{} {
 		}
 
 		data := []string{
-			c.Name,
-			c.Type,
-			c.Default.String,
+			mdEscRep.Replace(c.Name),
+			mdEscRep.Replace(c.Type),
+			mdEscRep.Replace(c.Default.String),
 			fmt.Sprintf("%v", c.Nullable),
 		}
 		adjustData(&data, t.ShowColumn(schema.ColumnExtraDef, hideColumns), mdEscRep.Replace(c.ExtraDef))

--- a/output/md/md_pipe_escape_test.go
+++ b/output/md/md_pipe_escape_test.go
@@ -1,0 +1,82 @@
+package md
+
+import (
+	"bytes"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/k1LoW/tbls/config"
+	"github.com/k1LoW/tbls/schema"
+)
+
+// countGFMCells returns the number of cells in a GFM table row by counting
+// pipe delimiters that are not backslash-escaped. A literal pipe inside a cell
+// must be written as "\|"; an unescaped "|" always starts a new cell.
+func countGFMCells(row string) int {
+	row = strings.TrimSpace(row)
+	row = strings.TrimPrefix(row, "|")
+	row = strings.TrimSuffix(row, "|")
+	n := 1
+	for i := 0; i < len(row); i++ {
+		if row[i] == '\\' {
+			i++
+			continue
+		}
+		if row[i] == '|' {
+			n++
+		}
+	}
+	return n
+}
+
+// A column's Comment is escaped with mdEscRep, but the Name, Type and Default
+// cells on the same row are written raw. A pipe in one of those cells adds an
+// extra column and breaks the GFM table.
+func TestOutputTablePipeInColumnCells(t *testing.T) {
+	col := &schema.Column{
+		Name:    "status",
+		Type:    "text",
+		Default: sql.NullString{String: "'a|b'", Valid: true},
+		Comment: "one | two",
+	}
+	tbl := &schema.Table{
+		Name:    "events",
+		Columns: []*schema.Column{col},
+	}
+	s := &schema.Schema{Name: "s", Tables: []*schema.Table{tbl}}
+	if err := s.Repair(); err != nil {
+		t.Fatal(err)
+	}
+	c, err := config.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.ER.Skip = true
+
+	buf := new(bytes.Buffer)
+	if err := New(c).OutputTable(buf, tbl); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+
+	var header, dataRow string
+	for _, ln := range strings.Split(out, "\n") {
+		l := strings.TrimSpace(ln)
+		if strings.HasPrefix(l, "|") && strings.Contains(l, "Nullable") {
+			header = l
+		}
+		if strings.HasPrefix(l, "| status ") {
+			dataRow = l
+		}
+	}
+	if header == "" || dataRow == "" {
+		t.Fatalf("could not locate header/data row in output:\n%s", out)
+	}
+
+	hc := countGFMCells(header)
+	dc := countGFMCells(dataRow)
+	if hc != dc {
+		t.Errorf("GFM cell-count mismatch: header=%d data=%d (a raw '|' splits the cell)\nheader:  %s\ndataRow: %s", hc, dc, header, dataRow)
+	}
+}


### PR DESCRIPTION
In the `## Columns` table, the `Comment` and `Extra Definition` cells are written through `mdEscRep` (which escapes `|`, `<` and `>`), but the `Name`, `Type` and `Default` cells on the same row are written raw:

```go
data := []string{
    c.Name,
    c.Type,
    c.Default.String,
    fmt.Sprintf("%v", c.Nullable),
}
adjustData(&data, ..., mdEscRep.Replace(c.ExtraDef))
...
adjustData(&data, ..., mdEscRep.Replace(c.Comment))
```

When one of those raw cells contains a `|` (for example a string or expression default such as `'a|b'`), the pipe is read as a cell separator, the row gains an extra column, and the table loses its alignment.

For a column with `default = 'a|b'` and `comment = "one | two"` the output is:

```
| Name | Type | Default | Nullable | Children | Parents | Comment |
| status | text | 'a|b' | false |  |  | one \| two |
```

The header has 7 cells but the data row has 8: the comment pipe is escaped (`one \| two`) while the default pipe is not, so the data row no longer matches the header.

This applies `mdEscRep.Replace` to the `Name`, `Type` and `Default` cells, the same way `Comment` and `Extra Definition` already are. The existing golden files do not contain these characters, so they are unchanged; the added test covers the pipe case.
