### PR TITLE
fix: repair the azuresql Makefile targets from #838

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,13 +137,18 @@ check_license:
 	--disallowed_types=permissive,forbidden,restricted \
 	--include_tests
 
+# Manual smoke test against a real Azure SQL / Fabric Warehouse endpoint.
+# Output goes to dbdoc/ (gitignored), not sample/azuresql: that directory is
+# generated from the local SQL Server container by `doc` and verified by `test`.
 doc_azuresql: build
 	@TBLS_DSN="azuresql://$(AZURESQL_CLIENT_ID)@$(AZURESQL_TENANT_ID):$(AZURESQL_CLIENT_SECRET)@$(AZURESQL_HOST)/$(AZURESQL_DB)" \
-		$(TBLS) doc -c testdata/test_tbls_azuresql.yml -f sample/azuresql
+		$(TBLS) doc -c testdata/test_tbls_azuresql.yml -f dbdoc/azuresql
 
-test_azuresql: build
+# Regenerates and diffs, so a second read of the same warehouse must match the
+# first. Catches introspection order that is not pinned down, as in #830/#851.
+test_azuresql: doc_azuresql
 	@TBLS_DSN="azuresql://$(AZURESQL_CLIENT_ID)@$(AZURESQL_TENANT_ID):$(AZURESQL_CLIENT_SECRET)@$(AZURESQL_HOST)/$(AZURESQL_DB)" \
-		$(TBLS) diff -c testdata/test_tbls_azuresql.yml sample/azuresql
+		$(TBLS) diff -c testdata/test_tbls_azuresql.yml dbdoc/azuresql
 
 doc_bigquery: build
 	$(TBLS) doc bq://bigquery-public-data/crypto_bitcoin?creds=client_secrets.json -c testdata/crypto_bitcoin_tbls.yml -f sample/bigquery_crypto_bitcoin

--- a/Makefile
+++ b/Makefile
@@ -141,14 +141,14 @@ check_license:
 # Output goes to dbdoc/ (gitignored), not sample/azuresql: that directory is
 # generated from the local SQL Server container by `doc` and verified by `test`.
 doc_azuresql: build
-	@TBLS_DSN="azuresql://$(AZURESQL_CLIENT_ID)@$(AZURESQL_TENANT_ID):$(AZURESQL_CLIENT_SECRET)@$(AZURESQL_HOST)/$(AZURESQL_DB)" \
-		$(TBLS) doc -c testdata/test_tbls_azuresql.yml -f dbdoc/azuresql
+	@TBLS_DSN="azuresql://$(AZURESQL_CLIENT_ID)@$(AZURESQL_TENANT_ID):$(AZURESQL_CLIENT_SECRET)@$(AZURESQL_HOST)/$(AZURESQL_DB)" TBLS_DOC_PATH=dbdoc/azuresql \
+		$(TBLS) doc -c testdata/test_tbls_azuresql.yml
 
 # Regenerates and diffs, so a second read of the same warehouse must match the
 # first. Catches introspection order that is not pinned down, as in #830/#851.
 test_azuresql: doc_azuresql
-	@TBLS_DSN="azuresql://$(AZURESQL_CLIENT_ID)@$(AZURESQL_TENANT_ID):$(AZURESQL_CLIENT_SECRET)@$(AZURESQL_HOST)/$(AZURESQL_DB)" \
-		$(TBLS) diff -c testdata/test_tbls_azuresql.yml dbdoc/azuresql
+	@TBLS_DSN="azuresql://$(AZURESQL_CLIENT_ID)@$(AZURESQL_TENANT_ID):$(AZURESQL_CLIENT_SECRET)@$(AZURESQL_HOST)/$(AZURESQL_DB)" TBLS_DOC_PATH=dbdoc/azuresql \
+		$(TBLS) diff -c testdata/test_tbls_azuresql.yml
 
 doc_bigquery: build
 	$(TBLS) doc bq://bigquery-public-data/crypto_bitcoin?creds=client_secrets.json -c testdata/crypto_bitcoin_tbls.yml -f sample/bigquery_crypto_bitcoin

