### PR TITLE
fix: panic on a trailing --config, and value truncation at the first =

### DIFF
--- a/cmdutil/option.go
+++ b/cmdutil/option.go
@@ -17,12 +17,15 @@ L:
 		for _, opt := range opts {
 			switch {
 			case a == opt:
+				if i+1 >= len(args) {
+					// The option has no value. Keep it in remains so that the caller can report it.
+					break
+				}
 				v = args[i+1]
 				skipNext = true
 				continue L
 			case strings.HasPrefix(a, fmt.Sprintf("%s=", opt)):
-				splited := strings.Split(a, "=")
-				v = splited[1]
+				_, v, _ = strings.Cut(a, "=")
 				continue L
 			}
 		}

--- a/cmdutil/option_test.go
+++ b/cmdutil/option_test.go
@@ -20,6 +20,12 @@ func TestPickOption(t *testing.T) {
 		{[]string{"-a", "-b=B", "-c"}, []string{"-d"}, "", []string{"-a", "-b=B", "-c"}},
 		{[]string{"-b=B"}, []string{"-b"}, "B", []string{}},
 		{[]string{"-b", "B"}, []string{"-b"}, "B", []string{}},
+		// Option without a value ( trailing option )
+		{[]string{"-b"}, []string{"-b"}, "", []string{"-b"}},
+		{[]string{"-a", "-b"}, []string{"-b"}, "", []string{"-a", "-b"}},
+		// Value containing "="
+		{[]string{"-b=B=BB"}, []string{"-b"}, "B=BB", []string{}},
+		{[]string{"-a", "--dsn=postgres://u:p@h/db?a=1&b=2", "-c"}, []string{"--dsn"}, "postgres://u:p@h/db?a=1&b=2", []string{"-a", "-c"}},
 	}
 	for _, tt := range tests {
 		got, gotRemains := PickOption(tt.args, tt.opts)


### PR DESCRIPTION
## What's broken

Two bugs in `PickOption`, two adjacent lines of the same function.

**A trailing option panics.**

```
$ tbls --config
panic: runtime error: index out of range [1] with length 1
	github.com/k1LoW/tbls/cmdutil.PickOption(...) cmdutil/option.go:20
	github.com/k1LoW/tbls/cmd.init.func9(...)     cmd/root.go:114
```

`v = args[i+1]` reads past the end. Subcommands are fine, `tbls doc -c` gives a clean `flag needs an argument: 'c' in -c`, because cobra parses those normally. Only the root command panics, since it sets `DisableFlagParsing: true` and hand-rolls the parsing here.

**The `--opt=value` form truncates at the first `=` inside the value.**

```
$ export FOO='a=b'
$ tbls --when '$FOO == "a=b"' hello      # runs
$ tbls '--when=$FOO == "a=b"' hello      # expected bool, but got string
```

The space form and the `=` form of the same expression disagree. `--dsn` is worse, because it fails silently:

```
before: --dsn=postgres://u:p@h/db?a=1&b=2   ->  TBLS_DSN=postgres://u:p@h/db?a
after:  --dsn=postgres://u:p@h/db?a=1&b=2   ->  TBLS_DSN=postgres://u:p@h/db?a=1&b=2
```

Every query parameter is dropped, `sslmode` and `connect_timeout` included, with no error at all.

## The fix

Bounds-check the lookahead, and use `strings.Cut` for the `=` form.

`cmdutil/when.go` already does exactly this ten lines away, `strings.Cut(kv, "=")` for the same first-`=` problem on env vars, so the right idiom was already in the file.

For the trailing option I left the bare flag in `remains` rather than returning an error. `PickOption` returns `(string, []string)` with no error slot, so an error would mean changing the signature and all three call sites, and the existing handler in `cmd/root.go` already does the right thing with it:

```
$ tbls --config
Error: unknown flag: '--config'
(usage follows)
```

That matches what an unknown flag already prints today, including its exit status, so the panic is routed into the existing path rather than a new one.

## Verification

Four cases added to the `TestPickOption` table: a trailing option alone and after another argument, a value containing `=`, and the full DSN with query parameters.

Reverting the bounds check alone makes the table panic with the original message. Reverting `Cut` back to `Split` alone gives `got B / want B=BB` and `got postgres://u:p@h/db?a`. Each case is load-bearing for its own line.

`go test ./...` is green across sixteen packages. `datasource` fails here with `dial tcp [::1]:33306: connect: connection refused`, which needs the compose databases; that failure is identical on an untouched tree.
