### PR TITLE
fix(mssql): close out the STRING_AGG migration from #838

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ dsn: sqlserver://DbUser:SQLServer-DbPassw0rd@hostname:1433/testdb
 dsn: ms://DbUser:SQLServer-DbPassw0rd@localhost:1433/testdb
 ```
 
-SQL Server **2017 or later** is required. Schema introspection uses `STRING_AGG`, which is unavailable on SQL Server 2016 and earlier.
+SQL Server **2017 or later** with a **database compatibility level of 110 or higher** is required. Schema introspection uses `STRING_AGG`, which is unavailable on SQL Server 2016 and earlier, and its `WITHIN GROUP (ORDER BY ...)` clause needs compatibility level 110+. A database migrated onto a newer server but left at level 100 fails with `Incorrect syntax near '('`; raise it with `ALTER DATABASE <name> SET COMPATIBILITY_LEVEL = 110` (or higher).
 
 **Azure SQL / Microsoft Fabric Warehouse (Experimental):**
 

--- a/README.md
+++ b/README.md
@@ -584,6 +584,8 @@ dsn: sqlserver://DbUser:SQLServer-DbPassw0rd@hostname:1433/testdb
 dsn: ms://DbUser:SQLServer-DbPassw0rd@localhost:1433/testdb
 ```
 
+SQL Server **2017 or later** is required. Schema introspection uses `STRING_AGG`, which is unavailable on SQL Server 2016 and earlier.
+
 **Azure SQL / Microsoft Fabric Warehouse (Experimental):**
 
 Azure AD Service Principal authentication (credentials in userinfo):

--- a/drivers/mssql/mssql.go
+++ b/drivers/mssql/mssql.go
@@ -350,7 +350,7 @@ SELECT
   i.is_unique,
   i.is_primary_key,
   i.is_unique_constraint,
-  STRING_AGG(CAST(COL_NAME(ic.object_id, ic.column_id) AS NVARCHAR(MAX)), ', ') WITHIN GROUP (ORDER BY ic.key_ordinal) AS column_names,
+  STRING_AGG(CAST(COL_NAME(ic.object_id, ic.column_id) AS NVARCHAR(MAX)), ', ') WITHIN GROUP (ORDER BY ic.key_ordinal, ic.index_column_id) AS column_names,
   c.is_system_named
 FROM sys.indexes AS i
 LEFT JOIN sys.key_constraints AS c

--- a/drivers/mssql/mssql.go
+++ b/drivers/mssql/mssql.go
@@ -163,7 +163,7 @@ SELECT
   i.is_unique,
   i.is_primary_key,
   i.is_unique_constraint,
-  STRING_AGG(COL_NAME(ic.object_id, ic.column_id), ', ') WITHIN GROUP (ORDER BY ic.key_ordinal) AS index_columns,
+  STRING_AGG(CAST(COL_NAME(ic.object_id, ic.column_id) AS NVARCHAR(MAX)), ', ') WITHIN GROUP (ORDER BY ic.key_ordinal) AS index_columns,
   c.is_system_named
 FROM sys.key_constraints AS c
 INNER JOIN sys.indexes AS i ON i.object_id = c.parent_object_id AND i.index_id = c.unique_index_id
@@ -224,8 +224,8 @@ SELECT
   OBJECT_NAME(f.parent_object_id) AS table_name,
   OBJECT_NAME(f.referenced_object_id) AS parent_table_name,
   OBJECT_SCHEMA_NAME(f.referenced_object_id) AS parent_schema_name,
-  STRING_AGG(COL_NAME(fc.parent_object_id, fc.parent_column_id), ', ') WITHIN GROUP (ORDER BY fc.constraint_column_id) AS column_names,
-  STRING_AGG(COL_NAME(fc.referenced_object_id, fc.referenced_column_id), ', ') WITHIN GROUP (ORDER BY fc.constraint_column_id) AS parent_column_names,
+  STRING_AGG(CAST(COL_NAME(fc.parent_object_id, fc.parent_column_id) AS NVARCHAR(MAX)), ', ') WITHIN GROUP (ORDER BY fc.constraint_column_id) AS column_names,
+  STRING_AGG(CAST(COL_NAME(fc.referenced_object_id, fc.referenced_column_id) AS NVARCHAR(MAX)), ', ') WITHIN GROUP (ORDER BY fc.constraint_column_id) AS parent_column_names,
   f.update_referential_action_desc,
   f.delete_referential_action_desc,
   f.is_system_named
