### PR TITLE
fix: --adjust-table misaligns columns containing East Asian characters

### DIFF
--- a/output/md/md.go
+++ b/output/md/md.go
@@ -964,7 +964,7 @@ func adjustTable(data [][]string) [][]string {
 			if i == 1 {
 				data[i][j] = strings.Repeat("-", w[j])
 			} else {
-				data[i][j] = fmt.Sprintf(fmt.Sprintf("%%-%ds", w[j]), r.Replace(data[i][j]))
+				data[i][j] = runewidth.FillRight(r.Replace(data[i][j]), w[j])
 			}
 		}
 	}

--- a/output/md/md_test.go
+++ b/output/md/md_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/k1LoW/tbls/config"
 	"github.com/k1LoW/tbls/schema"
 	"github.com/k1LoW/tbls/testutil"
+	"github.com/mattn/go-runewidth"
 	"github.com/tenntenn/golden"
 )
 
@@ -253,4 +254,22 @@ func testdataDir() string {
 	wd, _ := os.Getwd()
 	dir, _ := filepath.Abs(filepath.Join(filepath.Dir(filepath.Dir(wd)), "testdata"))
 	return dir
+}
+
+func TestAdjustTableEastAsianWidth(t *testing.T) {
+	data := [][]string{
+		{"Name", "Comment"},
+		{"----", "-------"},
+		{"ユーザー", "a"},
+		{"id", "説明"},
+	}
+	got := adjustTable(data)
+	for j := range got[0] {
+		want := runewidth.StringWidth(got[0][j])
+		for i := range got {
+			if w := runewidth.StringWidth(got[i][j]); w != want {
+				t.Errorf("column %d row %d: got display width %d, want %d (%q)", j, i, w, want, got[i][j])
+			}
+		}
+	}
 }

