### PR TITLE
fix: stabilize trigger introspection order in postgres/mysql/mssql/sqlite

### DIFF
--- a/drivers/mssql/mssql.go
+++ b/drivers/mssql/mssql.go
@@ -331,6 +331,7 @@ INNER JOIN sys.sql_modules AS sm
 ON sm.object_id = t.object_id
 WHERE type = 'TR'
 AND parent_id = object_id(@p1)
+ORDER BY t.object_id
 `, fmt.Sprintf("%s.%s", tableSchema, tableName))
 		if err != nil {
 			return errors.WithStack(err)

--- a/drivers/mssql/mssql_test.go
+++ b/drivers/mssql/mssql_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/k1LoW/tbls/schema"
 	_ "github.com/microsoft/go-mssqldb"
 	"github.com/xo/dburl"
@@ -58,6 +59,45 @@ func TestInfo(t *testing.T) {
 	}
 	if d.DatabaseVersion == "" {
 		t.Errorf("got not empty string.")
+	}
+}
+
+func TestTriggersOrder(t *testing.T) {
+	if _, err := db.Exec(`DROP TABLE IF EXISTS tbls_trigger_order`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE tbls_trigger_order (a int)`); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_, _ = db.Exec(`DROP TABLE IF EXISTS tbls_trigger_order`)
+	}()
+	// Create the triggers in descending name order so that creation order and name order differ.
+	// CREATE TRIGGER must be the first statement in a batch, so each one is executed on its own.
+	if _, err := db.Exec(`CREATE TRIGGER trg_tbls_trigger_order_b ON tbls_trigger_order AFTER INSERT AS BEGIN SET NOCOUNT ON; END`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TRIGGER trg_tbls_trigger_order_a ON tbls_trigger_order AFTER INSERT AS BEGIN SET NOCOUNT ON; END`); err != nil {
+		t.Fatal(err)
+	}
+
+	driver := New(db)
+	sc := &schema.Schema{Name: "testdb"}
+	if err := driver.Analyze(sc); err != nil {
+		t.Fatal(err)
+	}
+
+	tbl, err := sc.FindTableByName("tbls_trigger_order")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	for _, trig := range tbl.Triggers {
+		got = append(got, trig.Name)
+	}
+	want := []string{"trg_tbls_trigger_order_b", "trg_tbls_trigger_order_a"}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Error(diff)
 	}
 }
 

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -177,6 +177,7 @@ SELECT
   action_statement
 FROM information_schema.triggers
 WHERE event_object_schema = ?
+ORDER BY event_object_table, trigger_name
 `, s.Name)
 	if err != nil {
 		return errors.WithStack(err)

--- a/drivers/mysql/mysql_test.go
+++ b/drivers/mysql/mysql_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/google/go-cmp/cmp"
 	"github.com/k1LoW/tbls/schema"
 	"github.com/xo/dburl"
 )
@@ -82,6 +83,48 @@ func TestInfo(t *testing.T) {
 	}
 	if d.DatabaseVersion == "" {
 		t.Errorf("got not empty string.")
+	}
+}
+
+func TestTriggersOrder(t *testing.T) {
+	if _, err := db.Exec(`DROP TABLE IF EXISTS tbls_trigger_order`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE tbls_trigger_order (a int)`); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_, _ = db.Exec(`DROP TABLE IF EXISTS tbls_trigger_order`)
+	}()
+	// mysql orders triggers by name because information_schema has no stable creation-order key, so create
+	// them in descending name order to detect the creation order leaking into the output.
+	if _, err := db.Exec(`CREATE TRIGGER trg_tbls_trigger_order_b BEFORE INSERT ON tbls_trigger_order FOR EACH ROW SET NEW.a = NEW.a`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TRIGGER trg_tbls_trigger_order_a BEFORE INSERT ON tbls_trigger_order FOR EACH ROW SET NEW.a = NEW.a`); err != nil {
+		t.Fatal(err)
+	}
+
+	driver, err := New(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sc := &schema.Schema{Name: "testdb"}
+	if err := driver.Analyze(sc); err != nil {
+		t.Fatal(err)
+	}
+
+	tbl, err := sc.FindTableByName("tbls_trigger_order")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	for _, trig := range tbl.Triggers {
+		got = append(got, trig.Name)
+	}
+	want := []string{"trg_tbls_trigger_order_a", "trg_tbls_trigger_order_b"}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Error(diff)
 	}
 }
 

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -218,7 +218,7 @@ FROM pg_trigger AS trig
 LEFT JOIN pg_description AS descr ON trig.oid = descr.objoid
 WHERE tgisinternal = false
 AND tgrelid = $1::oid