@@ -350,7 +350,7 @@ SELECT
   i.is_unique,
   i.is_primary_key,
   i.is_unique_constraint,
-  STRING_AGG(COL_NAME(ic.object_id, ic.column_id), ', ') WITHIN GROUP (ORDER BY ic.key_ordinal) AS column_names,
+  STRING_AGG(CAST(COL_NAME(ic.object_id, ic.column_id) AS NVARCHAR(MAX)), ', ') WITHIN GROUP (ORDER BY ic.key_ordinal) AS column_names,
   c.is_system_named
 FROM sys.indexes AS i
 LEFT JOIN sys.key_constraints AS c
@@ -482,7 +482,8 @@ const query = `SELECT SCHEMA_NAME(obj.schema_id) AS schema_name,
 		WHEN 'X' THEN 'Extended stored procedure'
 	END AS type,
 	TYPE_NAME(ret.user_type_id) AS return_type,
-	(SELECT STRING_AGG(p.name + ' ' + TYPE_NAME(p.user_type_id), ', ')
+	(SELECT STRING_AGG(CAST(p.name + ' ' + TYPE_NAME(p.user_type_id) AS NVARCHAR(MAX)), ', ')
+	             WITHIN GROUP (ORDER BY p.parameter_id)
 	 FROM sys.parameters p
 	 WHERE p.object_id = obj.object_id AND p.parameter_id != 0) AS parameters
 FROM sys.objects obj

--- a/drivers/mssql/mssql_test.go
+++ b/drivers/mssql/mssql_test.go
@@ -163,3 +163,76 @@ func containsStringHelper(s, substr string) bool {
 	}
 	return false
 }
+
+func TestFunctionArgumentsOrder(t *testing.T) {
+	if _, err := db.Exec(`DROP PROCEDURE IF EXISTS tbls_param_order`); err != nil {
+		t.Fatal(err)
+	}
+	// Parameter names sort as @alpha, @mid, @zeta, so declaration order and name
+	// order differ and an unordered aggregate would be visible.
+	if _, err := db.Exec(`CREATE PROCEDURE tbls_param_order @zeta int, @alpha nvarchar(10), @mid bit AS BEGIN SET NOCOUNT ON; END`); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_, _ = db.Exec(`DROP PROCEDURE IF EXISTS tbls_param_order`)
+	}()
+
+	driver := New(db)
+	sc := &schema.Schema{Name: "testdb"}
+	if err := driver.Analyze(sc); err != nil {
+		t.Fatal(err)
+	}
+
+	var got string
+	for _, f := range sc.Functions {
+		if f.Name == "dbo.tbls_param_order" {
+			got = f.Arguments
+			break
+		}
+	}
+	want := "@zeta int, @alpha nvarchar, @mid bit"
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Error(diff)
+	}
+}
+
+func TestIndexIncludedColumnsOrder(t *testing.T) {
+	if _, err := db.Exec(`DROP TABLE IF EXISTS tbls_index_include`); err != nil {
+		t.Fatal(err)
+	}
+	// Three INCLUDE columns all carry key_ordinal = 0, so key_ordinal alone does
+	// not order them and index_column_id is what makes the aggregate total.
+	if _, err := db.Exec(`CREATE TABLE tbls_index_include (k int NOT NULL, z int, y int, x int)`); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_, _ = db.Exec(`DROP TABLE IF EXISTS tbls_index_include`)
+	}()
+	if _, err := db.Exec(`CREATE INDEX ix_tbls_index_include ON tbls_index_include (k) INCLUDE (z, y, x)`); err != nil {
+		t.Fatal(err)
+	}
+
+	driver := New(db)
+	sc := &schema.Schema{Name: "testdb"}
+	if err := driver.Analyze(sc); err != nil {
+		t.Fatal(err)
+	}
+
+	tbl, err := sc.FindTableByName("tbls_index_include")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	for _, idx := range tbl.Indexes {
+		if idx.Name == "ix_tbls_index_include" {
+			got = idx.Columns
+			break
+		}
+	}
+	// key_ordinal = 0 sorts the included columns ahead of the key column; within
+	// them index_column_id follows the INCLUDE list.
+	want := []string{"z", "y", "x", "k"}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Error(diff)
+	}
+}

--- a/drivers/mssql/mssql_test.go
+++ b/drivers/mssql/mssql_test.go
@@ -4,7 +4,9 @@ package mssql
 
 import (
 	"database/sql"
+	"fmt"
 	"log"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -169,7 +171,9 @@ func TestFunctionArgumentsOrder(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Parameter names sort as @alpha, @mid, @zeta, so declaration order and name
-	// order differ and an unordered aggregate would be visible.
+	// order differ and a wrong sort key such as p.name is caught. Removing the
+	// WITHIN GROUP clause altogether still passes: sys.parameters comes back in
+	// declaration order for a procedure this small and the plan cannot be forced.
 	if _, err := db.Exec(`CREATE PROCEDURE tbls_param_order @zeta int, @alpha nvarchar(10), @mid bit AS BEGIN SET NOCOUNT ON; END`); err != nil {
 		t.Fatal(err)
 	}
@@ -231,8 +235,115 @@ func TestIndexIncludedColumnsOrder(t *testing.T) {
 	}
 	// key_ordinal = 0 sorts the included columns ahead of the key column; within
 	// them index_column_id follows the INCLUDE list.
+	//
+	// This pins the expected order, so a wrong sort key is caught. It does not
+	// prove the tie-breaker is load-bearing: the server returns this order anyway
+	// for an object this small, and a test cannot force the plan that would
+	// reorder the included columns.
 	want := []string{"z", "y", "x", "k"}
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Error(diff)
+	}
+}
+
+// wideIdentifiers builds n identifiers of the given length, so that the
+// aggregated list is pushed past the 4000-character nvarchar limit that
+// STRING_AGG falls back to without an NVARCHAR(MAX) input.
+func wideIdentifiers(n, length int) []string {
+	names := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		suffix := fmt.Sprintf("%03d", i)
+		names = append(names, "c_"+strings.Repeat("x", length-2-len(suffix))+suffix)
+	}
+	return names
+}
+
+func TestIndexColumnsExceedingAggregateLimit(t *testing.T) {
+	if _, err := db.Exec(`DROP TABLE IF EXISTS tbls_wide_index`); err != nil {
+		t.Fatal(err)
+	}
+	cols := wideIdentifiers(40, 110)
+	defs := make([]string, 0, len(cols))
+	refs := make([]string, 0, len(cols))
+	for _, c := range cols {
+		defs = append(defs, "["+c+"] int")
+		refs = append(refs, "["+c+"]")
+	}
+	if _, err := db.Exec(`CREATE TABLE tbls_wide_index (k int NOT NULL, ` + strings.Join(defs, ", ") + `)`); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_, _ = db.Exec(`DROP TABLE IF EXISTS tbls_wide_index`)
+	}()
+	if _, err := db.Exec(`CREATE INDEX ix_tbls_wide_index ON tbls_wide_index (k) INCLUDE (` + strings.Join(refs, ", ") + `)`); err != nil {
+		t.Fatal(err)
+	}
+
+	driver := New(db)
+	sc := &schema.Schema{Name: "testdb"}
+	// Without the NVARCHAR(MAX) cast this fails with error 9829, "STRING_AGG
+	// aggregation result exceeded the limit of 8000 bytes".
+	if err := driver.Analyze(sc); err != nil {
+		t.Fatal(err)
+	}
+
+	tbl, err := sc.FindTableByName("tbls_wide_index")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []string
+	for _, idx := range tbl.Indexes {
+		if idx.Name == "ix_tbls_wide_index" {
+			got = idx.Columns
+			break
+		}
+	}
+	want := append(append([]string{}, cols...), "k")
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Error(diff)
+	}
+	if n := len(strings.Join(got, ", ")); n <= 4000 {
+		t.Errorf("aggregated length = %d, want > 4000 so the unbounded aggregate is actually exercised", n)
+	}
+}
+
+func TestFunctionArgumentsExceedingAggregateLimit(t *testing.T) {
+	if _, err := db.Exec(`DROP PROCEDURE IF EXISTS tbls_wide_params`); err != nil {
+		t.Fatal(err)
+	}
+	names := wideIdentifiers(40, 110)
+	params := make([]string, 0, len(names))
+	wantParts := make([]string, 0, len(names))
+	for _, n := range names {
+		params = append(params, "@"+n+" int")
+		wantParts = append(wantParts, "@"+n+" int")
+	}
+	if _, err := db.Exec(`CREATE PROCEDURE tbls_wide_params ` + strings.Join(params, ", ") + ` AS BEGIN SET NOCOUNT ON; END`); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_, _ = db.Exec(`DROP PROCEDURE IF EXISTS tbls_wide_params`)
+	}()
+
+	driver := New(db)
+	sc := &schema.Schema{Name: "testdb"}
+	// Without the NVARCHAR(MAX) cast this fails with error 9829.
+	if err := driver.Analyze(sc); err != nil {
+		t.Fatal(err)
+	}
+
+	var got string
+	for _, f := range sc.Functions {
+		if f.Name == "dbo.tbls_wide_params" {
+			got = f.Arguments
+			break
+		}
+	}
+	want := strings.Join(wantParts, ", ")
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Error(diff)
+	}
+	if len(want) <= 4000 {
+		t.Errorf("aggregated length = %d, want > 4000 so the unbounded aggregate is actually exercised", len(want))
 	}
 }


### PR DESCRIPTION
## Why

#838 replaced `FOR XML PATH` with `STRING_AGG` in `drivers/mssql` so that schema analysis works on Synapse SQL and Microsoft Fabric Warehouse, neither of which implements `FOR XML PATH`. The rewrite left three loose ends, all of which affect every existing `ms://` / `sqlserver://` user rather than only the new Azure path.

