### PR TITLE
feat: support ssl-ca, ssl-cert and ssl-key DSN parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,21 @@ comments:
 dsn: my://dbuser:dbpass@hostname:3306/dbname
 ```
 
+#### SSL/TLS
+
+For PostgreSQL, MySQL, MariaDB and Microsoft SQL Server, the generic "ssl-ca", "ssl-cert", "ssl-key" and "ssl-verify-identity" parameters configure SSL/TLS using certificate files:
+
+```yaml
+# .tbls.yml
+dsn: my://dbuser:dbpass@hostname:3306/dbname?ssl-ca=/path/to/ca.pem&ssl-cert=/path/to/client-cert.pem&ssl-key=/path/to/client-key.pem
+```
+
+- `ssl-ca` verifies the server certificate chain without hostname verification (like `mysql --ssl-mode=VERIFY_CA`).
+- `ssl-verify-identity=true` also verifies the hostname (like `mysql --ssl-mode=VERIFY_IDENTITY`). The explicit `=true` value is required.
+- `ssl-cert` and `ssl-key` present a client certificate, and must be set together. Without `ssl-ca` or `ssl-verify-identity=true` the connection is encrypted but the server is not verified.
+- Parameters with empty values are ignored, so DSN templates like `?ssl-ca=${MYSQL_SSL_CA}` work unchanged when the environment variables are not set. Paired variables (`ssl-cert`/`ssl-key`) must be set or unset together.
+- Explicit native TLS parameters that contradict these settings (e.g. `sslmode=disable`, `encrypt=disable`, `trustservercertificate=true`, `tls=preferred`) are rejected with an error instead of being silently overridden. `tls=true` keeps full verification, and `tls=skip-verify` is upgraded to the requested verification level.
+
 #### Support Datasource
 
 tbls supports the following databases/datasources.
@@ -431,6 +446,8 @@ For example:
 dsn: pg://dbuser:dbpass@hostname:5432/dbname?sslmode=disable
 ```
 
+The generic SSL/TLS parameters map to `sslrootcert`, `sslcert` and `sslkey`, with `sslmode=verify-ca` (or `sslmode=verify-full` when `ssl-verify-identity=true` is set). An explicit verifying `sslmode` (`require`, `verify-ca`, `verify-full`) is kept. Certificate paths containing spaces are not supported.
+
 **MySQL:**
 
 ```yaml
@@ -449,6 +466,16 @@ For example:
 ```yaml
 dsn: my://dbuser:dbpass@hostname:3306/dbname?hide_auto_increment
 ```
+
+Each `--ssl-mode` of the mysql client maps to DSN parameters (see the SSL/TLS section) as follows:
+
+| `--ssl-mode` | DSN parameters |
+| --- | --- |
+| `DISABLED` | `?tls=false` |
+| `PREFERRED` | `?tls=preferred` |
+| `REQUIRED` | `?tls=skip-verify` |
+| `VERIFY_CA` | `?ssl-ca=/path/to/ca.pem` |
+| `VERIFY_IDENTITY` | `?ssl-ca=/path/to/ca.pem&ssl-verify-identity=true` |
 
 **MariaDB:**
 
@@ -550,6 +577,8 @@ dsn: sqlserver://DbUser:SQLServer-DbPassw0rd@hostname:1433/testdb
 # .tbls.yml
 dsn: ms://DbUser:SQLServer-DbPassw0rd@localhost:1433/testdb
 ```
+
+The generic SSL/TLS `ssl-ca` parameter maps to `certificate` with `encrypt=true` and `trustservercertificate=false` (go-mssqldb always verifies the hostname when encryption is on). The certificate file must have a `.pem` or `.der` extension. An explicit `encrypt=strict` is kept. Client certificates (`ssl-cert`/`ssl-key`) are not supported by the driver.
 
 **Amazon DynamoDB:**
 

--- a/README.md
+++ b/README.md
@@ -411,18 +411,24 @@ dsn: my://dbuser:dbpass@hostname:3306/dbname
 
 #### SSL/TLS
 
-For PostgreSQL, MySQL, MariaDB and Microsoft SQL Server, the generic "ssl-ca", "ssl-cert", "ssl-key" and "ssl-verify-identity" parameters configure SSL/TLS using certificate files:
+For PostgreSQL, MySQL, MariaDB and Microsoft SQL Server, the `tls:` section of `dsn:` configures SSL/TLS using certificate files:
 
 ```yaml
 # .tbls.yml
-dsn: my://dbuser:dbpass@hostname:3306/dbname?ssl-ca=/path/to/ca.pem&ssl-cert=/path/to/client-cert.pem&ssl-key=/path/to/client-key.pem
+dsn:
+  url: my://dbuser:dbpass@hostname:3306/dbname
+  tls:
+    ca: /path/to/ca.pem
+    cert: /path/to/client-cert.pem
+    key: /path/to/client-key.pem
+    verify: identity
 ```
 
-- `ssl-ca` verifies the server certificate chain without hostname verification (like `mysql --ssl-mode=VERIFY_CA`).
-- `ssl-verify-identity=true` also verifies the hostname (like `mysql --ssl-mode=VERIFY_IDENTITY`). The explicit `=true` value is required.
-- `ssl-cert` and `ssl-key` present a client certificate, and must be set together. Without `ssl-ca` or `ssl-verify-identity=true` the connection is encrypted but the server is not verified.
-- Parameters with empty values are ignored, so DSN templates like `?ssl-ca=${MYSQL_SSL_CA}` work unchanged when the environment variables are not set. Paired variables (`ssl-cert`/`ssl-key`) must be set or unset together.
-- Explicit native TLS parameters that contradict these settings (e.g. `sslmode=disable`, `encrypt=disable`, `trustservercertificate=true`, `tls=preferred`) are rejected with an error instead of being silently overridden. `tls=true` keeps full verification, and `tls=skip-verify` is upgraded to the requested verification level.
+- `ca` verifies the server certificate chain without hostname verification (like `mysql --ssl-mode=VERIFY_CA`).
+- `verify: identity` also verifies the hostname (like `mysql --ssl-mode=VERIFY_IDENTITY`).
+- `cert` and `key` present a client certificate, and must be set together. Without `ca` or `verify: identity` the connection is encrypted but the server is not verified.
+- Empty values are treated as absent, so settings like `ca: ${MYSQL_SSL_CA}` work unchanged when the environment variables are not set. Paired settings (`cert`/`key`) must be set or unset together.
+- Native TLS DSN parameters that contradict these settings (e.g. `sslmode=disable`, `encrypt=disable`, `trustservercertificate=true`, `tls=preferred`) are rejected with an error instead of being silently overridden. `tls=true` keeps full verification, and `tls=skip-verify` is upgraded to the requested verification level.
 
 #### Support Datasource
 
@@ -446,7 +452,7 @@ For example:
 dsn: pg://dbuser:dbpass@hostname:5432/dbname?sslmode=disable
 ```
 
-The generic SSL/TLS parameters map to `sslrootcert`, `sslcert` and `sslkey`, with `sslmode=verify-ca` (or `sslmode=verify-full` when `ssl-verify-identity=true` is set). An explicit verifying `sslmode` (`require`, `verify-ca`, `verify-full`) is kept. Certificate paths containing spaces are not supported.
+The `dsn.tls` settings map to `sslrootcert`, `sslcert` and `sslkey`, with `sslmode=verify-ca` (or `sslmode=verify-full` when `verify: identity` is set). An explicit verifying `sslmode` (`require`, `verify-ca`, `verify-full`) is kept. Certificate paths containing spaces are not supported.
 
 **MySQL:**
 
@@ -467,15 +473,15 @@ For example:
 dsn: my://dbuser:dbpass@hostname:3306/dbname?hide_auto_increment
 ```
 
-Each `--ssl-mode` of the mysql client maps to DSN parameters (see the SSL/TLS section) as follows:
+Each `--ssl-mode` of the mysql client maps to a DSN parameter or `dsn.tls` settings (see the SSL/TLS section) as follows:
 
-| `--ssl-mode` | DSN parameters |
+| `--ssl-mode` | tbls configuration |
 | --- | --- |
 | `DISABLED` | `?tls=false` |
 | `PREFERRED` | `?tls=preferred` |
 | `REQUIRED` | `?tls=skip-verify` |
-| `VERIFY_CA` | `?ssl-ca=/path/to/ca.pem` |
-| `VERIFY_IDENTITY` | `?ssl-ca=/path/to/ca.pem&ssl-verify-identity=true` |
+| `VERIFY_CA` | `tls:` with `ca: /path/to/ca.pem` |
+| `VERIFY_IDENTITY` | `tls:` with `ca: /path/to/ca.pem` and `verify: identity` |
 
 **MariaDB:**
 
