### PR TITLE
fix: --adjust-table and --number skip the Enums table

### DIFF
--- a/output/md/md.go
+++ b/output/md/md.go
@@ -523,7 +523,7 @@ func (m *Md) makeSchemaTemplateData(s *schema.Schema) map[string]interface{} {
 	viewpointsData := m.viewpointsData(s.Viewpoints, number, adjust, showOnlyFirstParagraph)
 
 	// Enums
-	enumData := m.enumData(s.Enums)
+	enumData := m.enumData(s.Enums, number, adjust)
 
 	return map[string]interface{}{
 		"Schema":     s,
@@ -878,7 +878,7 @@ func (m *Md) functionsData(functions []*schema.Function, number, adjust bool) []
 	return data
 }
 
-func (m *Md) enumData(enums []*schema.Enum) [][]string {
+func (m *Md) enumData(enums []*schema.Enum, number, adjust bool) [][]string {
 	data := [][]string{}
 
 	if len(enums) == 0 {
@@ -902,6 +902,14 @@ func (m *Md) enumData(enums []*schema.Enum) [][]string {
 			strings.Join(e.Values, ", "),
 		}
 		data = append(data, d)
+	}
+
+	if number {
+		data = m.addNumberToTable(data)
+	}
+
+	if adjust {
+		data = adjustTable(data)
 	}
 
 	return data

--- a/sample/adjust/README.md
+++ b/sample/adjust/README.md
@@ -51,8 +51,8 @@ Sample PostgreSQL database document.
 
 ## Enums
 
-| Name | Values |
-| ---- | ------- |
+| Name              | Values                 |
+| ----------------- | ---------------------- |
 | public.post_types | draft, private, public |
 
 ## Relations

--- a/testdata/md_test_README.md.adjust.golden
+++ b/testdata/md_test_README.md.adjust.golden
@@ -19,8 +19,8 @@
 
 ## Enums
 
-| Name | Values |
-| ---- | ------- |
+| Name | Values          |
+| ---- | --------------- |
 | enum | one, three, two |
 
 ---

--- a/testdata/md_test_README.md.number.golden
+++ b/testdata/md_test_README.md.number.golden
@@ -19,9 +19,9 @@
 
 ## Enums
 
-| Name | Values |
-| ---- | ------- |
-| enum | one, three, two |
+| # | Name | Values |
+| - | ---- | ------- |
+| 1 | enum | one, three, two |
 
 ---
 


### PR DESCRIPTION
## What's broken

`--adjust-table` and `--number` skip the Enums table, and two committed goldens already record it.

`testdata/md_test_README.md.adjust.golden`, where Viewpoints and Tables are padded and Enums is not. Its separator row is even a different width from its own header row:

```
| Name | Values |
| ---- | ------- |
| enum | one, three, two |
```

`testdata/md_test_README.md.number.golden`, where every other table gets a `#` column and Enums does not, so the block is byte-identical to the one above despite a different flag.

## The fix

`enumData` was the only table builder without `number, adjust` parameters, and its body had neither `addNumberToTable` nor `adjustTable`. Its four siblings all have both: `tablesData`, `functionsData`, `viewpointsData` and the per-table set.

It now takes the same two parameters and ends with the same two blocks as `functionsData`, and the call site passes them.

After:

```
adjust:  | Name | Values          |     number:  | # | Name | Values |
         | ---- | --------------- |              | - | ---- | ------- |
         | enum | one, three, two |              | 1 | enum | one, three, two |
```

## Goldens

Regenerated with the repo's own updater, `UPDATE_GOLDEN=1 go test ./output/md/...`, not hand-edited. It rewrote exactly the two files above and nothing else, which is also a check that the change has no wider blast radius.

## Verification

No new test was needed: the existing `--adjust option` and `--number option` cases in `output/md/md_test.go` already drive this path and were simply agreeing with the wrong output. Reverting `md.go` while keeping the regenerated goldens fails `TestOutput/--adjust_option`, so they genuinely pin the behaviour now.

`go test ./...` passes apart from `datasource / TestAnalyzeSchema`, which needs the compose databases and fails identically on an untouched tree here.

## Not included

`adjustTable` measures column width with `runewidth.StringWidth` but pads with `%-Ns`, which counts runes, so any CJK identifier over-pads. That is a separate bug with no fixture covering it, and it is not touched here.