--- a/Makefile
+++ b/Makefile
@@ -138,10 +138,12 @@ check_license:
 	--include_tests
 
 doc_azuresql: build
-	$(TBLS) doc "azuresql://$(AZURESQL_CLIENT_ID)@$(AZURESQL_TENANT_ID):$(AZURESQL_CLIENT_SECRET)@$(AZURESQL_HOST)/$(AZURESQL_DB)" -c testdata/test_tbls_azuresql.yml -f sample/azuresql
+	@TBLS_DSN="azuresql://$(AZURESQL_CLIENT_ID)@$(AZURESQL_TENANT_ID):$(AZURESQL_CLIENT_SECRET)@$(AZURESQL_HOST)/$(AZURESQL_DB)" \
+		$(TBLS) doc -c testdata/test_tbls_azuresql.yml -f sample/azuresql
 
 test_azuresql: build
-	$(TBLS) diff "azuresql://$(AZURESQL_CLIENT_ID)@$(AZURESQL_TENANT_ID):$(AZURESQL_CLIENT_SECRET)@$(AZURESQL_HOST)/$(AZURESQL_DB)" -c testdata/test_tbls_azuresql.yml sample/azuresql
+	@TBLS_DSN="azuresql://$(AZURESQL_CLIENT_ID)@$(AZURESQL_TENANT_ID):$(AZURESQL_CLIENT_SECRET)@$(AZURESQL_HOST)/$(AZURESQL_DB)" \
+		$(TBLS) diff -c testdata/test_tbls_azuresql.yml sample/azuresql
 
 doc_bigquery: build
 	$(TBLS) doc bq://bigquery-public-data/crypto_bitcoin?creds=client_secrets.json -c testdata/crypto_bitcoin_tbls.yml -f sample/bigquery_crypto_bitcoin

--- a/Makefile
+++ b/Makefile
@@ -140,14 +140,16 @@ check_license:
 # Manual smoke test against a real Azure SQL / Fabric Warehouse endpoint.
 # Output goes to dbdoc/ (gitignored), not sample/azuresql: that directory is
 # generated from the local SQL Server container by `doc` and verified by `test`.
+# $${VAR} defers expansion to the shell, so the secret never enters the recipe
+# text and is never re-scanned for expansion or command substitution.
 doc_azuresql: build
-	@TBLS_DSN="azuresql://$(AZURESQL_CLIENT_ID)@$(AZURESQL_TENANT_ID):$(AZURESQL_CLIENT_SECRET)@$(AZURESQL_HOST)/$(AZURESQL_DB)" TBLS_DOC_PATH=dbdoc/azuresql \
+	@TBLS_DSN="azuresql://$${AZURESQL_CLIENT_ID}@$${AZURESQL_TENANT_ID}:$${AZURESQL_CLIENT_SECRET}@$${AZURESQL_HOST}/$${AZURESQL_DB}" TBLS_DOC_PATH=dbdoc/azuresql \
 		$(TBLS) doc -c testdata/test_tbls_azuresql.yml
 
 # Regenerates and diffs, so a second read of the same warehouse must match the
 # first. Catches introspection order that is not pinned down, as in #830/#851.
 test_azuresql: doc_azuresql
-	@TBLS_DSN="azuresql://$(AZURESQL_CLIENT_ID)@$(AZURESQL_TENANT_ID):$(AZURESQL_CLIENT_SECRET)@$(AZURESQL_HOST)/$(AZURESQL_DB)" TBLS_DOC_PATH=dbdoc/azuresql \
+	@TBLS_DSN="azuresql://$${AZURESQL_CLIENT_ID}@$${AZURESQL_TENANT_ID}:$${AZURESQL_CLIENT_SECRET}@$${AZURESQL_HOST}/$${AZURESQL_DB}" TBLS_DOC_PATH=dbdoc/azuresql \
 		$(TBLS) diff -c testdata/test_tbls_azuresql.yml
 
 doc_bigquery: build

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ check_license:
 # text and is never re-scanned for expansion or command substitution.
 doc_azuresql: build
 	@TBLS_DSN="azuresql://$${AZURESQL_CLIENT_ID}@$${AZURESQL_TENANT_ID}:$${AZURESQL_CLIENT_SECRET}@$${AZURESQL_HOST}/$${AZURESQL_DB}" TBLS_DOC_PATH=dbdoc/azuresql \