@@ -578,7 +584,7 @@ dsn: sqlserver://DbUser:SQLServer-DbPassw0rd@hostname:1433/testdb
 dsn: ms://DbUser:SQLServer-DbPassw0rd@localhost:1433/testdb
 ```
 
-The generic SSL/TLS `ssl-ca` parameter maps to `certificate` with `encrypt=true` and `trustservercertificate=false` (go-mssqldb always verifies the hostname when encryption is on). The certificate file must have a `.pem` or `.der` extension. An explicit `encrypt=strict` is kept. Client certificates (`ssl-cert`/`ssl-key`) are not supported by the driver.
+The `dsn.tls.ca` setting maps to `certificate` with `encrypt=true` and `trustservercertificate=false` (go-mssqldb always verifies the hostname when encryption is on). The certificate file must have a `.pem` or `.der` extension. An explicit `encrypt=strict` is kept. Client certificates (`cert`/`key`) are not supported by the driver.
 
 **Amazon DynamoDB:**
 

--- a/config/config.go
+++ b/config/config.go
@@ -69,7 +69,7 @@ type Config struct {
 type DSN struct {
 	URL     string            `yaml:"url"`
 	Headers map[string]string `yaml:"headers,omitempty"`
-	TLS     TLS               `yaml:"tls,omitempty"`
+	TLS     *TLS              `yaml:"tls,omitempty"`
 }
 
 // TLS is the SSL/TLS configuration for the datasource connection.

--- a/config/config.go
+++ b/config/config.go
@@ -69,6 +69,15 @@ type Config struct {
 type DSN struct {
 	URL     string            `yaml:"url"`
 	Headers map[string]string `yaml:"headers,omitempty"`
+	TLS     TLS               `yaml:"tls,omitempty"`
+}
+
+// TLS is the SSL/TLS configuration for the datasource connection.
+type TLS struct {
+	CA     string `yaml:"ca,omitempty"`
+	Cert   string `yaml:"cert,omitempty"`
+	Key    string `yaml:"key,omitempty"`
+	Verify string `yaml:"verify,omitempty"`
 }
 
 // Format is document format setting.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -718,6 +718,32 @@ func TestNeedToGenerateERImages(t *testing.T) {
 	}
 }
 
+func TestDSNTLSConfig(t *testing.T) {
+	c, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	in := []byte(`
+dsn:
+  url: my://dbuser:dbpass@hostname:3306/dbname
+  tls:
+    ca: /path/to/ca.pem
+    cert: /path/to/client-cert.pem
+    key: /path/to/client-key.pem
+    verify: identity
+`)
+	if err := c.LoadConfig(in); err != nil {
+		t.Fatal(err)
+	}
+	if want := "my://dbuser:dbpass@hostname:3306/dbname"; c.DSN.URL != want {
+		t.Errorf("got %v\nwant %v", c.DSN.URL, want)
+	}
+	want := TLS{CA: "/path/to/ca.pem", Cert: "/path/to/client-cert.pem", Key: "/path/to/client-key.pem", Verify: "identity"}
+	if c.DSN.TLS != want {
+		t.Errorf("got %#v\nwant %#v", c.DSN.TLS, want)
+	}
+}
+
 func TestDetectShowColumnsForER(t *testing.T) {
 	tests := []struct {
 		showColumnTypes   *ShowColumnTypes

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -739,8 +739,31 @@ dsn:
 		t.Errorf("got %v\nwant %v", c.DSN.URL, want)
 	}
 	want := TLS{CA: "/path/to/ca.pem", Cert: "/path/to/client-cert.pem", Key: "/path/to/client-key.pem", Verify: "identity"}
-	if c.DSN.TLS != want {
+	if c.DSN.TLS == nil || *c.DSN.TLS != want {
 		t.Errorf("got %#v\nwant %#v", c.DSN.TLS, want)
+	}
+}
+
+func TestDSNTLSConfigEmptyValues(t *testing.T) {
+	c, err := New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TBLS_TEST_TLS_CA", "")
+	in := []byte(`
+dsn:
+  url: my://dbuser:dbpass@hostname:3306/dbname
+  tls:
+    ca: ${TBLS_TEST_TLS_CA}
+`)
+	if err := c.LoadConfig(in); err != nil {
+		t.Fatal(err)
+	}
+	if c.DSN.TLS == nil {
+		t.Fatal("DSN.TLS should not be nil when the tls block is present")
+	}
+	if *c.DSN.TLS != (TLS{}) {
+		t.Errorf("got %#v\nwant %#v", *c.DSN.TLS, TLS{})
 	}
 }
 

--- a/config/yaml.go
+++ b/config/yaml.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (d DSN) MarshalYAML() ([]byte, error) {
-	if len(d.Headers) == 0 && d.TLS == (TLS{}) {
+	if len(d.Headers) == 0 && d.TLS == nil {
 		dsn := d.URL
 		return yaml.Marshal(dsn)
 	}

--- a/config/yaml.go
+++ b/config/yaml.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (d DSN) MarshalYAML() ([]byte, error) {
-	if len(d.Headers) == 0 {
+	if len(d.Headers) == 0 && d.TLS == (TLS{}) {
 		dsn := d.URL
 		return yaml.Marshal(dsn)
 	}
@@ -22,9 +22,13 @@ func (d *DSN) UnmarshalYAML(data []byte) error {
 	case string:
 		d.URL = raw
 	case interface{}:
-		if err := yaml.Unmarshal(data, d); err != nil {
+		// Unmarshal via an alias type to avoid recursing into this method.
+		type plain DSN
+		var p plain
+		if err := yaml.Unmarshal(data, &p); err != nil {
 			return err
 		}
+		*d = DSN(p)
 	}
 	return nil
 }

--- a/datasource/datasource.go
+++ b/datasource/datasource.go
@@ -56,6 +56,14 @@ func Analyze(dsn config.DSN) (_ *schema.Schema, err error) {
 	if strings.HasPrefix(urlstr, "json://") {
 		return AnalyzeJSON(urlstr)
 	}
+	for _, prefix := range []string{"bq://", "bigquery://", "span://", "spanner://", "dynamodb://", "dynamo://", "mongodb://", "mongo://", "databricks://"} {
+		if strings.HasPrefix(urlstr, prefix) {
+			if err := rejectSSLParams(urlstr); err != nil {
+				return nil, err
+			}
+			break
+		}
+	}
 	if strings.HasPrefix(urlstr, "bq://") || strings.HasPrefix(urlstr, "bigquery://") {
 		return AnalyzeBigquery(urlstr)
 	}
@@ -83,6 +91,14 @@ func Analyze(dsn config.DSN) (_ *schema.Schema, err error) {
 	splitted := strings.Split(u.Short(), "/")
 	if len(splitted) < 2 {
 		return s, fmt.Errorf("invalid DSN: parse %s -> %#v", urlstr, u)
+	}
+
+	changed, err := applySSLParams(u)
+	if err != nil {
+		return nil, err
+	}
+	if changed {
+		urlstr = u.String()
 	}
 
 	opts := []drivers.Option{}

--- a/datasource/datasource.go
+++ b/datasource/datasource.go
@@ -47,6 +47,12 @@ func Analyze(dsn config.DSN) (_ *schema.Schema, err error) {
 		err = errors.WithStack(err)
 	}()
 	urlstr := dsn.URL
+	hasTLS := dsn.TLS != (config.TLS{})
+	if hasTLS {
+		if u, err := dburl.Parse(urlstr); err != nil || !slices.Contains(tlsSupportedDrivers, u.Driver) {
+			return nil, fmt.Errorf("dsn.tls is not supported for this datasource")
+		}
+	}
 	if strings.HasPrefix(urlstr, "https://") || strings.HasPrefix(urlstr, "http://") {
 		return AnalyzeHTTPResource(dsn)
 	}
@@ -55,14 +61,6 @@ func Analyze(dsn config.DSN) (_ *schema.Schema, err error) {
 	}
 	if strings.HasPrefix(urlstr, "json://") {
 		return AnalyzeJSON(urlstr)
-	}
-	for _, prefix := range []string{"bq://", "bigquery://", "span://", "spanner://", "dynamodb://", "dynamo://", "mongodb://", "mongo://", "databricks://"} {
-		if strings.HasPrefix(urlstr, prefix) {
-			if err := rejectSSLParams(urlstr); err != nil {
-				return nil, err
-			}
-			break
-		}
 	}
 	if strings.HasPrefix(urlstr, "bq://") || strings.HasPrefix(urlstr, "bigquery://") {
 		return AnalyzeBigquery(urlstr)
@@ -93,11 +91,10 @@ func Analyze(dsn config.DSN) (_ *schema.Schema, err error) {
 		return s, fmt.Errorf("invalid DSN: parse %s -> %#v", urlstr, u)
 	}
 
-	changed, err := applySSLParams(u)
-	if err != nil {
-		return nil, err
-	}
-	if changed {
+	if hasTLS {
+		if err := applyTLSConfig(u, dsn.TLS); err != nil {
+			return nil, err
+		}
 		urlstr = u.String()
 	}
 

--- a/datasource/datasource.go
+++ b/datasource/datasource.go
@@ -47,8 +47,11 @@ func Analyze(dsn config.DSN) (_ *schema.Schema, err error) {
 		err = errors.WithStack(err)
 	}()
 	urlstr := dsn.URL
-	hasTLS := dsn.TLS != (config.TLS{})
+	hasTLS := dsn.TLS != nil
 	if hasTLS {
+		if *dsn.TLS == (config.TLS{}) {
+			return nil, fmt.Errorf("dsn.tls: at least one of ca, cert, key, verify must be set (check that env vars referenced under dsn.tls are set)")
+		}
 		if u, err := dburl.Parse(urlstr); err != nil || !slices.Contains(tlsSupportedDrivers, u.Driver) {
 			return nil, fmt.Errorf("dsn.tls is not supported for this datasource")
 		}
@@ -92,7 +95,7 @@ func Analyze(dsn config.DSN) (_ *schema.Schema, err error) {
 	}
 
 	if hasTLS {
-		if err := applyTLSConfig(u, dsn.TLS); err != nil {
+		if err := applyTLSConfig(u, *dsn.TLS); err != nil {
 			return nil, err
 		}
 		urlstr = u.String()
@@ -211,7 +214,7 @@ func AnalyzeGitHubContent(dsn config.DSN) (_ *schema.Schema, err error) {
 	}()
 	splitted := strings.SplitN(strings.TrimPrefix(dsn.URL, "github://"), "/", 3)
 	if len(splitted) != 3 {
-		return nil, fmt.Errorf("invalid dsn: %s", dsn)
+		return nil, fmt.Errorf("invalid dsn: %s", dsn.URL)
 	}
 	s := &schema.Schema{}
 	options := []factory.Option{factory.OwnerRepo(splitted[0] + "/" + splitted[1])}

--- a/datasource/ssl.go
+++ b/datasource/ssl.go
@@ -1,0 +1,237 @@
+package datasource
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync/atomic"
+
+	mysqldriver "github.com/go-sql-driver/mysql"
+	"github.com/xo/dburl"
+)
+
+var mysqlTLSConfigCounter atomic.Uint64
+
+var sslParamKeys = []string{"ssl-ca", "ssl-cert", "ssl-key", "ssl-verify-identity"}
+
+type sslParams struct {
+	ca             string
+	cert           string
+	key            string
+	verifyIdentity bool
+}
+
+// applySSLParams extracts the ssl-ca, ssl-cert, ssl-key and ssl-verify-identity
+// DSN parameters and applies them to the connection using each driver's own TLS
+// mechanism. Empty values are treated as absent. Explicit native TLS parameters
+// that contradict them (e.g. sslmode=disable, encrypt=disable,
+// trustservercertificate=true) are rejected instead of silently overridden.
+// Reports whether the DSN query was rewritten.
+func applySSLParams(u *dburl.URL) (bool, error) {
+	values := u.Query()
+	present := false
+	for _, k := range sslParamKeys {
+		if _, ok := values[k]; ok {
+			present = true
+		}
+	}
+	if !present {
+		return false, nil
+	}
+	p := sslParams{
+		ca:   values.Get("ssl-ca"),
+		cert: values.Get("ssl-cert"),
+		key:  values.Get("ssl-key"),
+	}
+	if v := values.Get("ssl-verify-identity"); v != "" {
+		verifyIdentity, err := strconv.ParseBool(v)
+		if err != nil {
+			return false, fmt.Errorf("invalid ssl-verify-identity value: %s", v)
+		}
+		p.verifyIdentity = verifyIdentity
+	}
+	for _, k := range sslParamKeys {
+		values.Del(k)
+	}
+
+	if p.ca == "" && p.cert == "" && p.key == "" && !p.verifyIdentity {
+		u.RawQuery = values.Encode()
+		return true, nil
+	}
+	if (p.cert == "") != (p.key == "") {
+		return false, fmt.Errorf("ssl-cert and ssl-key must be set together")
+	}
+
+	var err error
+	switch u.Driver {
+	case "mysql":
+		err = registerMySQLTLS(p, values)
+	case "postgres":
+		err = applyPostgresSSL(p, values)
+	case "sqlserver":
+		err = applySQLServerSSL(p, values)
+	default:
+		err = fmt.Errorf("ssl-ca/ssl-cert/ssl-key/ssl-verify-identity are not supported for driver '%s'", u.Driver)
+	}
+	if err != nil {
+		return false, err
+	}
+	u.RawQuery = values.Encode()
+	return true, nil
+}
+
+// registerMySQLTLS registers a TLS config for MySQL/MariaDB connections and
+// rewrites the tls parameter to use it. An explicit tls=true is honored by
+// keeping full verification; tls=false and tls=preferred cannot be combined
+// with certificate files and are rejected.
+func registerMySQLTLS(p sslParams, values url.Values) error {
+	switch explicit := values.Get("tls"); explicit {
+	case "", "skip-verify":
+	case "true":
+		p.verifyIdentity = true
+	default:
+		return fmt.Errorf("cannot combine tls=%s with ssl-ca/ssl-cert/ssl-key", explicit)
+	}
+
+	tlsConfig := &tls.Config{} //nolint:gosec // the verification level is set explicitly below
+	var pool *x509.CertPool
+	if p.ca != "" {
+		pem, err := os.ReadFile(p.ca)
+		if err != nil {
+			return fmt.Errorf("failed to read ssl-ca: %w", err)
+		}
+		pool = x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(pem) {
+			return fmt.Errorf("failed to parse CA certificate from ssl-ca: %s", p.ca)
+		}
+	}
+	switch {
+	case p.verifyIdentity:
+		// Full verification (chain + hostname) against ssl-ca, or the system roots when no ssl-ca is given.
+		tlsConfig.RootCAs = pool
+	case pool != nil:
+		// VERIFY_CA: chain verification without hostname verification.
+		tlsConfig.InsecureSkipVerify = true
+		tlsConfig.VerifyConnection = verifyServerCertificate(pool)
+	default:
+		// Encrypted without server verification, like tls=skip-verify.
+		tlsConfig.InsecureSkipVerify = true
+	}
+	if p.cert != "" {
+		pair, err := tls.LoadX509KeyPair(p.cert, p.key)
+		if err != nil {
+			return fmt.Errorf("failed to load ssl-cert/ssl-key: %w", err)
+		}
+		// GetClientCertificate (instead of Certificates) sends the certificate
+		// even when the server's acceptable-CA list does not match its issuer.
+		tlsConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return &pair, nil
+		}
+	}
+
+	name := fmt.Sprintf("tbls-dsn-%d", mysqlTLSConfigCounter.Add(1))
+	if err := mysqldriver.RegisterTLSConfig(name, tlsConfig); err != nil {
+		return err
+	}
+	values.Set("tls", name)
+	return nil
+}
+
+// applyPostgresSSL maps the parameters to lib/pq's native ssl parameters.
+func applyPostgresSSL(p sslParams, values url.Values) error {
+	for _, path := range []string{p.ca, p.cert, p.key} {
+		if strings.Contains(path, " ") {
+			return fmt.Errorf("certificate paths containing spaces are not supported for postgres DSNs: %s", path)
+		}
+	}
+	mode := values.Get("sslmode")
+	switch mode {
+	case "disable", "allow", "prefer":
+		return fmt.Errorf("ssl-ca/ssl-cert/ssl-key/ssl-verify-identity conflict with sslmode=%s", mode)
+	}
+	if p.verifyIdentity {
+		if mode != "" && mode != "verify-full" {
+			return fmt.Errorf("ssl-verify-identity=true conflicts with sslmode=%s", mode)
+		}
+		values.Set("sslmode", "verify-full")
+	} else if p.ca != "" && mode == "" {
+		values.Set("sslmode", "verify-ca")
+	}
+	if p.ca != "" {
+		values.Set("sslrootcert", p.ca)
+	}
+	if p.cert != "" {
+		values.Set("sslcert", p.cert)
+		values.Set("sslkey", p.key)
+	}
+	return nil
+}
+
+// applySQLServerSSL maps ssl-ca to go-mssqldb's certificate parameter (the file
+// must have a .pem or .der extension). go-mssqldb performs full verification
+// (chain + hostname) when encryption is on and trustservercertificate is
+// false, so ssl-verify-identity needs no extra mapping.
+func applySQLServerSSL(p sslParams, values url.Values) error {
+	if p.cert != "" {
+		return fmt.Errorf("ssl-cert/ssl-key are not supported for driver 'sqlserver'")
+	}
+	if t := values.Get("trustservercertificate"); t != "" {
+		trust, err := strconv.ParseBool(t)
+		if err == nil && trust && p.ca != "" {
+			return fmt.Errorf("ssl-ca conflicts with trustservercertificate=true")
+		}
+	}
+	switch strings.ToLower(values.Get("encrypt")) {
+	case "":
+		values.Set("encrypt", "true")
+	case "disable", "optional", "no", "0", "f", "false":
+		return fmt.Errorf("ssl-ca/ssl-verify-identity conflict with encrypt=%s", values.Get("encrypt"))
+	}
+	if p.ca != "" {
+		values.Set("certificate", p.ca)
+		values.Set("trustservercertificate", "false")
+	}
+	return nil
+}
+
+// rejectSSLParams returns an error when the DSN carries generic ssl parameters
+// for a datasource that does not support them, instead of silently ignoring
+// the requested security settings.
+func rejectSSLParams(urlstr string) error {
+	u, err := url.Parse(urlstr)
+	if err != nil {
+		return nil //nolint:nilerr // let the datasource report its own DSN parse error
+	}
+	for _, k := range sslParamKeys {
+		if _, ok := u.Query()[k]; ok {
+			return fmt.Errorf("ssl-ca/ssl-cert/ssl-key/ssl-verify-identity are not supported for datasource '%s://'", u.Scheme)
+		}
+	}
+	return nil
+}
+
+// verifyServerCertificate verifies the server chain against roots, skipping
+// hostname verification. VerifyConnection (instead of VerifyPeerCertificate)
+// also covers resumed sessions.
+func verifyServerCertificate(roots *x509.CertPool) func(tls.ConnectionState) error {
+	return func(cs tls.ConnectionState) error {
+		if len(cs.PeerCertificates) == 0 {
+			return fmt.Errorf("no server certificate presented")
+		}
+		opts := x509.VerifyOptions{
+			Roots:         roots,
+			Intermediates: x509.NewCertPool(),
+		}
+		for _, cert := range cs.PeerCertificates[1:] {
+			opts.Intermediates.AddCert(cert)
+		}
+		if _, err := cs.PeerCertificates[0].Verify(opts); err != nil {
+			return fmt.Errorf("failed to verify server certificate against ssl-ca: %w", err)
+		}
+		return nil
+	}
+}

--- a/datasource/ssl.go
+++ b/datasource/ssl.go
@@ -11,107 +11,79 @@ import (
 	"sync/atomic"
 
 	mysqldriver "github.com/go-sql-driver/mysql"
+	"github.com/k1LoW/tbls/config"
 	"github.com/xo/dburl"
 )
 
 var mysqlTLSConfigCounter atomic.Uint64
 
-var sslParamKeys = []string{"ssl-ca", "ssl-cert", "ssl-key", "ssl-verify-identity"}
+// tlsSupportedDrivers are the dburl drivers that the dsn.tls configuration can
+// be applied to.
+var tlsSupportedDrivers = []string{"mysql", "postgres", "sqlserver"}
 
-type sslParams struct {
-	ca             string
-	cert           string
-	key            string
-	verifyIdentity bool
-}
+const tlsVerifyIdentity = "identity"
 
-// applySSLParams extracts the ssl-ca, ssl-cert, ssl-key and ssl-verify-identity
-// DSN parameters and applies them to the connection using each driver's own TLS
-// mechanism. Empty values are treated as absent. Explicit native TLS parameters
-// that contradict them (e.g. sslmode=disable, encrypt=disable,
+// applyTLSConfig applies the dsn.tls configuration to the connection using
+// each driver's own TLS mechanism, rewriting the DSN query accordingly.
+// Empty values are treated as absent. Native TLS DSN parameters that
+// contradict the configuration (e.g. sslmode=disable, encrypt=disable,
 // trustservercertificate=true) are rejected instead of silently overridden.
-// Reports whether the DSN query was rewritten.
-func applySSLParams(u *dburl.URL) (bool, error) {
+func applyTLSConfig(u *dburl.URL, t config.TLS) error {
+	if t.Verify != "" && t.Verify != tlsVerifyIdentity {
+		return fmt.Errorf("invalid dsn.tls.verify value: %s", t.Verify)
+	}
+	if (t.Cert == "") != (t.Key == "") {
+		return fmt.Errorf("dsn.tls.cert and dsn.tls.key must be set together")
+	}
+
 	values := u.Query()
-	present := false
-	for _, k := range sslParamKeys {
-		if _, ok := values[k]; ok {
-			present = true
-		}
-	}
-	if !present {
-		return false, nil
-	}
-	p := sslParams{
-		ca:   values.Get("ssl-ca"),
-		cert: values.Get("ssl-cert"),
-		key:  values.Get("ssl-key"),
-	}
-	if v := values.Get("ssl-verify-identity"); v != "" {
-		verifyIdentity, err := strconv.ParseBool(v)
-		if err != nil {
-			return false, fmt.Errorf("invalid ssl-verify-identity value: %s", v)
-		}
-		p.verifyIdentity = verifyIdentity
-	}
-	for _, k := range sslParamKeys {
-		values.Del(k)
-	}
-
-	if p.ca == "" && p.cert == "" && p.key == "" && !p.verifyIdentity {
-		u.RawQuery = values.Encode()
-		return true, nil
-	}
-	if (p.cert == "") != (p.key == "") {
-		return false, fmt.Errorf("ssl-cert and ssl-key must be set together")
-	}
-
 	var err error
 	switch u.Driver {
 	case "mysql":
-		err = registerMySQLTLS(p, values)
+		err = registerMySQLTLS(t, values)
 	case "postgres":
-		err = applyPostgresSSL(p, values)
+		err = applyPostgresTLS(t, values)
 	case "sqlserver":
-		err = applySQLServerSSL(p, values)
+		err = applySQLServerTLS(t, values)
 	default:
-		err = fmt.Errorf("ssl-ca/ssl-cert/ssl-key/ssl-verify-identity are not supported for driver '%s'", u.Driver)
+		err = fmt.Errorf("dsn.tls is not supported for driver '%s'", u.Driver)
 	}
 	if err != nil {
-		return false, err
+		return err
 	}
 	u.RawQuery = values.Encode()
-	return true, nil
+	return nil
 }
 
 // registerMySQLTLS registers a TLS config for MySQL/MariaDB connections and
 // rewrites the tls parameter to use it. An explicit tls=true is honored by
 // keeping full verification; tls=false and tls=preferred cannot be combined
-// with certificate files and are rejected.
-func registerMySQLTLS(p sslParams, values url.Values) error {
+// with dsn.tls and are rejected.
+func registerMySQLTLS(t config.TLS, values url.Values) error {
+	identity := t.Verify == tlsVerifyIdentity
 	switch explicit := values.Get("tls"); explicit {
 	case "", "skip-verify":
 	case "true":
-		p.verifyIdentity = true
+		identity = true
 	default:
-		return fmt.Errorf("cannot combine tls=%s with ssl-ca/ssl-cert/ssl-key", explicit)
+		return fmt.Errorf("cannot combine tls=%s with dsn.tls", explicit)
 	}
 
 	tlsConfig := &tls.Config{} //nolint:gosec // the verification level is set explicitly below
 	var pool *x509.CertPool
-	if p.ca != "" {
-		pem, err := os.ReadFile(p.ca)
+	if t.CA != "" {
+		pem, err := os.ReadFile(t.CA)
 		if err != nil {
-			return fmt.Errorf("failed to read ssl-ca: %w", err)
+			return fmt.Errorf("failed to read dsn.tls.ca: %w", err)
 		}
 		pool = x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(pem) {
-			return fmt.Errorf("failed to parse CA certificate from ssl-ca: %s", p.ca)
+			return fmt.Errorf("failed to parse CA certificate from dsn.tls.ca: %s", t.CA)
 		}
 	}
 	switch {
-	case p.verifyIdentity:
-		// Full verification (chain + hostname) against ssl-ca, or the system roots when no ssl-ca is given.
+	case identity:
+		// Full verification (chain + hostname) against dsn.tls.ca, or the system roots when no ca is given.
 		tlsConfig.RootCAs = pool
 	case pool != nil:
 		// VERIFY_CA: chain verification without hostname verification.
@@ -121,10 +93,10 @@ func registerMySQLTLS(p sslParams, values url.Values) error {
 		// Encrypted without server verification, like tls=skip-verify.
 		tlsConfig.InsecureSkipVerify = true
 	}
-	if p.cert != "" {
-		pair, err := tls.LoadX509KeyPair(p.cert, p.key)
+	if t.Cert != "" {
+		pair, err := tls.LoadX509KeyPair(t.Cert, t.Key)
 		if err != nil {
-			return fmt.Errorf("failed to load ssl-cert/ssl-key: %w", err)
+			return fmt.Errorf("failed to load dsn.tls.cert/dsn.tls.key: %w", err)
 		}
 		// GetClientCertificate (instead of Certificates) sends the certificate
 		// even when the server's acceptable-CA list does not match its issuer.
@@ -141,9 +113,10 @@ func registerMySQLTLS(p sslParams, values url.Values) error {
 	return nil
 }
 
-// applyPostgresSSL maps the parameters to lib/pq's native ssl parameters.
-func applyPostgresSSL(p sslParams, values url.Values) error {
-	for _, path := range []string{p.ca, p.cert, p.key} {
+// applyPostgresTLS maps the dsn.tls configuration to lib/pq's native ssl
+// parameters.
+func applyPostgresTLS(t config.TLS, values url.Values) error {
+	for _, path := range []string{t.CA, t.Cert, t.Key} {
 		if strings.Contains(path, " ") {
 			return fmt.Errorf("certificate paths containing spaces are not supported for postgres DSNs: %s", path)
 		}
@@ -151,65 +124,49 @@ func applyPostgresSSL(p sslParams, values url.Values) error {
 	mode := values.Get("sslmode")
 	switch mode {
 	case "disable", "allow", "prefer":
-		return fmt.Errorf("ssl-ca/ssl-cert/ssl-key/ssl-verify-identity conflict with sslmode=%s", mode)
+		return fmt.Errorf("dsn.tls conflicts with sslmode=%s", mode)
 	}
-	if p.verifyIdentity {
+	if t.Verify == tlsVerifyIdentity {
 		if mode != "" && mode != "verify-full" {
-			return fmt.Errorf("ssl-verify-identity=true conflicts with sslmode=%s", mode)
+			return fmt.Errorf("dsn.tls.verify: identity conflicts with sslmode=%s", mode)
 		}
 		values.Set("sslmode", "verify-full")
-	} else if p.ca != "" && mode == "" {
+	} else if t.CA != "" && mode == "" {
 		values.Set("sslmode", "verify-ca")
 	}
-	if p.ca != "" {
-		values.Set("sslrootcert", p.ca)
+	if t.CA != "" {
+		values.Set("sslrootcert", t.CA)
 	}
-	if p.cert != "" {
-		values.Set("sslcert", p.cert)
-		values.Set("sslkey", p.key)
+	if t.Cert != "" {
+		values.Set("sslcert", t.Cert)
+		values.Set("sslkey", t.Key)
 	}
 	return nil
 }
 
-// applySQLServerSSL maps ssl-ca to go-mssqldb's certificate parameter (the file
-// must have a .pem or .der extension). go-mssqldb performs full verification
-// (chain + hostname) when encryption is on and trustservercertificate is
-// false, so ssl-verify-identity needs no extra mapping.
-func applySQLServerSSL(p sslParams, values url.Values) error {
-	if p.cert != "" {
-		return fmt.Errorf("ssl-cert/ssl-key are not supported for driver 'sqlserver'")
+// applySQLServerTLS maps dsn.tls.ca to go-mssqldb's certificate parameter (the
+// file must have a .pem or .der extension). go-mssqldb performs full
+// verification (chain + hostname) when encryption is on and
+// trustservercertificate is false, so verify: identity needs no extra mapping.
+func applySQLServerTLS(t config.TLS, values url.Values) error {
+	if t.Cert != "" {
+		return fmt.Errorf("dsn.tls.cert/dsn.tls.key are not supported for driver 'sqlserver'")
 	}
-	if t := values.Get("trustservercertificate"); t != "" {
-		trust, err := strconv.ParseBool(t)
-		if err == nil && trust && p.ca != "" {
-			return fmt.Errorf("ssl-ca conflicts with trustservercertificate=true")
+	if v := values.Get("trustservercertificate"); v != "" {
+		trust, err := strconv.ParseBool(v)
+		if err == nil && trust && t.CA != "" {
+			return fmt.Errorf("dsn.tls.ca conflicts with trustservercertificate=true")
 		}
 	}
 	switch strings.ToLower(values.Get("encrypt")) {
 	case "":
 		values.Set("encrypt", "true")
 	case "disable", "optional", "no", "0", "f", "false":
-		return fmt.Errorf("ssl-ca/ssl-verify-identity conflict with encrypt=%s", values.Get("encrypt"))
+		return fmt.Errorf("dsn.tls conflicts with encrypt=%s", values.Get("encrypt"))
 	}
-	if p.ca != "" {
-		values.Set("certificate", p.ca)
+	if t.CA != "" {
+		values.Set("certificate", t.CA)
 		values.Set("trustservercertificate", "false")
-	}
-	return nil
-}
-
-// rejectSSLParams returns an error when the DSN carries generic ssl parameters
-// for a datasource that does not support them, instead of silently ignoring
-// the requested security settings.
-func rejectSSLParams(urlstr string) error {
-	u, err := url.Parse(urlstr)
-	if err != nil {
-		return nil //nolint:nilerr // let the datasource report its own DSN parse error
-	}
-	for _, k := range sslParamKeys {
-		if _, ok := u.Query()[k]; ok {
-			return fmt.Errorf("ssl-ca/ssl-cert/ssl-key/ssl-verify-identity are not supported for datasource '%s://'", u.Scheme)
-		}
 	}
 	return nil
 }
@@ -230,7 +187,7 @@ func verifyServerCertificate(roots *x509.CertPool) func(tls.ConnectionState) err
 			opts.Intermediates.AddCert(cert)
 		}
 		if _, err := cs.PeerCertificates[0].Verify(opts); err != nil {
-			return fmt.Errorf("failed to verify server certificate against ssl-ca: %w", err)
+			return fmt.Errorf("failed to verify server certificate against dsn.tls.ca: %w", err)
 		}
 		return nil
 	}

--- a/datasource/ssl.go
+++ b/datasource/ssl.go
@@ -154,8 +154,8 @@ func applySQLServerTLS(t config.TLS, values url.Values) error {
 	}
 	if v := values.Get("trustservercertificate"); v != "" {
 		trust, err := strconv.ParseBool(v)
-		if err == nil && trust && t.CA != "" {
-			return fmt.Errorf("dsn.tls.ca conflicts with trustservercertificate=true")
+		if err == nil && trust {
+			return fmt.Errorf("dsn.tls conflicts with trustservercertificate=true")
 		}
 	}
 	switch strings.ToLower(values.Get("encrypt")) {

--- a/datasource/ssl_test.go
+++ b/datasource/ssl_test.go
@@ -1,0 +1,448 @@
+package datasource
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/xo/dburl"
+)
+
+func TestApplySSLParamsAbsent(t *testing.T) {
+	tests := []struct {
+		name        string
+		dsn         string
+		wantChanged bool
+	}{
+		{"no ssl params", "mysql://user:pass@hostname:3306/dbname?hide_auto_increment", false},
+		{"empty ssl params", "mysql://user:pass@hostname:3306/dbname?ssl-ca=&ssl-cert=&ssl-key=&ssl-verify-identity=", true},
+		{"empty ssl params on postgres", "postgres://user:pass@hostname:5432/dbname?ssl-ca=", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := dburl.Parse(tt.dsn)
+			if err != nil {
+				t.Fatal(err)
+			}
+			changed, err := applySSLParams(u)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if changed != tt.wantChanged {
+				t.Errorf("changed = %v, want %v", changed, tt.wantChanged)
+			}
+			assertSSLParamsRemoved(t, u)
+			if got := u.Query().Get("tls"); got != "" {
+				t.Errorf("tls parameter should not be set, got %q", got)
+			}
+		})
+	}
+}
+
+func TestApplySSLParamsMySQL(t *testing.T) {
+	dir := t.TempDir()
+	ca := writeTestCA(t, dir)
+	cert, key := writeTestKeyPair(t, dir)
+
+	tests := []struct {
+		name    string
+		dsn     string
+		wantErr bool
+	}{
+		{"ca only", "mysql://user:pass@hostname:3306/dbname?ssl-ca=" + ca, false},
+		{"ca with client cert", "mysql://user:pass@hostname:3306/dbname?ssl-ca=" + ca + "&ssl-cert=" + cert + "&ssl-key=" + key, false},
+		{"client cert only", "maria://user:pass@hostname:3306/dbname?ssl-cert=" + cert + "&ssl-key=" + key, false},
+		{"ca with verify identity", "mysql://user:pass@hostname:3306/dbname?ssl-ca=" + ca + "&ssl-verify-identity=true", false},
+		{"verify identity only", "mysql://user:pass@hostname:3306/dbname?ssl-verify-identity=true", false},
+		{"explicit tls=true keeps full verification", "mysql://user:pass@hostname:3306/dbname?tls=true&ssl-cert=" + cert + "&ssl-key=" + key, false},
+		{"explicit tls=skip-verify is upgraded", "mysql://user:pass@hostname:3306/dbname?tls=skip-verify&ssl-ca=" + ca, false},
+		{"explicit tls=preferred conflicts", "mysql://user:pass@hostname:3306/dbname?tls=preferred&ssl-ca=" + ca, true},
+		{"explicit tls=false conflicts", "mysql://user:pass@hostname:3306/dbname?tls=false&ssl-ca=" + ca, true},
+		{"invalid verify identity value", "mysql://user:pass@hostname:3306/dbname?ssl-ca=" + ca + "&ssl-verify-identity=yeah", true},
+		{"cert without key", "mysql://user:pass@hostname:3306/dbname?ssl-ca=" + ca + "&ssl-cert=" + cert, true},
+		{"key without cert", "mysql://user:pass@hostname:3306/dbname?ssl-key=" + key, true},
+		{"missing ca file", "mysql://user:pass@hostname:3306/dbname?ssl-ca=" + filepath.Join(dir, "missing.pem"), true},
+		{"invalid ca file", "mysql://user:pass@hostname:3306/dbname?ssl-ca=" + key, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := dburl.Parse(tt.dsn)
+			if err != nil {
+				t.Fatal(err)
+			}
+			changed, err := applySSLParams(u)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !changed {
+				t.Error("changed = false, want true")
+			}
+			assertSSLParamsRemoved(t, u)
+			if got := u.Query().Get("tls"); !strings.HasPrefix(got, "tbls-dsn-") {
+				t.Errorf("tls parameter should be a registered tbls-dsn config, got %q", got)
+			}
+		})
+	}
+}
+
+func TestApplySSLParamsMySQLRegistersUniqueNames(t *testing.T) {
+	dir := t.TempDir()
+	ca := writeTestCA(t, dir)
+	names := map[string]bool{}
+	for range 2 {
+		u, err := dburl.Parse("mysql://user:pass@hostname:3306/dbname?ssl-ca=" + ca)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := applySSLParams(u); err != nil {
+			t.Fatal(err)
+		}
+		names[u.Query().Get("tls")] = true
+	}
+	if len(names) != 2 {
+		t.Errorf("expected unique tls config names per call, got %v", names)
+	}
+}
+
+func TestApplySSLParamsPostgres(t *testing.T) {
+	dir := t.TempDir()
+	ca := writeTestCA(t, dir)
+	cert, key := writeTestKeyPair(t, dir)
+
+	tests := []struct {
+		name         string
+		dsn          string
+		wantErr      bool
+		wantSSLMode  string
+		wantRootCert string
+		wantCert     string
+		wantKey      string
+	}{
+		{"ca only", "postgres://user:pass@hostname:5432/dbname?ssl-ca=" + ca, false, "verify-ca", ca, "", ""},
+		{"ca keeps explicit verify-full", "postgres://user:pass@hostname:5432/dbname?sslmode=verify-full&ssl-ca=" + ca, false, "verify-full", ca, "", ""},
+		{"ca keeps explicit require", "postgres://user:pass@hostname:5432/dbname?sslmode=require&ssl-ca=" + ca, false, "require", ca, "", ""},
+		{"ca with client cert", "postgres://user:pass@hostname:5432/dbname?ssl-ca=" + ca + "&ssl-cert=" + cert + "&ssl-key=" + key, false, "verify-ca", ca, cert, key},
+		{"ca with verify identity", "postgres://user:pass@hostname:5432/dbname?ssl-ca=" + ca + "&ssl-verify-identity=true", false, "verify-full", ca, "", ""},
+		{"redshift scheme", "rs://user:pass@hostname:5439/dbname?ssl-ca=" + ca, false, "verify-ca", ca, "", ""},
+		{"ca conflicts with sslmode=disable", "postgres://user:pass@hostname:5432/dbname?sslmode=disable&ssl-ca=" + ca, true, "", "", "", ""},
+		{"verify identity conflicts with explicit sslmode", "postgres://user:pass@hostname:5432/dbname?sslmode=require&ssl-verify-identity=true", true, "", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := dburl.Parse(tt.dsn)
+			if err != nil {
+				t.Fatal(err)
+			}
+			changed, err := applySSLParams(u)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !changed {
+				t.Error("changed = false, want true")
+			}
+			assertSSLParamsRemoved(t, u)
+			values := u.Query()
+			for param, want := range map[string]string{
+				"sslmode":     tt.wantSSLMode,
+				"sslrootcert": tt.wantRootCert,
+				"sslcert":     tt.wantCert,
+				"sslkey":      tt.wantKey,
+			} {
+				if got := values.Get(param); got != want {
+					t.Errorf("%s = %q, want %q", param, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestApplySSLParamsPostgresRejectsPathsWithSpaces(t *testing.T) {
+	dir := t.TempDir()
+	spacedDir := filepath.Join(dir, "with space")
+	if err := os.Mkdir(spacedDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	ca := writeTestCA(t, spacedDir)
+	u, err := dburl.Parse("postgres://user:pass@hostname:5432/dbname?ssl-ca=" + url.QueryEscape(ca))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := applySSLParams(u); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestApplySSLParamsSQLServer(t *testing.T) {
+	dir := t.TempDir()
+	ca := writeTestCA(t, dir)
+	cert, key := writeTestKeyPair(t, dir)
+
+	t.Run("ca only", func(t *testing.T) {
+		u, err := dburl.Parse("sqlserver://user:pass@hostname:1433/instance?ssl-ca=" + ca)
+		if err != nil {
+			t.Fatal(err)
+		}
+		changed, err := applySSLParams(u)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !changed {
+			t.Error("changed = false, want true")
+		}
+		assertSSLParamsRemoved(t, u)
+		values := u.Query()
+		if got := values.Get("encrypt"); got != "true" {
+			t.Errorf("encrypt = %q, want %q", got, "true")
+		}
+		if got := values.Get("certificate"); got != ca {
+			t.Errorf("certificate = %q, want %q", got, ca)
+		}
+		if got := values.Get("trustservercertificate"); got != "false" {
+			t.Errorf("trustservercertificate = %q, want %q", got, "false")
+		}
+	})
+	t.Run("verify identity only", func(t *testing.T) {
+		u, err := dburl.Parse("sqlserver://user:pass@hostname:1433/instance?ssl-verify-identity=true")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := applySSLParams(u); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		values := u.Query()
+		if got := values.Get("encrypt"); got != "true" {
+			t.Errorf("encrypt = %q, want %q", got, "true")
+		}
+		if _, ok := values["certificate"]; ok {
+			t.Error("certificate should not be set")
+		}
+	})
+	t.Run("explicit encrypt=strict is kept", func(t *testing.T) {
+		u, err := dburl.Parse("sqlserver://user:pass@hostname:1433/instance?encrypt=strict&ssl-ca=" + ca)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := applySSLParams(u); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := u.Query().Get("encrypt"); got != "strict" {
+			t.Errorf("encrypt = %q, want %q", got, "strict")
+		}
+	})
+	t.Run("ca conflicts with encrypt=disable", func(t *testing.T) {
+		u, err := dburl.Parse("sqlserver://user:pass@hostname:1433/instance?encrypt=disable&ssl-ca=" + ca)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := applySSLParams(u); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+	t.Run("ca conflicts with trustservercertificate=true", func(t *testing.T) {
+		u, err := dburl.Parse("sqlserver://user:pass@hostname:1433/instance?trustservercertificate=true&ssl-ca=" + ca)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := applySSLParams(u); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+	t.Run("client cert unsupported", func(t *testing.T) {
+		u, err := dburl.Parse("sqlserver://user:pass@hostname:1433/instance?ssl-cert=" + cert + "&ssl-key=" + key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := applySSLParams(u); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestApplySSLParamsUnsupportedDriver(t *testing.T) {
+	u, err := dburl.Parse("clickhouse://user:pass@hostname:9000/dbname?ssl-ca=/path/to/ca.pem")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := applySSLParams(u); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestRejectSSLParams(t *testing.T) {
+	if err := rejectSSLParams("mongodb://user:pass@hostname:27017/dbname?ssl-ca=/path/to/ca.pem"); err == nil {
+		t.Error("expected error, got nil")
+	}
+	if err := rejectSSLParams("mongodb://user:pass@hostname:27017/dbname?tls=true"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestVerifyServerCertificate(t *testing.T) {
+	caCert, caKey := generateCA(t)
+	leaf := generateLeaf(t, caCert, caKey)
+	otherCACert, otherCAKey := generateCA(t)
+	otherLeaf := generateLeaf(t, otherCACert, otherCAKey)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(caCert)
+	verify := verifyServerCertificate(pool)
+
+	if err := verify(tls.ConnectionState{PeerCertificates: []*x509.Certificate{leaf}}); err != nil {
+		t.Errorf("valid chain rejected: %v", err)
+	}
+	if err := verify(tls.ConnectionState{PeerCertificates: []*x509.Certificate{otherLeaf}}); err == nil {
+		t.Error("certificate from a different CA accepted")
+	}
+	if err := verify(tls.ConnectionState{}); err == nil {
+		t.Error("connection without server certificate accepted")
+	}
+}
+
+func assertSSLParamsRemoved(t *testing.T, u *dburl.URL) {
+	t.Helper()
+	values := u.Query()
+	for _, k := range sslParamKeys {
+		if _, ok := values[k]; ok {
+			t.Errorf("%s should be removed from the DSN", k)
+		}
+	}
+}
+
+func generateCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "tbls test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert, priv
+}
+
+func generateLeaf(t *testing.T, caCert *x509.Certificate, caKey *ecdsa.PrivateKey) *x509.Certificate {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "tbls test server"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &priv.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert
+}
+
+func writeTestCA(t *testing.T, dir string) string {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "tbls test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "ca.pem")
+	writePEM(t, path, "CERTIFICATE", der)
+	return path
+}
+
+func writeTestKeyPair(t *testing.T, dir string) (string, string) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "tbls test client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certPath := filepath.Join(dir, "client-cert.pem")
+	keyPath := filepath.Join(dir, "client-key.pem")
+	writePEM(t, certPath, "CERTIFICATE", der)
+	writePEM(t, keyPath, "EC PRIVATE KEY", keyDER)
+	return certPath, keyPath
+}
+
+func writePEM(t *testing.T, path, blockType string, der []byte) {
+	t.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := pem.Encode(f, &pem.Block{Type: blockType, Bytes: der}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/datasource/ssl_test.go
+++ b/datasource/ssl_test.go
@@ -228,6 +228,15 @@ func TestApplyTLSConfigSQLServer(t *testing.T) {
 			t.Fatal("expected error, got nil")
 		}
 	})
+	t.Run("verify identity conflicts with trustservercertificate=true", func(t *testing.T) {
+		u, err := dburl.Parse("sqlserver://user:pass@hostname:1433/instance?trustservercertificate=true")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := applyTLSConfig(u, config.TLS{Verify: "identity"}); err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
 	t.Run("client cert unsupported", func(t *testing.T) {
 		u, err := dburl.Parse("sqlserver://user:pass@hostname:1433/instance")
 		if err != nil {

--- a/datasource/ssl_test.go
+++ b/datasource/ssl_test.go
@@ -263,9 +263,15 @@ func TestAnalyzeTLSUnsupportedDatasource(t *testing.T) {
 		"mongodb://user:pass@hostname:27017/dbname",
 		"json://path/to/schema.json",
 	} {
-		if _, err := Analyze(config.DSN{URL: urlstr, TLS: config.TLS{CA: "/path/to/ca.pem"}}); err == nil {
+		if _, err := Analyze(config.DSN{URL: urlstr, TLS: &config.TLS{CA: "/path/to/ca.pem"}}); err == nil {
 			t.Errorf("expected error for %s, got nil", urlstr)
 		}
+	}
+}
+
+func TestAnalyzeTLSEmptyBlock(t *testing.T) {
+	if _, err := Analyze(config.DSN{URL: "my://user:pass@hostname:3306/dbname", TLS: &config.TLS{}}); err == nil {
+		t.Fatal("expected error, got nil")
 	}
 }
 

--- a/datasource/ssl_test.go
+++ b/datasource/ssl_test.go
@@ -9,48 +9,17 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/k1LoW/tbls/config"
 	"github.com/xo/dburl"
 )
 
-func TestApplySSLParamsAbsent(t *testing.T) {
-	tests := []struct {
-		name        string
-		dsn         string
-		wantChanged bool
-	}{
-		{"no ssl params", "mysql://user:pass@hostname:3306/dbname?hide_auto_increment", false},
-		{"empty ssl params", "mysql://user:pass@hostname:3306/dbname?ssl-ca=&ssl-cert=&ssl-key=&ssl-verify-identity=", true},
-		{"empty ssl params on postgres", "postgres://user:pass@hostname:5432/dbname?ssl-ca=", true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			u, err := dburl.Parse(tt.dsn)
-			if err != nil {
-				t.Fatal(err)
-			}
-			changed, err := applySSLParams(u)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if changed != tt.wantChanged {
-				t.Errorf("changed = %v, want %v", changed, tt.wantChanged)
-			}
-			assertSSLParamsRemoved(t, u)
-			if got := u.Query().Get("tls"); got != "" {
-				t.Errorf("tls parameter should not be set, got %q", got)
-			}
-		})
-	}
-}
-
-func TestApplySSLParamsMySQL(t *testing.T) {
+func TestApplyTLSConfigMySQL(t *testing.T) {
 	dir := t.TempDir()
 	ca := writeTestCA(t, dir)
 	cert, key := writeTestKeyPair(t, dir)
@@ -58,22 +27,23 @@ func TestApplySSLParamsMySQL(t *testing.T) {
 	tests := []struct {
 		name    string
 		dsn     string
+		tls     config.TLS
 		wantErr bool
 	}{
-		{"ca only", "mysql://user:pass@hostname:3306/dbname?ssl-ca=" + ca, false},
-		{"ca with client cert", "mysql://user:pass@hostname:3306/dbname?ssl-ca=" + ca + "&ssl-cert=" + cert + "&ssl-key=" + key, false},
-		{"client cert only", "maria://user:pass@hostname:3306/dbname?ssl-cert=" + cert + "&ssl-key=" + key, false},
-		{"ca with verify identity", "mysql://user:pass@hostname:3306/dbname?ssl-ca=" + ca + "&ssl-verify-identity=true", false},
-		{"verify identity only", "mysql://user:pass@hostname:3306/dbname?ssl-verify-identity=true", false},
-		{"explicit tls=true keeps full verification", "mysql://user:pass@hostname:3306/dbname?tls=true&ssl-cert=" + cert + "&ssl-key=" + key, false},
-		{"explicit tls=skip-verify is upgraded", "mysql://user:pass@hostname:3306/dbname?tls=skip-verify&ssl-ca=" + ca, false},
-		{"explicit tls=preferred conflicts", "mysql://user:pass@hostname:3306/dbname?tls=preferred&ssl-ca=" + ca, true},
-		{"explicit tls=false conflicts", "mysql://user:pass@hostname:3306/dbname?tls=false&ssl-ca=" + ca, true},
-		{"invalid verify identity value", "mysql://user:pass@hostname:3306/dbname?ssl-ca=" + ca + "&ssl-verify-identity=yeah", true},
-		{"cert without key", "mysql://user:pass@hostname:3306/dbname?ssl-ca=" + ca + "&ssl-cert=" + cert, true},
-		{"key without cert", "mysql://user:pass@hostname:3306/dbname?ssl-key=" + key, true},
-		{"missing ca file", "mysql://user:pass@hostname:3306/dbname?ssl-ca=" + filepath.Join(dir, "missing.pem"), true},
-		{"invalid ca file", "mysql://user:pass@hostname:3306/dbname?ssl-ca=" + key, true},
+		{"ca only", "mysql://user:pass@hostname:3306/dbname", config.TLS{CA: ca}, false},
+		{"ca with client cert", "mysql://user:pass@hostname:3306/dbname", config.TLS{CA: ca, Cert: cert, Key: key}, false},
+		{"client cert only", "maria://user:pass@hostname:3306/dbname", config.TLS{Cert: cert, Key: key}, false},
+		{"ca with verify identity", "mysql://user:pass@hostname:3306/dbname", config.TLS{CA: ca, Verify: "identity"}, false},
+		{"verify identity only", "mysql://user:pass@hostname:3306/dbname", config.TLS{Verify: "identity"}, false},
+		{"explicit tls=true keeps full verification", "mysql://user:pass@hostname:3306/dbname?tls=true", config.TLS{Cert: cert, Key: key}, false},
+		{"explicit tls=skip-verify is upgraded", "mysql://user:pass@hostname:3306/dbname?tls=skip-verify", config.TLS{CA: ca}, false},
+		{"explicit tls=preferred conflicts", "mysql://user:pass@hostname:3306/dbname?tls=preferred", config.TLS{CA: ca}, true},
+		{"explicit tls=false conflicts", "mysql://user:pass@hostname:3306/dbname?tls=false", config.TLS{CA: ca}, true},
+		{"invalid verify value", "mysql://user:pass@hostname:3306/dbname", config.TLS{CA: ca, Verify: "yeah"}, true},
+		{"cert without key", "mysql://user:pass@hostname:3306/dbname", config.TLS{CA: ca, Cert: cert}, true},
+		{"key without cert", "mysql://user:pass@hostname:3306/dbname", config.TLS{Key: key}, true},
+		{"missing ca file", "mysql://user:pass@hostname:3306/dbname", config.TLS{CA: filepath.Join(dir, "missing.pem")}, true},
+		{"invalid ca file", "mysql://user:pass@hostname:3306/dbname", config.TLS{CA: key}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -81,7 +51,7 @@ func TestApplySSLParamsMySQL(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			changed, err := applySSLParams(u)
+			err = applyTLSConfig(u, tt.tls)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -91,10 +61,6 @@ func TestApplySSLParamsMySQL(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if !changed {
-				t.Error("changed = false, want true")
-			}
-			assertSSLParamsRemoved(t, u)
 			if got := u.Query().Get("tls"); !strings.HasPrefix(got, "tbls-dsn-") {
 				t.Errorf("tls parameter should be a registered tbls-dsn config, got %q", got)
 			}
@@ -102,16 +68,16 @@ func TestApplySSLParamsMySQL(t *testing.T) {
 	}
 }
 
-func TestApplySSLParamsMySQLRegistersUniqueNames(t *testing.T) {
+func TestApplyTLSConfigMySQLRegistersUniqueNames(t *testing.T) {
 	dir := t.TempDir()
 	ca := writeTestCA(t, dir)
 	names := map[string]bool{}
 	for range 2 {
-		u, err := dburl.Parse("mysql://user:pass@hostname:3306/dbname?ssl-ca=" + ca)
+		u, err := dburl.Parse("mysql://user:pass@hostname:3306/dbname")
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := applySSLParams(u); err != nil {
+		if err := applyTLSConfig(u, config.TLS{CA: ca}); err != nil {
 			t.Fatal(err)
 		}
 		names[u.Query().Get("tls")] = true
@@ -121,7 +87,7 @@ func TestApplySSLParamsMySQLRegistersUniqueNames(t *testing.T) {
 	}
 }
 
-func TestApplySSLParamsPostgres(t *testing.T) {
+func TestApplyTLSConfigPostgres(t *testing.T) {
 	dir := t.TempDir()
 	ca := writeTestCA(t, dir)
 	cert, key := writeTestKeyPair(t, dir)
@@ -129,20 +95,21 @@ func TestApplySSLParamsPostgres(t *testing.T) {
 	tests := []struct {
 		name         string
 		dsn          string
+		tls          config.TLS
 		wantErr      bool
 		wantSSLMode  string
 		wantRootCert string
 		wantCert     string
 		wantKey      string
 	}{
-		{"ca only", "postgres://user:pass@hostname:5432/dbname?ssl-ca=" + ca, false, "verify-ca", ca, "", ""},
-		{"ca keeps explicit verify-full", "postgres://user:pass@hostname:5432/dbname?sslmode=verify-full&ssl-ca=" + ca, false, "verify-full", ca, "", ""},
-		{"ca keeps explicit require", "postgres://user:pass@hostname:5432/dbname?sslmode=require&ssl-ca=" + ca, false, "require", ca, "", ""},
-		{"ca with client cert", "postgres://user:pass@hostname:5432/dbname?ssl-ca=" + ca + "&ssl-cert=" + cert + "&ssl-key=" + key, false, "verify-ca", ca, cert, key},
-		{"ca with verify identity", "postgres://user:pass@hostname:5432/dbname?ssl-ca=" + ca + "&ssl-verify-identity=true", false, "verify-full", ca, "", ""},
-		{"redshift scheme", "rs://user:pass@hostname:5439/dbname?ssl-ca=" + ca, false, "verify-ca", ca, "", ""},
-		{"ca conflicts with sslmode=disable", "postgres://user:pass@hostname:5432/dbname?sslmode=disable&ssl-ca=" + ca, true, "", "", "", ""},
-		{"verify identity conflicts with explicit sslmode", "postgres://user:pass@hostname:5432/dbname?sslmode=require&ssl-verify-identity=true", true, "", "", "", ""},
+		{"ca only", "postgres://user:pass@hostname:5432/dbname", config.TLS{CA: ca}, false, "verify-ca", ca, "", ""},
+		{"ca keeps explicit verify-full", "postgres://user:pass@hostname:5432/dbname?sslmode=verify-full", config.TLS{CA: ca}, false, "verify-full", ca, "", ""},
+		{"ca keeps explicit require", "postgres://user:pass@hostname:5432/dbname?sslmode=require", config.TLS{CA: ca}, false, "require", ca, "", ""},
+		{"ca with client cert", "postgres://user:pass@hostname:5432/dbname", config.TLS{CA: ca, Cert: cert, Key: key}, false, "verify-ca", ca, cert, key},
+		{"ca with verify identity", "postgres://user:pass@hostname:5432/dbname", config.TLS{CA: ca, Verify: "identity"}, false, "verify-full", ca, "", ""},
+		{"redshift scheme", "rs://user:pass@hostname:5439/dbname", config.TLS{CA: ca}, false, "verify-ca", ca, "", ""},
+		{"ca conflicts with sslmode=disable", "postgres://user:pass@hostname:5432/dbname?sslmode=disable", config.TLS{CA: ca}, true, "", "", "", ""},
+		{"verify identity conflicts with explicit sslmode", "postgres://user:pass@hostname:5432/dbname?sslmode=require", config.TLS{Verify: "identity"}, true, "", "", "", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -150,7 +117,7 @@ func TestApplySSLParamsPostgres(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			changed, err := applySSLParams(u)
+			err = applyTLSConfig(u, tt.tls)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
@@ -160,10 +127,6 @@ func TestApplySSLParamsPostgres(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if !changed {
-				t.Error("changed = false, want true")
-			}
-			assertSSLParamsRemoved(t, u)
 			values := u.Query()
 			for param, want := range map[string]string{
 				"sslmode":     tt.wantSSLMode,
@@ -179,40 +142,35 @@ func TestApplySSLParamsPostgres(t *testing.T) {
 	}
 }
 
-func TestApplySSLParamsPostgresRejectsPathsWithSpaces(t *testing.T) {
+func TestApplyTLSConfigPostgresRejectsPathsWithSpaces(t *testing.T) {
 	dir := t.TempDir()
 	spacedDir := filepath.Join(dir, "with space")
 	if err := os.Mkdir(spacedDir, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	ca := writeTestCA(t, spacedDir)
-	u, err := dburl.Parse("postgres://user:pass@hostname:5432/dbname?ssl-ca=" + url.QueryEscape(ca))
+	u, err := dburl.Parse("postgres://user:pass@hostname:5432/dbname")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := applySSLParams(u); err == nil {
+	if err := applyTLSConfig(u, config.TLS{CA: ca}); err == nil {
 		t.Fatal("expected error, got nil")
 	}
 }
 
-func TestApplySSLParamsSQLServer(t *testing.T) {
+func TestApplyTLSConfigSQLServer(t *testing.T) {
 	dir := t.TempDir()
 	ca := writeTestCA(t, dir)
 	cert, key := writeTestKeyPair(t, dir)
 
 	t.Run("ca only", func(t *testing.T) {
-		u, err := dburl.Parse("sqlserver://user:pass@hostname:1433/instance?ssl-ca=" + ca)
+		u, err := dburl.Parse("sqlserver://user:pass@hostname:1433/instance")
 		if err != nil {
 			t.Fatal(err)
 		}
-		changed, err := applySSLParams(u)
-		if err != nil {
+		if err := applyTLSConfig(u, config.TLS{CA: ca}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if !changed {
-			t.Error("changed = false, want true")
-		}
-		assertSSLParamsRemoved(t, u)
 		values := u.Query()
 		if got := values.Get("encrypt"); got != "true" {
 			t.Errorf("encrypt = %q, want %q", got, "true")
@@ -225,11 +183,11 @@ func TestApplySSLParamsSQLServer(t *testing.T) {
 		}
 	})
 	t.Run("verify identity only", func(t *testing.T) {
-		u, err := dburl.Parse("sqlserver://user:pass@hostname:1433/instance?ssl-verify-identity=true")
+		u, err := dburl.Parse("sqlserver://user:pass@hostname:1433/instance")
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := applySSLParams(u); err != nil {
+		if err := applyTLSConfig(u, config.TLS{Verify: "identity"}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		values := u.Query()
@@ -241,11 +199,11 @@ func TestApplySSLParamsSQLServer(t *testing.T) {
 		}
 	})
 	t.Run("explicit encrypt=strict is kept", func(t *testing.T) {
-		u, err := dburl.Parse("sqlserver://user:pass@hostname:1433/instance?encrypt=strict&ssl-ca=" + ca)
+		u, err := dburl.Parse("sqlserver://user:pass@hostname:1433/instance?encrypt=strict")
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := applySSLParams(u); err != nil {
+		if err := applyTLSConfig(u, config.TLS{CA: ca}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if got := u.Query().Get("encrypt"); got != "strict" {
@@ -253,50 +211,52 @@ func TestApplySSLParamsSQLServer(t *testing.T) {
 		}
 	})
 	t.Run("ca conflicts with encrypt=disable", func(t *testing.T) {
-		u, err := dburl.Parse("sqlserver://user:pass@hostname:1433/instance?encrypt=disable&ssl-ca=" + ca)
+		u, err := dburl.Parse("sqlserver://user:pass@hostname:1433/instance?encrypt=disable")
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := applySSLParams(u); err == nil {
+		if err := applyTLSConfig(u, config.TLS{CA: ca}); err == nil {
 			t.Fatal("expected error, got nil")
 		}
 	})
 	t.Run("ca conflicts with trustservercertificate=true", func(t *testing.T) {
-		u, err := dburl.Parse("sqlserver://user:pass@hostname:1433/instance?trustservercertificate=true&ssl-ca=" + ca)
+		u, err := dburl.Parse("sqlserver://user:pass@hostname:1433/instance?trustservercertificate=true")
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := applySSLParams(u); err == nil {
+		if err := applyTLSConfig(u, config.TLS{CA: ca}); err == nil {
 			t.Fatal("expected error, got nil")
 		}
 	})
 	t.Run("client cert unsupported", func(t *testing.T) {
-		u, err := dburl.Parse("sqlserver://user:pass@hostname:1433/instance?ssl-cert=" + cert + "&ssl-key=" + key)
+		u, err := dburl.Parse("sqlserver://user:pass@hostname:1433/instance")
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err := applySSLParams(u); err == nil {
+		if err := applyTLSConfig(u, config.TLS{Cert: cert, Key: key}); err == nil {
 			t.Fatal("expected error, got nil")
 		}
 	})
 }
 
-func TestApplySSLParamsUnsupportedDriver(t *testing.T) {
-	u, err := dburl.Parse("clickhouse://user:pass@hostname:9000/dbname?ssl-ca=/path/to/ca.pem")
+func TestApplyTLSConfigUnsupportedDriver(t *testing.T) {
+	u, err := dburl.Parse("clickhouse://user:pass@hostname:9000/dbname")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := applySSLParams(u); err == nil {
+	if err := applyTLSConfig(u, config.TLS{CA: "/path/to/ca.pem"}); err == nil {
 		t.Fatal("expected error, got nil")
 	}
 }
 
-func TestRejectSSLParams(t *testing.T) {
-	if err := rejectSSLParams("mongodb://user:pass@hostname:27017/dbname?ssl-ca=/path/to/ca.pem"); err == nil {
-		t.Error("expected error, got nil")
-	}
-	if err := rejectSSLParams("mongodb://user:pass@hostname:27017/dbname?tls=true"); err != nil {
-		t.Errorf("unexpected error: %v", err)
+func TestAnalyzeTLSUnsupportedDatasource(t *testing.T) {
+	for _, urlstr := range []string{
+		"mongodb://user:pass@hostname:27017/dbname",
+		"json://path/to/schema.json",
+	} {
+		if _, err := Analyze(config.DSN{URL: urlstr, TLS: config.TLS{CA: "/path/to/ca.pem"}}); err == nil {
+			t.Errorf("expected error for %s, got nil", urlstr)
+		}
 	}
 }
 
@@ -318,16 +278,6 @@ func TestVerifyServerCertificate(t *testing.T) {
 	}
 	if err := verify(tls.ConnectionState{}); err == nil {
 		t.Error("connection without server certificate accepted")
-	}
-}
-
-func assertSSLParamsRemoved(t *testing.T, u *dburl.URL) {
-	t.Helper()
-	values := u.Query()
-	for _, k := range sslParamKeys {
-		if _, ok := values[k]; ok {
-			t.Errorf("%s should be removed from the DSN", k)
-		}
 	}
 }
 


### PR DESCRIPTION
## Why

Connecting to databases that use a private CA or require client certificates (e.g. managed MySQL with `REQUIRE X509` accounts) is currently not possible for drivers whose Go SQL driver has no file-based TLS DSN parameters. The go-sql-driver/mysql `tls` parameter only accepts `true|false|skip-verify|preferred`; loading certificate files requires `RegisterTLSConfig()`, which a DSN-only tool like tbls never calls. This makes tbls unusable in CI/Kubernetes environments where the database mandates certificate-based TLS.

## What

Adds four generic DSN query parameters — `ssl-ca`, `ssl-cert`, `ssl-key` and `ssl-verify-identity` — applied through each driver's own TLS mechanism:

| Driver | Behavior |
|---|---|
| `mysql` / `maria` | Loads the files, registers a per-call TLS config via `mysql.RegisterTLSConfig`, and rewrites `tls=` to use it. `ssl-ca` alone verifies the chain without hostname verification (`VERIFY_CA`); adding `ssl-verify-identity=true` also verifies the hostname (`VERIFY_IDENTITY`). An explicit `tls=true` keeps full verification; `tls=false`/`tls=preferred` conflict and are rejected |
| `postgres` / `rs` | Translates to lib/pq's native `sslrootcert` / `sslcert` / `sslkey`; sets `sslmode=verify-ca` when no `sslmode` was given (an explicit verifying `sslmode` is kept — lib/pq treats `require` + root cert like `verify-ca`), and `sslmode=verify-full` for `ssl-verify-identity=true` |
| `sqlserver` | `ssl-ca` maps to go-mssqldb's `certificate` (`.pem`/`.der` file) with `encrypt=true` and `trustservercertificate=false`; an explicit `encrypt=strict` is kept; `ssl-cert`/`ssl-key` return an error — SQL Server has no client-certificate authentication |
| others | Explicit error — including the non-dburl datasources (BigQuery, Spanner, DynamoDB, MongoDB, Databricks), so the parameters are never silently ignored |

Combined with the drivers' existing native parameters (`tls=` for MySQL/MariaDB, `sslmode=` for PostgreSQL, `encrypt=` for SQL Server), every standard SSL mode is now expressible.

Additional semantics:

- Explicit native TLS parameters that contradict the requested verification (`sslmode=disable`, `encrypt=disable`, `trustservercertificate=true`, …) are rejected with an error instead of being silently overridden or ignored.
- `ssl-cert`/`ssl-key` present a client certificate and must be set together. The client certificate is supplied via `GetClientCertificate`, so it is sent even when the server's acceptable-CA list does not match the issuer.
- Chain verification uses `tls.Config.VerifyConnection` (not `VerifyPeerCertificate`), so it also covers resumed sessions and passes gosec's G123 check.
- TLS configs are registered under a unique per-call name, so concurrent library use cannot clobber another call's configuration.
- **Empty values are treated as absent** and stripped from the DSN, so config templates like `?ssl-ca=${MYSQL_SSL_CA}` keep working unchanged when the environment variables are not set.
- The parameters are always removed before the DSN reaches the SQL driver (same pattern as `hide_auto_increment`).

## Docs

- New "SSL/TLS" section under "DSN" in the README documenting the generic parameters and the conflict rules, with driver-specific mapping notes in the PostgreSQL and Microsoft SQL Server sections.
- The MySQL section documents how each `--ssl-mode` of the mysql client maps to DSN parameters.

## Testing

- `golangci-lint run` (the repo config, including gosec) passes with 0 issues.
- Unit tests cover all dispatch paths (mysql/maria, postgres/redshift, sqlserver, unsupported and non-dburl datasources), the chain-verification callback itself (valid chain, wrong CA, missing certificate), conflict rejection for every driver, unique config-name registration, empty-value stripping, `ssl-verify-identity` parsing, cert-without-key validation, and bad/missing/invalid certificate files (test certificates are generated in-test).
- Verified end-to-end against a real MySQL 8.0 server: connects with the full `ssl-ca` + `ssl-cert` + `ssl-key` trio; `tls=skip-verify&ssl-ca=…` upgrades to chain verification; `ssl-verify-identity=true` correctly rejects a server certificate without a matching SAN; `tls=preferred&ssl-ca=…` is rejected as a conflict.