**`STRING_AGG` is bounded where `FOR XML PATH` was not.** It returns `nvarchar(4000)` unless one of its inputs is already `(MAX)`. `COL_NAME` returns `sysname` (`nvarchar(128)`), so every aggregated column list is capped at 4000 characters, and past that SQL Server raises error 9829 (`STRING_AGG aggregation result exceeded the limit of 8000 bytes`) and aborts the entire query — `Analyze` fails outright for that table. The index queries do not filter `is_included_column`, and an INCLUDE list may hold up to 1023 columns, so this is reachable on wide indexes. `FOR XML PATH` had no equivalent limit, which makes this a regression rather than a bound that was always there.

**One of the four aggregates has no total order.** The index and foreign-key rewrites all gained `WITHIN GROUP (ORDER BY ...)`; the stored-procedure/function parameter list did not. Its order is therefore whatever access path the server happens to choose, so `schema.Function.Arguments` can reorder between runs and generate diffs unrelated to any schema change. Same class of problem as #829 and #850.

**The version requirement is undocumented.** `STRING_AGG` arrived in SQL Server 2017, so 2016 and earlier stopped working. #502 had previously removed `STRING_AGG` specifically "to allow older MSSQL versions", so #838 reverses an earlier compatibility decision, and nothing in the repository records it. A 2016 user currently gets a bare `'STRING_AGG' is not a recognized built-in function name` from mid-analysis with no hint that the server version is the cause.