-ORDER BY tgrelid
+ORDER BY trig.oid
 `, tableOid)
 			if err != nil {
 				return errors.WithStack(err)

--- a/drivers/postgres/postgres_test.go
+++ b/drivers/postgres/postgres_test.go
@@ -70,6 +70,44 @@ func TestInfo(t *testing.T) {
 	}
 }
 
+func TestTriggersOrder(t *testing.T) {
+	if _, err := db.Exec(`DROP TABLE IF EXISTS tbls_trigger_order`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TABLE tbls_trigger_order (a int)`); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_, _ = db.Exec(`DROP TABLE IF EXISTS tbls_trigger_order`)
+	}()
+	// Create the triggers in descending name order so that creation order and name order differ.
+	if _, err := db.Exec(`CREATE TRIGGER trg_tbls_trigger_order_b AFTER INSERT ON tbls_trigger_order FOR EACH ROW EXECUTE PROCEDURE update_updated()`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`CREATE TRIGGER trg_tbls_trigger_order_a AFTER INSERT ON tbls_trigger_order FOR EACH ROW EXECUTE PROCEDURE update_updated()`); err != nil {
+		t.Fatal(err)
+	}
+
+	driver := New(db)
+	sc := &schema.Schema{Name: "testdb"}
+	if err := driver.Analyze(sc); err != nil {
+		t.Fatal(err)
+	}
+
+	tbl, err := sc.FindTableByName("public.tbls_trigger_order")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	for _, trig := range tbl.Triggers {
+		got = append(got, trig.Name)
+	}
+	want := []string{"trg_tbls_trigger_order_b", "trg_tbls_trigger_order_a"}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Error(diff)
+	}
+}
+
 func TestParseFK(t *testing.T) {
 	tests := []struct {
 		in              string

--- a/drivers/sqlite/sqlite.go
+++ b/drivers/sqlite/sqlite.go
@@ -335,7 +335,7 @@ WHERE name != 'sqlite_sequence' AND (type = 'table' OR type = 'view');`)
 
 		// triggers
 		triggerRows, err := l.db.Query(`
-SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND tbl_name = ?;
+SELECT name, sql FROM sqlite_master WHERE type = 'trigger' AND tbl_name = ? ORDER BY rowid;
 `, tableName)
 		if err != nil {
 			return errors.WithStack(err)

--- a/drivers/sqlite/sqlite_test.go
+++ b/drivers/sqlite/sqlite_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/k1LoW/tbls/schema"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/xo/dburl"
@@ -56,6 +57,28 @@ func TestInfo(t *testing.T) {
 	}
 	if d.DatabaseVersion == "" {
 		t.Errorf("got not empty string.")
+	}
+}
+
+// posts has multiple triggers in testdata/ddl/sqlite.sql, created in an order that differs from name order.
+func TestTriggersOrder(t *testing.T) {
+	driver := New(db)
+	sc := &schema.Schema{Name: "testdb.sqlite3"}
+	if err := driver.Analyze(sc); err != nil {
+		t.Fatal(err)
+	}
+
+	tbl, err := sc.FindTableByName("posts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	for _, trig := range tbl.Triggers {
+		got = append(got, trig.Name)
+	}
+	want := []string{"update_posts_updated", "posts_fts_insert", "posts_fts_delete", "posts_fts_update"}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Error(diff)
 	}
 }
 


### PR DESCRIPTION
## Why

The trigger queries do not fix the order of their results, so the same schema can produce different documents between runs — the order is whatever access path the database happens to choose. For the standard tbls workflow (commit the generated documents, review them as diffs) this shows up as row reordering unrelated to any schema change, and when generation runs in CI, local runs and CI runs keep rewriting the order back and forth.

- **postgres** has an `ORDER BY`, but `tgrelid` is pinned to a single value by the `WHERE` clause, so every row carries the same sort key and the ordering is left unspecified. A Seq Scan returns heap physical order, an Index Scan on `pg_trigger_tgrelid_tgname_index` returns `tgname` order — and both plans occur in normal use
- **mysql / mssql / sqlite** have no `ORDER BY` at all

This is the same class of problem as #829 (MySQL constraints), fixed in #830 by giving the query an explicit `ORDER BY`.

Closes #850

## What

Give the trigger query in each of the four drivers a total order, following the ordering convention each driver already uses:

| Driver | Change | Key |
| --- | --- | --- |
| postgres | `ORDER BY tgrelid` → `ORDER BY trig.oid` | creation order |
| mssql | add `ORDER BY t.object_id` | creation order |
| sqlite | add `ORDER BY rowid` | creation order |
| mysql | add `ORDER BY event_object_table, trigger_name` | name |

`TestTriggersOrder` is added to all four driver test packages. postgres / mysql / mssql create a table whose triggers are created in descending name order, so creation order and name order differ, then assert the expected order and drop the table — the same shape as `TestCheckConstraintsOrder` from #830. sqlite asserts the four triggers already on `posts` in `testdata/ddl/sqlite.sql`, without writing to the shared test database that `make testdoc_sqlite` also reads.

No sample regeneration is needed: `sample/sqlite/posts.md` is the only file under `sample/` with more than one trigger on a table, and it already records them in creation order. The diff is limited to `drivers/`.

No other driver needs changing: `mariadb` embeds `mysql.Mysql` and follows automatically, `redshift` skips trigger collection via `if !p.rsMode`, and the rest never touch triggers.

## Notes for reviewers

**Ordering follows each driver's existing convention rather than being uniformly alphabetical**, per the direction in [this comment](https://github.com/k1LoW/tbls/issues/850#issuecomment-5139933064). tbls orders by definition/creation order in postgres (`oid`, `attnum`, `indexrelid`) and mssql (`OBJECT_ID`, `column_id`, `index_id`), and sqlite follows definition order through `PRAGMA`. Making triggers alone alphabetical would have introduced an approach that contradicts the surrounding code in those drivers, so consistency within each driver was prioritised over byte-identical order across DBMSs.

**mysql is the exception and stays name-ordered**, because `information_schema` has no stable key equivalent to an oid. This is the same constraint that made #830 alphabetical. Its first sort key, `event_object_table`, does not affect the output — the query fetches the triggers for the whole schema at once and the rows are bucketed into a per-table map afterwards — but it is kept so the query keeps the same shape as the constraint query fixed in #830.

**Two of the acceptance criteria in #850 no longer hold as written**, and the issue body has been left as the original record rather than rewritten:

- Criterion 1 said "ordered by trigger name ascending". That reads as "totally ordered" now — the order is deterministic and plan-independent, but it is creation order in three of the four drivers
- Criterion 3 (a database where a trigger was dropped and re-created under the same name produces the same output as one built from scratch) is not met. As noted in the comment above, this is already the case for tables and indexes, so it is not a deficiency specific to triggers

Criterion 2 (output independent of `enable_seqscan` / `enable_indexscan` / `enable_bitmapscan`) is met: the sort key is unique per row, so the total order is structural and holds under any plan.

**What the tests do and do not cover**: they pin the expected order, so a regression that reintroduces name sorting — or any other reordering — fails them. They are not a guard against the `ORDER BY` being deleted outright, since the natural scan order often coincides with creation order. That follows from #850's own note that a total order in the query guarantees the plan-independence structurally, so checking it manually is enough and there is no need to drive planner settings from the test suite.

One consequence worth naming: in PostgreSQL, triggers of the same timing and event fire in alphabetical order, so name order would have doubled as firing order there. Creation order does not. Representing firing order was never a goal of #850, and the other three DBMSs make no such guarantee, so this seemed an acceptable loss for driver-internal consistency.

<details>
<summary>sqlite: measured behaviour of <code>rowid</code> in <code>sqlite_master</code></summary>

Re-applying `testdata/ddl/sqlite.sql` to an existing database (what `make db_sqlite` does) keeps the relative order — the rowids are renumbered but the sequence is unchanged:

```
first build:   18|update_posts_updated  59|posts_fts_insert  60|posts_fts_delete  61|posts_fts_update
re-applied:    75|update_posts_updated  93|posts_fts_insert  94|posts_fts_delete  95|posts_fts_update
```

`VACUUM` compacts the rowids but preserves the order. Dropping and re-creating a trigger under the same name moves it to the end, which is the criterion 3 case above.

</details>

## Verification

All four drivers were verified locally. For postgres / mssql / sqlite the test was confirmed to fail before the query change and pass after it — before the change each returned the triggers in name order:

```
$ go test ./drivers/postgres/... ./drivers/mysql/... ./drivers/mssql/... ./drivers/sqlite/... \
    -tags 'postgres mysql mssql sqlite sqlite_fts5'
ok  github.com/k1LoW/tbls/drivers/postgres
ok  github.com/k1LoW/tbls/drivers/mysql
ok  github.com/k1LoW/tbls/drivers/mssql
ok  github.com/k1LoW/tbls/drivers/sqlite

$ make testdoc_sqlite     # passes without regenerating the sample
$ ./tbls diff pg://... sample/postgres     # no diff
$ ./tbls diff my://... sample/mysql        # no diff
$ ./tbls diff ms://... sample/mssql        # no diff

$ golangci-lint run --build-tags 'postgres mysql mssql sqlite sqlite_fts5' ./drivers/...
0 issues.
```