-		$(TBLS) doc -c testdata/test_tbls_azuresql.yml
+		$(TBLS) doc -c testdata/test_tbls_azuresql.yml -f
 
 # Regenerates and diffs, so a second read of the same warehouse must match the
 # first. Catches introspection order that is not pinned down, as in #830/#851.


### PR DESCRIPTION
## Why

The two `azuresql` targets added in #838 have a problem each. They are in one PR because they edit the same two recipe lines.

**A live client secret is echoed and put on a command line.**

```make
doc_azuresql: build
	$(TBLS) doc "azuresql://$(AZURESQL_CLIENT_ID)@$(AZURESQL_TENANT_ID):$(AZURESQL_CLIENT_SECRET)@$(AZURESQL_HOST)/$(AZURESQL_DB)" ...
```

Neither recipe carries an `@` prefix, so make echoes the command before running it and `$(AZURESQL_CLIENT_SECRET)` is written to the terminal and to any CI log that invokes these targets. Because it is an argument rather than an environment value, it is also readable by any other user on the host through `ps`. Every other credential-bearing target here hands the credential over as a file (`creds=client_secrets.json` for `doc_bigquery` / `doc_spanner`), so these two are the only recipes that put a live cloud secret on a command line.

**`sample/azuresql` has two producers that overwrite each other.** `doc` (Makefile:56) generates it from the local SQL Server container at `ms://...@localhost:11433/azuresqldb`, and `test` (Makefile:83) diffs it from there; `doc_azuresql` generates the same directory from a real Azure endpoint. They cannot agree — the committed golden records the container (`"name": "azuresqldb"`, `Microsoft Azure SQL Edge ... (ARM64)`), and Fabric Warehouse would additionally drop the IDENTITY, CHECK, DEFAULT and index metadata the fixture relies on. Running `doc_azuresql` once leaves the tree dirty and breaks `make ci` for everyone.

`test_azuresql` is worse than dirty, it cannot pass at all: it diffs a real warehouse against goldens built from a different database.

## What

Pass the DSN through `TBLS_DSN` with an `@` prefix, and send the real-endpoint output to `dbdoc/` instead of `sample/azuresql`:

```make
doc_azuresql: build
	@TBLS_DSN="azuresql://$(AZURESQL_CLIENT_ID)@$(AZURESQL_TENANT_ID):$(AZURESQL_CLIENT_SECRET)@$(AZURESQL_HOST)/$(AZURESQL_DB)" \
		$(TBLS) doc -c testdata/test_tbls_azuresql.yml -f dbdoc/azuresql
```

`Config.LoadEnviron` already reads `TBLS_DSN`, and `Load` calls it after `LoadConfigFile`, so it takes precedence over `-c testdata/test_tbls_azuresql.yml` (which carries no `dsn:` of its own). Dropping the positional DSN leaves `tbls doc` with zero arguments and `tbls diff` with one, both already handled — `loadDocArgs` only consumes `args[0]` when present, and `diff`'s `case 1` treats an existing path as the document path and takes the DSN from the config.

`test_azuresql` now depends on `doc_azuresql` and diffs its output, so it checks that a second read of the same warehouse matches the first. Weaker than a golden diff, but meaningful, and it is the same introspection-order class of bug as #830 and #851.

## Notes for reviewers

**Two exposures needed two fixes.** `@` alone would have closed the log leak but left the secret in `ps`; moving it out of argv alone would have left make echoing the expanded assignment.

**The container stays the owner of `sample/azuresql`**, because that is what CI verifies and what the committed output actually came from. Committing a real Fabric golden would be the stronger option, but it needs an endpoint this repository does not have in CI.

`AZURESQL_*` is not referenced from any workflow under `.github/workflows/`, so these targets are run by hand and nothing in CI changes.

The remaining follow-ups from the same review are in #859 (the `STRING_AGG` loose ends) and #860 (`dsn.tls`, tests).