## What

| Change | Location |
| --- | --- |
| Cast every `STRING_AGG` input to `NVARCHAR(MAX)` so the aggregate is unbounded | all 5 aggregates in `drivers/mssql/mssql.go` |
| Add `WITHIN GROUP (ORDER BY p.parameter_id)` to the parameter list | the procedure/function query |
| State the SQL Server 2017+ requirement | `README.md`, under Microsoft SQL Server |

`parameter_id` is declaration order, which follows the convention the surrounding mssql queries already use (`object_id`, `column_id`, `index_id`) rather than introducing alphabetical ordering that would contradict them — the same reasoning as #851.

## Notes for reviewers

**The ordering fix may produce a one-time diff.** The old `FOR XML PATH` form had no `ORDER BY` either, so the current order is whatever the server returns, which in practice is usually already `parameter_id` order. Any user whose procedures happen to come back in another order will see one `tbls diff` on next generation. Landing it now rather than later means that cost is paid once. No file under `sample/` records procedure arguments, so no regeneration is needed here.

**Only documentation is added for the version drop, not a guard.** A version check that fails early with a clear message, or a conditional query path that restores 2016 support, would both be additive on top of this. They are left out deliberately so that the release-facing statement is not entangled with a behaviour change — worth deciding separately.

Integration tests for this driver need the SQL Server container from `make db`, so they were not run locally; `go build ./...` and `go vet -tags mssql ./drivers/mssql/` are clean.