### PR TITLE
perf(spanner): fetch schema in bulk to avoid N+1 queries

### DIFF
--- a/drivers/spanner/spanner.go
+++ b/drivers/spanner/spanner.go
@@ -37,7 +37,7 @@ func (sp *Spanner) Analyze(s *schema.Schema) error {
 	}
 	s.Driver = d
 
-	// tables / constraints
+	// tables
 	tableStmt := spanner.Statement{SQL: `
 SELECT
   TABLE_NAME, PARENT_TABLE_NAME, ON_DELETE_ACTION
@@ -82,92 +82,100 @@ WHERE
 			})
 		}
 
-		// columns
-		columnStmt := spanner.Statement{
-			SQL: `
+		tables = append(tables, table)
+		tableMap[table.Name] = table
+	}
+
+	// bulk get columns (avoid a per-table query)
+	columnMap := map[string]map[string]*schema.Column{}
+	columnStmt := spanner.Statement{SQL: `
 SELECT
-  COLUMN_NAME, IS_NULLABLE, SPANNER_TYPE
+  TABLE_NAME, COLUMN_NAME, IS_NULLABLE, SPANNER_TYPE
 FROM
   INFORMATION_SCHEMA.COLUMNS
 WHERE
-  TABLE_NAME = @tableName AND TABLE_CATALOG = '' AND TABLE_SCHEMA = ''
-ORDER BY ORDINAL_POSITION ASC;
-`,
-			Params: map[string]interface{}{"tableName": tableName},
+  TABLE_CATALOG = '' AND TABLE_SCHEMA = ''
+ORDER BY TABLE_NAME, ORDINAL_POSITION ASC;
+`}
+	columnIter := sp.client.Single().Query(sp.ctx, columnStmt)
+	defer columnIter.Stop()
+	for {
+		columnRow, err := columnIter.Next()
+		if errors.Is(err, iterator.Done) {
+			break
 		}
-		columnIter := sp.client.Single().Query(sp.ctx, columnStmt)
-		columns := []*schema.Column{}
-		for {
-			columnRow, err := columnIter.Next()
-			if errors.Is(err, iterator.Done) {
-				columnIter.Stop()
-				break
-			}
-			if err != nil {
-				columnIter.Stop()
-				return errors.WithStack(err)
-			}
-			var (
-				columnName string
-				isNullable string
-				columnType string
-			)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		var (
+			tableName  string
+			columnName string
+			isNullable string
+			columnType string
+		)
+		if err := columnRow.Columns(&tableName, &columnName, &isNullable, &columnType); err != nil {
+			return errors.WithStack(err)
+		}
+		table, ok := tableMap[tableName]
+		if !ok {
+			continue
+		}
+		column := &schema.Column{
+			Name:     columnName,
+			Type:     columnType,
+			Nullable: convertColumnNullable(isNullable),
+		}
+		table.Columns = append(table.Columns, column)
+		if columnMap[tableName] == nil {
+			columnMap[tableName] = map[string]*schema.Column{}
+		}
+		columnMap[tableName][columnName] = column
+	}
 
-			if err := columnRow.Columns(&columnName, &isNullable, &columnType); err != nil {
-				columnIter.Stop()
-				return errors.WithStack(err)
-			}
-			column := &schema.Column{
-				Name:     columnName,
-				Type:     columnType,
-				Nullable: convertColumnNullable(isNullable),
-			}
-
-			// column options
-			optionStmt := spanner.Statement{
-				SQL: `
+	// bulk get column options (avoid a per-column query)
+	optionStmt := spanner.Statement{SQL: `
 SELECT
-  OPTION_NAME, OPTION_VALUE
+  TABLE_NAME, COLUMN_NAME, OPTION_NAME, OPTION_VALUE
 FROM
   INFORMATION_SCHEMA.COLUMN_OPTIONS
 WHERE
-  TABLE_NAME = @tableName AND COLUMN_NAME = @columnName AND TABLE_CATALOG = '' AND TABLE_SCHEMA = '';
-`,
-				Params: map[string]interface{}{"tableName": tableName, "columnName": columnName},
-			}
-			optionIter := sp.client.Single().Query(sp.ctx, optionStmt)
-			for {
-				optionRow, err := optionIter.Next()
-				if errors.Is(err, iterator.Done) {
-					optionIter.Stop()
-					break
-				}
-				if err != nil {
-					optionIter.Stop()
-					return errors.WithStack(err)
-				}
-				var (
-					optionName  string
-					optionValue string
-				)
-				if err := optionRow.Columns(&optionName, &optionValue); err != nil {
-					optionIter.Stop()
-					return errors.WithStack(err)
-				}
-				column.Type = fmt.Sprintf("%s (%s=%s)", column.Type, optionName, optionValue)
-			}
-			optionIter.Stop()
-
-			columns = append(columns, column)
+  TABLE_CATALOG = '' AND TABLE_SCHEMA = ''
+ORDER BY TABLE_NAME, COLUMN_NAME, OPTION_NAME ASC;
+`}
+	optionIter := sp.client.Single().Query(sp.ctx, optionStmt)
+	defer optionIter.Stop()
+	for {
+		optionRow, err := optionIter.Next()
+		if errors.Is(err, iterator.Done) {
+			break
 		}
-		columnIter.Stop()
-		table.Columns = columns
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		var (
+			tableName   string
+			columnName  string
+			optionName  string
+			optionValue string
+		)
+		if err := optionRow.Columns(&tableName, &columnName, &optionName, &optionValue); err != nil {
+			return errors.WithStack(err)
+		}
+		columns, ok := columnMap[tableName]
+		if !ok {
+			continue
+		}
+		column, ok := columns[columnName]
+		if !ok {
+			continue
+		}
+		column.Type = fmt.Sprintf("%s (%s=%s)", column.Type, optionName, optionValue)
+	}
 
-		// indexes / constraints
-		indexStmt := spanner.Statement{
-			SQL: `
+	// bulk get indexes / constraints (avoid a per-table query)
+	indexStmt := spanner.Statement{SQL: `
 SELECT
-  c.INDEX_NAME, c.INDEX_TYPE, ARRAY_TO_STRING(ARRAY(
+  c.TABLE_NAME, c.INDEX_NAME, c.INDEX_TYPE, ARRAY_TO_STRING(ARRAY(
    SELECT COLUMN_NAME
    FROM INFORMATION_SCHEMA.INDEX_COLUMNS
    WHERE TABLE_NAME = c.TABLE_NAME AND INDEX_NAME = c.INDEX_NAME AND INDEX_TYPE = c.INDEX_TYPE AND ORDINAL_POSITION IS NOT NULL
@@ -184,90 +192,82 @@ FROM
   INFORMATION_SCHEMA.INDEX_COLUMNS AS c
 INNER JOIN INFORMATION_SCHEMA.INDEXES AS i ON i.TABLE_NAME = c.TABLE_NAME AND i.INDEX_NAME = c.INDEX_NAME
 WHERE
-  c.TABLE_CATALOG = '' AND c.TABLE_SCHEMA = '' AND c.TABLE_NAME = @tableName
-GROUP BY c.TABLE_CATALOG, c.TABLE_SCHEMA, c.TABLE_NAME, c.INDEX_NAME, c.INDEX_TYPE, i.PARENT_TABLE_NAME, i.IS_UNIQUE, i.IS_NULL_FILTERED, i.INDEX_STATE;
-`,
-			Params: map[string]interface{}{"tableName": tableName},
+  c.TABLE_CATALOG = '' AND c.TABLE_SCHEMA = ''
+GROUP BY c.TABLE_CATALOG, c.TABLE_SCHEMA, c.TABLE_NAME, c.INDEX_NAME, c.INDEX_TYPE, i.PARENT_TABLE_NAME, i.IS_UNIQUE, i.IS_NULL_FILTERED, i.INDEX_STATE
+ORDER BY c.TABLE_NAME, c.INDEX_NAME ASC;
+`}
+	indexIter := sp.client.Single().Query(sp.ctx, indexStmt)
+	defer indexIter.Stop()
+	for {
+		indexRow, err := indexIter.Next()
+		if errors.Is(err, iterator.Done) {
+			break
 		}
-		indexIter := sp.client.Single().Query(sp.ctx, indexStmt)
-		indexes := []*schema.Index{}
-		constraints := []*schema.Constraint{}
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		var (
+			tableName       string
+			indexName       string
+			indexType       string
+			columns         string
+			storingColumns  string
+			parentTableName spanner.NullString
+			isUnique        bool
+			isNullFiltered  bool
+			indexState      spanner.NullString
+		)
+		if err := indexRow.Columns(&tableName, &indexName, &indexType, &columns, &storingColumns, &parentTableName, &isUnique, &isNullFiltered, &indexState); err != nil {
+			return errors.WithStack(err)
+		}
+		table, ok := tableMap[tableName]
+		if !ok {
+			continue
+		}
 
-		for {
-			indexRow, err := indexIter.Next()
-			if errors.Is(err, iterator.Done) {
-				indexIter.Stop()
-				break
-			}
-			if err != nil {
-				indexIter.Stop()
-				return errors.WithStack(err)
-			}
+		switch indexType {
+		case "INDEX":
 			var (
-				indexName       string
-				indexType       string
-				columns         string
-				storingColumns  string
-				parentTableName spanner.NullString
-				isUnique        bool
-				isNullFiltered  bool
-				indexState      spanner.NullString
+				strUnique         string
+				strNullFiltered   string
+				strInterleave     string
+				strStoringColumns string
 			)
-			if err := indexRow.Columns(&indexName, &indexType, &columns, &storingColumns, &parentTableName, &isUnique, &isNullFiltered, &indexState); err != nil {
-				indexIter.Stop()
-				return errors.WithStack(err)
+			if isUnique {
+				strUnique = "UNIQUE "
+			}
+			if isNullFiltered {
+				strNullFiltered = "NULL_FILTERED "
+			}
+			if storingColumns != "" {
+				strStoringColumns = fmt.Sprintf(" STORING (%s)", storingColumns)
+			}
+			if parentTableName.StringVal != "" {
+				strInterleave = fmt.Sprintf(", INTERLEAVE IN %s", parentTableName.StringVal)
 			}
 
-			switch indexType {
-			case "INDEX":
-				var (
-					strUnique         string
-					strNullFiltered   string
-					strInterleave     string
-					strStoringColumns string
-				)
-				if isUnique {
-					strUnique = "UNIQUE "
-				}
-				if isNullFiltered {
-					strNullFiltered = "NULL_FILTERED "
-				}
-				if storingColumns != "" {
-					strStoringColumns = fmt.Sprintf(" STORING (%s)", storingColumns)
-				}
-				if parentTableName.StringVal != "" {
-					strInterleave = fmt.Sprintf(", INTERLEAVE IN %s", parentTableName.StringVal)
-				}
+			indexDef := fmt.Sprintf("CREATE %s%sINDEX %s ON %s (%s)%s%s", strUnique, strNullFiltered, indexName, table.Name, columns, strStoringColumns, strInterleave)
 
-				indexDef := fmt.Sprintf("CREATE %s%sINDEX %s ON %s (%s)%s%s", strUnique, strNullFiltered, indexName, table.Name, columns, strStoringColumns, strInterleave)
-
-				index := &schema.Index{
-					Name:    indexName,
-					Def:     indexDef,
-					Table:   &table.Name,
-					Columns: strings.Split(columns, ", "),
-				}
-				indexes = append(indexes, index)
-			case "PRIMARY_KEY":
-				constraint := &schema.Constraint{
-					Name:              "PRIMARY_KEY",
-					Type:              "PRIMARY_KEY",
-					Def:               fmt.Sprintf("PRIMARY KEY(%s)", columns),
-					Table:             &table.Name,
-					Columns:           strings.Split(columns, ", "),
-					ReferencedTable:   nil,
-					ReferencedColumns: []string{},
-				}
-				constraints = append(constraints, constraint)
-			default:
+			index := &schema.Index{
+				Name:    indexName,
+				Def:     indexDef,
+				Table:   &table.Name,
+				Columns: strings.Split(columns, ", "),
 			}
+			table.Indexes = append(table.Indexes, index)
+		case "PRIMARY_KEY":
+			constraint := &schema.Constraint{
+				Name:              "PRIMARY_KEY",
+				Type:              "PRIMARY_KEY",
+				Def:               fmt.Sprintf("PRIMARY KEY(%s)", columns),
+				Table:             &table.Name,
+				Columns:           strings.Split(columns, ", "),
+				ReferencedTable:   nil,
+				ReferencedColumns: []string{},
+			}
+			table.Constraints = append(table.Constraints, constraint)
+		default:
 		}
-		indexIter.Stop()
-		table.Indexes = indexes
-		table.Constraints = constraints
-
-		tables = append(tables, table)
-		tableMap[table.Name] = table
 	}
 
 	s.Tables = tables


### PR DESCRIPTION
## Summary

The Spanner driver's `Analyze()` queried `INFORMATION_SCHEMA` **per table** (columns, indexes)
and **per column** (column options). This is an N+1 pattern that dominates `tbls doc` /
`tbls out` runtime on non-trivial schemas.

This PR fetches columns, column options, and indexes with **one bulk query each** and groups
the rows in Go, mirroring the pattern the `mysql` driver already uses for columns and the
foreign-key query already used in this same driver. Query count becomes constant (5),
independent of table/column count. **The generated output is unchanged.**

## Problem

For a schema with `T` tables and `C` total columns, `Analyze()` issued:
1 (tables)

T (columns, one query per table)
C (column options, one query per column) ← worst offender
T (indexes, one query per table)
1 (foreign keys, already bulk)
= 2 + 2T + C queries
The per-column `COLUMN_OPTIONS` query is the biggest contributor.

## Benchmark
Measured against the Cloud Spanner emulator with a real-world schema of **135 tables / 977 columns**,
built from source, warm-up run discarded, `tbls out -t json` (median of 5 runs):
| | before (this driver on `main`) | after (this PR) |
|---|---|---|
| queries | **1249** | **5** |
| wall time | **~194 s** | **~1.2 s** |
~160x faster. On a remote Spanner instance the gap is larger, since each of the ~1249
round-trips pays network latency.
## Change
- Columns: single query `... ORDER BY TABLE_NAME, ORDINAL_POSITION`, grouped per table in Go.
- Column options: single query, applied to columns via a `map[table]map[column]*Column`.
- Indexes / primary keys: single query (dropped the per-table `WHERE`, kept the existing
  `GROUP BY`), `ORDER BY TABLE_NAME, INDEX_NAME`.
- Foreign keys: unchanged (already bulk).
`ORDER BY` was added to the bulk queries so column/index ordering is deterministic; the
previous per-table queries had no top-level `ORDER BY`, so ordering was unspecified.
## Compatibility / how verified
The schema output is identical before and after this change:
- `tbls out -t json` before vs after → **byte-identical** on
  (a) `testdata/ddl/spanner.sql` and (b) the 135-table schema above (MD5 match).
- `go build ./...`, `go vet ./drivers/spanner/`, `gofmt` clean.
- The existing `//go:build spanner` integration test (`drivers/spanner/spanner_test.go`)
  compiles and is unaffected.
> Note: benchmarking/verification used the Spanner **emulator**.