### PR TITLE
feat(xlsx): link table names in the index sheet to their sheets

### DIFF
--- a/output/xlsx/xlsx.go
+++ b/output/xlsx/xlsx.go
@@ -121,7 +121,7 @@ func (x *Xlsx) createSchemaSheet(w *excl.Workbook, s *schema.Schema) error {
 	})
 	n := 5
 	for i, t := range s.Tables {
-		setStringWithBorder(sheet, n+i, 1, t.Name)
+		setFormulaWithBorder(sheet, n+i, 1, hyperlinkToSheet(tableSheetName(t.Name), t.Name))
 		setNumberWithBorder(sheet, n+i, 2, len(t.Columns))
 		setStringWithBorder(sheet, n+i, 3, t.Comment)
 		setStringWithBorder(sheet, n+i, 4, t.Type)
@@ -145,11 +145,7 @@ func adjustData(hasData bool, sheet *excl.Sheet, row int, column int, value stri
 }
 
 func (x *Xlsx) createTableSheet(w *excl.Workbook, t *schema.Table) (e error) {
-	sheetName := t.Name
-	if utf8.RuneCountInString(sheetName) > 31 { // MS Excel assumes a maximum length of 31 characters for sheet name
-		r := []rune(sheetName)
-		sheetName = string(r[0:31])
-	}
+	sheetName := tableSheetName(t.Name)
 	sheet, err := w.OpenSheet(sheetName)
 	defer func() {
 		err := sheet.Close()
@@ -290,16 +286,41 @@ func setStringWithBorder(sheet *excl.Sheet, rowNo int, colNo int, v string) *exc
 	})
 }
 
-// func setFormula(sheet *excl.Sheet, rowNo int, colNo int, v string) *excl.Cell {
-// 	row := sheet.GetRow(rowNo)
-// 	return row.SetFormula(v, colNo)
-// }
+func setFormula(sheet *excl.Sheet, rowNo int, colNo int, v string) *excl.Cell {
+	row := sheet.GetRow(rowNo)
+	return row.SetFormula(v, colNo)
+}
 
-// func setFormulaWithBorder(sheet *excl.Sheet, rowNo int, colNo int, v string) *excl.Cell {
-// 	return setFormula(sheet, rowNo, colNo, v).SetBorder(excl.Border{
-// 		Left:   &excl.BorderSetting{Style: "thin"},
-// 		Right:  &excl.BorderSetting{Style: "thin"},
-// 		Top:    &excl.BorderSetting{Style: "thin"},
-// 		Bottom: &excl.BorderSetting{Style: "thin"},
-// 	})
-// }
+func setFormulaWithBorder(sheet *excl.Sheet, rowNo int, colNo int, v string) *excl.Cell {
+	return setFormula(sheet, rowNo, colNo, v).SetBorder(excl.Border{
+		Left:   &excl.BorderSetting{Style: "thin"},
+		Right:  &excl.BorderSetting{Style: "thin"},
+		Top:    &excl.BorderSetting{Style: "thin"},
+		Bottom: &excl.BorderSetting{Style: "thin"},
+	})
+}
+
+// tableSheetName returns the sheet name tbls uses for a table. Excel limits
+// sheet names to 31 characters, so longer table names are truncated.
+func tableSheetName(name string) string {
+	if utf8.RuneCountInString(name) > 31 {
+		r := []rune(name)
+		return string(r[0:31])
+	}
+	return name
+}
+
+// hyperlinkToSheet builds a HYPERLINK formula that jumps to cell A1 of the
+// given sheet while showing display as the link text. The sheet name is always
+// single quoted (which Excel accepts even when quoting is not required) so names
+// with spaces or other special characters still resolve, and any embedded quote
+// is doubled per Excel's escaping rules.
+func hyperlinkToSheet(sheetName, display string) string {
+	ref := "#'" + strings.ReplaceAll(sheetName, "'", "''") + "'!A1"
+	return "HYPERLINK(" + excelString(ref) + "," + excelString(display) + ")"
+}
+
+// excelString quotes s as an Excel string literal, doubling any double quote.
+func excelString(s string) string {
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}

--- a/output/xlsx/xlsx_test.go
+++ b/output/xlsx/xlsx_test.go
@@ -1,0 +1,75 @@
+package xlsx
+
+import (
+	"archive/zip"
+	"bytes"
+	"html"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/k1LoW/tbls/config"
+	"github.com/k1LoW/tbls/schema"
+)
+
+func TestOutputSchemaLinksTableNamesToSheets(t *testing.T) {
+	longName := strings.Repeat("x", 40)
+	s := &schema.Schema{
+		Name: "testschema",
+		Tables: []*schema.Table{
+			{Name: "users", Columns: []*schema.Column{{Name: "id"}}},
+			{Name: "user profiles", Columns: []*schema.Column{{Name: "id"}}},
+			{Name: longName, Columns: []*schema.Column{{Name: "id"}}},
+		},
+	}
+
+	c, err := config.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf := &bytes.Buffer{}
+	if err := New(c).OutputSchema(buf, s); err != nil {
+		t.Fatal(err)
+	}
+
+	got := html.UnescapeString(worksheetsXML(t, buf.Bytes()))
+
+	// The index sheet should link each table name to its own sheet. Sheet names
+	// are single quoted so names with spaces resolve, and names longer than 31
+	// characters are truncated to match the table sheet name.
+	want := []string{
+		`HYPERLINK("#'users'!A1","users")`,
+		`HYPERLINK("#'user profiles'!A1","user profiles")`,
+		`HYPERLINK("#'` + longName[:31] + `'!A1","` + longName + `")`,
+	}
+	for _, w := range want {
+		if !strings.Contains(got, w) {
+			t.Errorf("index sheet is missing hyperlink formula %q", w)
+		}
+	}
+}
+
+func worksheetsXML(t *testing.T, b []byte) string {
+	t.Helper()
+	zr, err := zip.NewReader(bytes.NewReader(b), int64(len(b)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out strings.Builder
+	for _, f := range zr.File {
+		if !strings.HasPrefix(f.Name, "xl/worksheets/") || !strings.HasSuffix(f.Name, ".xml") {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		data, err := io.ReadAll(rc)
+		_ = rc.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		out.Write(data)
+	}
+	return out.String()
+}


### PR DESCRIPTION
Closes #506.

The "Tables of" index sheet in the xlsx output lists every table name, but they were plain text. This turns each name into a `HYPERLINK("#'<sheet>'!A1", "<name>")` formula so you can click a table in the index and jump straight to its sheet. Handy once a schema has more than a handful of tables.

A couple of small things to keep the links valid:

The target sheet name is single quoted, so names with spaces still resolve, and I pulled the existing 31 character truncation out into a `tableSheetName` helper that both the index link and the table sheet use, so a long name links to the same sheet it actually creates. Any embedded quote gets doubled per Excel's rules.

I added a test that renders a schema (including a name with a space and one over 31 chars), unzips the result and checks the formulas land in the index sheet. There was no test file for this package before.