--- a/sample/dict/CamelizeTable.md
+++ b/sample/dict/CamelizeTable.md
@@ -17,20 +17,20 @@ CREATE TABLE `CamelizeTable` (
 
 ## カラム一覧
 
-| 名前      | タイプ      | デフォルト値       | Nullable | Extra Definition | 子テーブル      | 親テーブル      | コメント     |
+| 名前    | タイプ   | デフォルト値 | Nullable | Extra Definition | 子テーブル | 親テーブル | コメント |
 | ------- | -------- | ------------ | -------- | ---------------- | ---------- | ---------- | -------- |
 | id      | bigint   |              | false    | auto_increment   |            |            |          |
 | created | datetime |              | false    |                  |            |            |          |
 
 ## 制約一覧
 
-| 名前      | タイプ         | 定義               |
+| 名前    | タイプ      | 定義             |
 | ------- | ----------- | ---------------- |
 | PRIMARY | PRIMARY KEY | PRIMARY KEY (id) |
 
 ## INDEX一覧
 
-| 名前      | 定義                           |
+| 名前    | 定義                         |
 | ------- | ---------------------------- |
 | PRIMARY | PRIMARY KEY (id) USING BTREE |
 

--- a/sample/dict/README.md
+++ b/sample/dict/README.md
@@ -2,13 +2,13 @@
 
 ## テーブル一覧
 
-| 名前                                                                                                          | カラム一覧      | コメント                                             | タイプ        |
+| 名前                                                                                                        | カラム一覧 | コメント                                         | タイプ     |
 | ----------------------------------------------------------------------------------------------------------- | ---------- | ------------------------------------------------ | ---------- |
 | [CamelizeTable](CamelizeTable.md)                                                                           | 2          |                                                  | BASE TABLE |
 | [comment_stars](comment_stars.md)                                                                           | 6          |                                                  | BASE TABLE |
 | [comments](comments.md)                                                                                     | 7          | Comments<br />Multi-line<br />table<br />comment | BASE TABLE |
 | [hyphen-table](hyphen-table.md)                                                                             | 3          |                                                  | BASE TABLE |
-| [logs](logs.md)                                                                                             | 7          | Auditログ                                          | BASE TABLE |
+| [logs](logs.md)                                                                                             | 7          | Auditログ                                        | BASE TABLE |
 | [long_long_long_long_long_long_long_long_table_name](long_long_long_long_long_long_long_long_table_name.md) | 2          |                                                  | BASE TABLE |
 | [post_comments](post_comments.md)                                                                           | 7          | VIEW                                             | VIEW       |
 | [posts](posts.md)                                                                                           | 7          | Posts table                                      | BASE TABLE |
@@ -17,7 +17,7 @@
 
 ## Stored procedures and functions
 
-| 名前             | ReturnType | Arguments      | タイプ       |
+| 名前           | ReturnType | Arguments      | タイプ    |
 | -------------- | ---------- | -------------- | --------- |
 | CustomerLevel  | varchar    | credit decimal | FUNCTION  |
 | GetAllComments |            |                | PROCEDURE |

--- a/sample/dict/comment_stars.md
+++ b/sample/dict/comment_stars.md
@@ -26,7 +26,7 @@ CREATE TABLE `comment_stars` (
 
 ## カラム一覧
 
-| 名前              | タイプ       | デフォルト値       | Nullable | Extra Definition | 子テーブル      | 親テーブル                                     | コメント     |
+| 名前            | タイプ    | デフォルト値 | Nullable | Extra Definition | 子テーブル | 親テーブル                                | コメント |
 | --------------- | --------- | ------------ | -------- | ---------------- | ---------- | ----------------------------------------- | -------- |
 | id              | bigint    |              | false    | auto_increment   |            |                                           |          |
 | user_id         | int       |              | false    |                  |            |                                           |          |
@@ -37,7 +37,7 @@ CREATE TABLE `comment_stars` (
 
 ## 制約一覧
 
-| 名前                               | タイプ         | 定義                                                                                    |
+| 名前                             | タイプ      | 定義                                                                                  |
 | -------------------------------- | ----------- | ------------------------------------------------------------------------------------- |
 | comment_stars_user_id_fk         | FOREIGN KEY | FOREIGN KEY (comment_user_id) REFERENCES users (id)                                   |
 | comment_stars_user_id_post_id_fk | FOREIGN KEY | FOREIGN KEY (comment_post_id, comment_user_id) REFERENCES comments (post_id, user_id) |
@@ -46,7 +46,7 @@ CREATE TABLE `comment_stars` (
 
 ## INDEX一覧
 
-| 名前                               | 定義                                                                                  |
+| 名前                             | 定義                                                                                |
 | -------------------------------- | ----------------------------------------------------------------------------------- |
 | comment_stars_user_id_fk         | KEY comment_stars_user_id_fk (comment_user_id) USING BTREE                          |
 | comment_stars_user_id_post_id_fk | KEY comment_stars_user_id_post_id_fk (comment_post_id, comment_user_id) USING BTREE |

--- a/sample/dict/comments.md
+++ b/sample/dict/comments.md
@@ -32,7 +32,7 @@ CREATE TABLE `comments` (
 
 ## カラム一覧
 
-| 名前           | タイプ      | デフォルト値       | Nullable | Extra Definition                               | 子テーブル                             | 親テーブル             | コメント                                             |
+| 名前         | タイプ   | デフォルト値 | Nullable | Extra Definition                               | 子テーブル                        | 親テーブル        | コメント                                         |
 | ------------ | -------- | ------------ | -------- | ---------------------------------------------- | --------------------------------- | ----------------- | ------------------------------------------------ |
 | id           | bigint   |              | false    | auto_increment                                 |                                   |                   |                                                  |
 | post_id      | bigint   |              | false    |                                                | [comment_stars](comment_stars.md) | [posts](posts.md) |                                                  |
@@ -44,7 +44,7 @@ CREATE TABLE `comments` (
 
 ## 制約一覧
 
-| 名前                  | タイプ         | 定義                                          |
+| 名前                | タイプ      | 定義                                        |
 | ------------------- | ----------- | ------------------------------------------- |
 | comments_post_id_fk | FOREIGN KEY | FOREIGN KEY (post_id) REFERENCES posts (id) |
 | comments_user_id_fk | FOREIGN KEY | FOREIGN KEY (user_id) REFERENCES users (id) |
@@ -53,7 +53,7 @@ CREATE TABLE `comments` (
 
 ## INDEX一覧
 
-| 名前                           | 定義                                                              |
+| 名前                         | 定義                                                            |
 | ---------------------------- | --------------------------------------------------------------- |
 | comments_post_id_user_id_idx | KEY comments_post_id_user_id_idx (post_id, user_id) USING BTREE |
 | comments_user_id_fk          | KEY comments_user_id_fk (user_id) USING BTREE                   |

--- a/sample/dict/hyphen-table.md
+++ b/sample/dict/hyphen-table.md
@@ -18,7 +18,7 @@ CREATE TABLE `hyphen-table` (
 
 ## カラム一覧
 
-| 名前            | タイプ      | デフォルト値       | Nullable | Extra Definition | 子テーブル      | 親テーブル      | コメント     |
+| 名前          | タイプ   | デフォルト値 | Nullable | Extra Definition | 子テーブル | 親テーブル | コメント |
 | ------------- | -------- | ------------ | -------- | ---------------- | ---------- | ---------- | -------- |
 | id            | bigint   |              | false    | auto_increment   |            |            |          |
 | hyphen-column | text     |              | false    |                  |            |            |          |
@@ -26,13 +26,13 @@ CREATE TABLE `hyphen-table` (
 
 ## 制約一覧
 
-| 名前      | タイプ         | 定義               |
+| 名前    | タイプ      | 定義             |
 | ------- | ----------- | ---------------- |
 | PRIMARY | PRIMARY KEY | PRIMARY KEY (id) |
 
 ## INDEX一覧
 
-| 名前      | 定義                           |
+| 名前    | 定義                         |
 | ------- | ---------------------------- |
 | PRIMARY | PRIMARY KEY (id) USING BTREE |
 

--- a/sample/dict/logs.md
+++ b/sample/dict/logs.md
@@ -24,7 +24,7 @@ CREATE TABLE `logs` (
 
 ## カラム一覧
 
-| 名前              | タイプ      | デフォルト値       | Nullable | Extra Definition | 子テーブル      | 親テーブル      | コメント     |
+| 名前            | タイプ   | デフォルト値 | Nullable | Extra Definition | 子テーブル | 親テーブル | コメント |
 | --------------- | -------- | ------------ | -------- | ---------------- | ---------- | ---------- | -------- |
 | id              | bigint   |              | false    | auto_increment   |            |            |          |
 | user_id         | int      |              | false    |                  |            |            |          |
@@ -36,13 +36,13 @@ CREATE TABLE `logs` (
 
 ## 制約一覧
 
-| 名前      | タイプ         | 定義               |
+| 名前    | タイプ      | 定義             |
 | ------- | ----------- | ---------------- |
 | PRIMARY | PRIMARY KEY | PRIMARY KEY (id) |
 
 ## INDEX一覧
 
-| 名前      | 定義                           |
+| 名前    | 定義                         |
 | ------- | ---------------------------- |
 | PRIMARY | PRIMARY KEY (id) USING BTREE |
 

--- a/sample/dict/long_long_long_long_long_long_long_long_table_name.md
+++ b/sample/dict/long_long_long_long_long_long_long_long_table_name.md
@@ -17,20 +17,20 @@ CREATE TABLE `long_long_long_long_long_long_long_long_table_name` (
 
 ## カラム一覧
 
-| 名前      | タイプ      | デフォルト値       | Nullable | Extra Definition | 子テーブル      | 親テーブル      | コメント     |
+| 名前    | タイプ   | デフォルト値 | Nullable | Extra Definition | 子テーブル | 親テーブル | コメント |
 | ------- | -------- | ------------ | -------- | ---------------- | ---------- | ---------- | -------- |
 | id      | bigint   |              | false    | auto_increment   |            |            |          |
 | created | datetime |              | false    |                  |            |            |          |
 
 ## 制約一覧
 
-| 名前      | タイプ         | 定義               |
+| 名前    | タイプ      | 定義             |
 | ------- | ----------- | ---------------- |
 | PRIMARY | PRIMARY KEY | PRIMARY KEY (id) |
 
 ## INDEX一覧
 
-| 名前      | 定義                           |
+| 名前    | 定義                         |
 | ------- | ---------------------------- |
 | PRIMARY | PRIMARY KEY (id) USING BTREE |
 

--- a/sample/dict/post_comments.md
+++ b/sample/dict/post_comments.md
@@ -15,7 +15,7 @@ CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2
 
 ## カラム一覧
 
-| 名前           | タイプ          | デフォルト値       | Nullable | 子テーブル      | 親テーブル      | コメント                                             |
+| 名前         | タイプ       | デフォルト値 | Nullable | 子テーブル | 親テーブル | コメント                                         |
 | ------------ | ------------ | ------------ | -------- | ---------- | ---------- | ------------------------------------------------ |
 | id           | bigint       | 0            | true     |            |            |                                                  |
 | title        | varchar(255) | Untitled     | false    |            |            |                                                  |
@@ -27,11 +27,11 @@ CREATE VIEW post_comments AS (select `c`.`id` AS `id`,`p`.`title` AS `title`,`u2
 
 ## Referenced Tables
 
-| 名前                        | カラム一覧           | コメント                                                 | タイプ           |
-| ------------------------- | --------------- | ---------------------------------------------------- | ------------- |
-| [posts](posts.md)         | 7               | Posts table                                          | BASE TABLE    |
-| [comments](comments.md)   | 7               | Comments<br />Multi-line<br />table<br />comment     | BASE TABLE    |
-| [users](users.md)         | 6               | Users table                                          | BASE TABLE    |
+| 名前                    | カラム一覧 | コメント                                         | タイプ     |
+| ----------------------- | ---------- | ------------------------------------------------ | ---------- |
+| [posts](posts.md)       | 7          | Posts table                                      | BASE TABLE |
+| [comments](comments.md) | 7          | Comments<br />Multi-line<br />table<br />comment | BASE TABLE |
+| [users](users.md)       | 6          | Users table                                      | BASE TABLE |
 
 ## ER図
 

--- a/sample/dict/posts.md
+++ b/sample/dict/posts.md
@@ -27,7 +27,7 @@ CREATE TABLE `posts` (
 
 ## カラム一覧
 
-| 名前        | タイプ                              | デフォルト値       | Nullable | Extra Definition | 子テーブル                   | 親テーブル             | コメント                 |
+| 名前      | タイプ                           | デフォルト値 | Nullable | Extra Definition | 子テーブル              | 親テーブル        | コメント             |
 | --------- | -------------------------------- | ------------ | -------- | ---------------- | ----------------------- | ----------------- | -------------------- |
 | id        | bigint                           |              | false    | auto_increment   | [comments](comments.md) |                   |                      |
 | user_id   | int                              |              | false    |                  |                         | [users](users.md) |                      |
@@ -39,7 +39,7 @@ CREATE TABLE `posts` (
 
 ## 制約一覧
 
-| 名前               | タイプ         | 定義                                          |
+| 名前             | タイプ      | 定義                                        |
 | ---------------- | ----------- | ------------------------------------------- |
 | posts_user_id_fk | FOREIGN KEY | FOREIGN KEY (user_id) REFERENCES users (id) |
 | PRIMARY          | PRIMARY KEY | PRIMARY KEY (id)                            |
@@ -47,7 +47,7 @@ CREATE TABLE `posts` (
 
 ## INDEX一覧
 
-| 名前                | 定義                                              |
+| 名前              | 定義                                            |
 | ----------------- | ----------------------------------------------- |
 | posts_user_id_idx | KEY posts_user_id_idx (id) USING BTREE          |
 | PRIMARY           | PRIMARY KEY (id) USING BTREE                    |
@@ -55,7 +55,7 @@ CREATE TABLE `posts` (
 
 ## トリガー
 
-| 名前                   | 定義                                                                                                                      |
+| 名前                 | 定義                                                                                                                    |
 | -------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | update_posts_updated | CREATE TRIGGER update_posts_updated BEFORE UPDATE ON posts<br />FOR EACH ROW<br />SET NEW.updated = CURRENT_TIMESTAMP() |
 

--- a/sample/dict/user_options.md
+++ b/sample/dict/user_options.md
@@ -23,7 +23,7 @@ CREATE TABLE `user_options` (
 
 ## カラム一覧
 
-| 名前         | タイプ        | デフォルト値       | Nullable | 子テーブル      | 親テーブル             | コメント     |
+| 名前       | タイプ     | デフォルト値 | Nullable | 子テーブル | 親テーブル        | コメント |
 | ---------- | ---------- | ------------ | -------- | ---------- | ----------------- | -------- |
 | user_id    | int        |              | false    |            | [users](users.md) |          |
 | show_email | tinyint(1) | 0            | false    |            |                   |          |
@@ -32,7 +32,7 @@ CREATE TABLE `user_options` (
 
 ## 制約一覧
 
-| 名前                      | タイプ         | 定義                                          |
+| 名前                    | タイプ      | 定義                                        |
 | ----------------------- | ----------- | ------------------------------------------- |
 | PRIMARY                 | PRIMARY KEY | PRIMARY KEY (user_id)                       |
 | user_id                 | UNIQUE      | UNIQUE KEY user_id (user_id)                |
@@ -40,7 +40,7 @@ CREATE TABLE `user_options` (
 
 ## INDEX一覧
 
-| 名前      | 定義                                       |
+| 名前    | 定義                                     |
 | ------- | ---------------------------------------- |
 | PRIMARY | PRIMARY KEY (user_id) USING BTREE        |
 | user_id | UNIQUE KEY user_id (user_id) USING BTREE |

--- a/sample/dict/users.md
+++ b/sample/dict/users.md
@@ -26,7 +26,7 @@ CREATE TABLE `users` (
 
 ## カラム一覧
 
-| 名前       | タイプ          | デフォルト値       | Nullable | Extra Definition | 子テーブル                                                                                                       | 親テーブル      | コメント                 |
+| 名前     | タイプ       | デフォルト値 | Nullable | Extra Definition | 子テーブル                                                                                                  | 親テーブル | コメント             |
 | -------- | ------------ | ------------ | -------- | ---------------- | ----------------------------------------------------------------------------------------------------------- | ---------- | -------------------- |
 | id       | int          |              | false    | auto_increment   | [comment_stars](comment_stars.md) [comments](comments.md) [posts](posts.md) [user_options](user_options.md) |            |                      |
 | username | varchar(50)  |              | false    |                  |                                                                                                             |            |                      |
@@ -37,7 +37,7 @@ CREATE TABLE `users` (
 
 ## 制約一覧
 
-| 名前          | タイプ         | 定義                                    |
+| 名前        | タイプ      | 定義                                  |
 | ----------- | ----------- | ------------------------------------- |
 | email       | UNIQUE      | UNIQUE KEY email (email)              |
 | PRIMARY     | PRIMARY KEY | PRIMARY KEY (id)                      |
@@ -46,7 +46,7 @@ CREATE TABLE `users` (
 
 ## INDEX一覧
 
-| 名前       | 定義                                         |
+| 名前     | 定義                                       |
 | -------- | ------------------------------------------ |
 | PRIMARY  | PRIMARY KEY (id) USING BTREE               |
 | email    | UNIQUE KEY email (email) USING BTREE       |


### PR DESCRIPTION
## What's broken

`--adjust-table` misaligns any column containing East Asian characters.

`adjustTable` measures column width with `runewidth.StringWidth`, which counts display cells, then pads with `%-Ns`, which counts runes. For a character that occupies two cells the two disagree, so the cell is padded to N runes and ends up 2N cells wide.

Padding to a target of 8, with the two approaches side by side:

```
"ユーザー"    %-8s -> width 12    FillRight -> width 8
"id"         %-8s -> width  8    FillRight -> width 8
"説明"        %-8s -> width 10    FillRight -> width 8
```

The whole point of `--adjust-table` is that the raw markdown lines up in a text editor, so a Japanese or Chinese column name defeats it for every row of that table.

## The fix

`runewidth.FillRight`, from the package already imported two lines above to do the measuring. That makes the padding use the same notion of width as the measurement.

ASCII is unaffected, since `FillRight` and `%-Ns` agree when every rune is one cell wide. The existing `--adjust` golden tests pass unchanged, which is the check that this does not disturb the ASCII fixtures.

## Verification

`TestAdjustTableEastAsianWidth` in `output/md/md_test.go` runs a table mixing `ユーザー`, `説明` and ASCII through `adjustTable`, then asserts every cell in a column has the same display width as its header. That is the property `--adjust-table` exists to provide, rather than a golden of one particular string.

Reverting only the padding expression fails it:

```
md_test.go:271: column 0 row 2: got display width 12, want 8 ("ユーザー    ")
md_test.go:271: column 1 row 3: got display width 9, want 7 ("説明     ")
```

`go test ./output/...` passes, `gofmt -l output/` is clean and `go vet ./output/...` is clean.

*Disclosure: written with AI assistance (Claude Code). I confirmed the width difference by running both padding approaches directly, and ran the revert check myself.*
