### PR TITLE
fix: azuresql follow-ups from #838 (dsn.tls, tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,7 @@ Supported DSN formats and parameters:
 - Other supported `fedauth` modes include `ActiveDirectoryPassword`, `ActiveDirectoryMSI`, etc.
 
 See also: https://github.com/microsoft/go-mssqldb
+
 The `dsn.tls.ca` setting maps to `certificate` with `encrypt=true` and `trustservercertificate=false` (go-mssqldb always verifies the hostname when encryption is on). The certificate file must have a `.pem` or `.der` extension. An explicit `encrypt=strict` is kept. Client certificates (`cert`/`key`) are not supported by the driver.
 
 **Amazon DynamoDB:**

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -392,6 +392,13 @@ func TestMaskedDSN(t *testing.T) {
 			"bq://project-id/dataset-id?creds=/path/to/google_application_credentials.json",
 			"bq://project-id/dataset-id?creds=/path/to/google_application_credentials.json",
 		},
+		{
+			// The azuresql client secret sits in the userinfo password, so it is
+			// masked. The '@' separating client id from tenant id is normalized
+			// to %40 by url.String() and must survive.
+			"azuresql://client-id@tenant-id:client-secret@myworkspace.datawarehouse.fabric.microsoft.com/mydb",
+			"azuresql://client-id%40tenant-id:*****@myworkspace.datawarehouse.fabric.microsoft.com/mydb",
+		},
 	}
 
 	for _, tt := range tests {

--- a/datasource/azuresql.go
+++ b/datasource/azuresql.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/k1LoW/errors"
+	"github.com/k1LoW/tbls/config"
 	mssqlDriver "github.com/k1LoW/tbls/drivers/mssql"
 	"github.com/k1LoW/tbls/schema"
 	_ "github.com/microsoft/go-mssqldb/azuread" // registers "azuresql" driver
@@ -15,7 +16,7 @@ import (
 // prepareAzureSQLURL swaps the scheme to sqlserver:// (the only scheme
 // go-mssqldb/azuread's msdsn.Parse URL-parses) and sets default query params.
 // Returns the rewritten URL string and the database name.
-func prepareAzureSQLURL(urlstr string) (string, string, error) {
+func prepareAzureSQLURL(urlstr string, t *config.TLS) (string, string, error) {
 	u, err := url.Parse(urlstr)
 	if err != nil {
 		return "", "", err
@@ -39,6 +40,17 @@ func prepareAzureSQLURL(urlstr string) (string, string, error) {
 			q.Set("fedauth", "ActiveDirectoryDefault")
 		}
 	}
+	// azuread shares the sqlserver TLS parameters, so dsn.tls is applied through
+	// the same helper. It runs before the encrypt default below so that its
+	// conflict checks see the value the user actually wrote.
+	if t != nil {
+		if err := validateTLSOptions(*t); err != nil {
+			return "", "", err
+		}
+		if err := applySQLServerTLS(*t, q); err != nil {
+			return "", "", err
+		}
+	}
 	if q.Get("encrypt") == "" {
 		q.Set("encrypt", "true")
 	}
@@ -48,10 +60,10 @@ func prepareAzureSQLURL(urlstr string) (string, string, error) {
 	return u.String(), dbName, nil
 }
 
-func AnalyzeAzureSQL(urlstr string) (_ *schema.Schema, err error) {
+func AnalyzeAzureSQL(urlstr string, t *config.TLS) (_ *schema.Schema, err error) {
 	defer func() { err = errors.WithStack(err) }()
 
-	connURL, dbName, err := prepareAzureSQLURL(urlstr)
+	connURL, dbName, err := prepareAzureSQLURL(urlstr, t)
 	if err != nil {
 		return nil, err
 	}

--- a/datasource/azuresql.go
+++ b/datasource/azuresql.go
@@ -22,6 +22,11 @@ func prepareAzureSQLURL(urlstr string, t *config.TLS) (string, string, error) {
 		return "", "", err
 	}
 	q := u.Query()
+	// msdsn lowercases connection string keys, so `?Database=` and `?Encrypt=`
+	// have to be canonicalized before anything here reads or sets them.
+	if err := canonicalizeSQLServerKeys(q); err != nil {
+		return "", "", err
+	}
 
 	dbName := q.Get("database")
 	if dbName == "" && u.Path != "" && u.Path != "/" {

--- a/datasource/azuresql.go
+++ b/datasource/azuresql.go
@@ -60,10 +60,10 @@ func prepareAzureSQLURL(urlstr string, t *config.TLS) (string, string, error) {
 	return u.String(), dbName, nil
 }
 
-func AnalyzeAzureSQL(urlstr string, t *config.TLS) (_ *schema.Schema, err error) {
+func AnalyzeAzureSQL(dsn config.DSN) (_ *schema.Schema, err error) {
 	defer func() { err = errors.WithStack(err) }()
 
-	connURL, dbName, err := prepareAzureSQLURL(urlstr, t)
+	connURL, dbName, err := prepareAzureSQLURL(dsn.URL, dsn.TLS)
 	if err != nil {
 		return nil, err
 	}

--- a/datasource/azuresql_test.go
+++ b/datasource/azuresql_test.go
@@ -4,6 +4,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/k1LoW/tbls/config"
 )
 
 func TestPrepareAzureSQLURL(t *testing.T) {
@@ -17,6 +19,9 @@ func TestPrepareAzureSQLURL(t *testing.T) {
 		wantDB      string
 		wantUser    string
 		wantPass    string
+		tls         *config.TLS
+		wantCert    string
+		wantTrust   string
 	}{
 		{
 			name:    "no database param or path returns error",
@@ -116,11 +121,52 @@ func TestPrepareAzureSQLURL(t *testing.T) {
 			wantFedauth: "ActiveDirectoryDefault",
 			wantEncrypt: "true",
 		},
+		{
+			// dsn.tls must reach the connection, not be silently dropped.
+			name:        "dsn.tls.ca maps to certificate and disables trustservercertificate",
+			urlstr:      "azuresql://cid@tid:sec@myhost.example.com/mydb",
+			tls:         &config.TLS{CA: "/etc/ssl/azure.pem"},
+			wantScheme:  "sqlserver",
+			wantDB:      "mydb",
+			wantFedauth: "ActiveDirectoryServicePrincipal",
+			wantEncrypt: "true",
+			wantCert:    "/etc/ssl/azure.pem",
+			wantTrust:   "false",
+		},
+		{
+			name:        "dsn.tls keeps an explicit encrypt=strict",
+			urlstr:      "azuresql://cid@tid:sec@myhost.example.com/mydb?encrypt=strict",
+			tls:         &config.TLS{CA: "/etc/ssl/azure.pem"},
+			wantScheme:  "sqlserver",
+			wantDB:      "mydb",
+			wantFedauth: "ActiveDirectoryServicePrincipal",
+			wantEncrypt: "strict",
+			wantCert:    "/etc/ssl/azure.pem",
+			wantTrust:   "false",
+		},
+		{
+			name:    "dsn.tls conflicting with encrypt=disable returns error",
+			urlstr:  "azuresql://cid@tid:sec@myhost.example.com/mydb?encrypt=disable",
+			tls:     &config.TLS{CA: "/etc/ssl/azure.pem"},
+			wantErr: "dsn.tls conflicts with encrypt=disable",
+		},
+		{
+			name:    "dsn.tls client certificate is rejected",
+			urlstr:  "azuresql://cid@tid:sec@myhost.example.com/mydb",
+			tls:     &config.TLS{Cert: "/etc/ssl/c.pem", Key: "/etc/ssl/c.key"},
+			wantErr: "not supported for driver 'sqlserver'",
+		},
+		{
+			name:    "dsn.tls.cert without dsn.tls.key returns error",
+			urlstr:  "azuresql://cid@tid:sec@myhost.example.com/mydb",
+			tls:     &config.TLS{Cert: "/etc/ssl/c.pem"},
+			wantErr: "must be set together",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotURL, gotDB, err := prepareAzureSQLURL(tt.urlstr)
+			gotURL, gotDB, err := prepareAzureSQLURL(tt.urlstr, tt.tls)
 			if tt.wantErr != "" {
 				if err == nil {
 					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
@@ -166,14 +212,18 @@ func TestPrepareAzureSQLURL(t *testing.T) {
 				}
 			}
 
-			// Verify password with ';' is not raw in the URL string
-			if strings.Contains(tt.urlstr, "%3B") {
-				if strings.Contains(gotURL, ";") {
-					rawQuery := u.RawQuery
-					if strings.Contains(rawQuery, "=sec;ret") {
-						t.Error("password ';' leaked unencoded into query string — ADO injection possible")
-					}
-				}
+			if tt.wantCert != "" && q.Get("certificate") != tt.wantCert {
+				t.Errorf("certificate = %q, want %q", q.Get("certificate"), tt.wantCert)
+			}
+			if tt.wantTrust != "" && q.Get("trustservercertificate") != tt.wantTrust {
+				t.Errorf("trustservercertificate = %q, want %q", q.Get("trustservercertificate"), tt.wantTrust)
+			}
+
+			// msdsn splits ADO key=value connection strings on ';', so a ';' that
+			// reaches the query unencoded could inject extra options. RawQuery is
+			// the encoded form, so it must never contain one.
+			if strings.Contains(u.RawQuery, ";") {
+				t.Errorf("raw query contains an unencoded ';': %q", u.RawQuery)
 			}
 		})
 	}

--- a/datasource/azuresql_test.go
+++ b/datasource/azuresql_test.go
@@ -162,6 +162,44 @@ func TestPrepareAzureSQLURL(t *testing.T) {
 			tls:     &config.TLS{Cert: "/etc/ssl/c.pem"},
 			wantErr: "must be set together",
 		},
+		{
+			// msdsn lowercases keys and rejects two that collide once lowered, so
+			// an uppercase Encrypt must be seen here rather than duplicated.
+			name:        "uppercase Encrypt is honoured, not duplicated",
+			urlstr:      "azuresql://cid@tid:sec@myhost.example.com/mydb?Encrypt=strict",
+			wantScheme:  "sqlserver",
+			wantDB:      "mydb",
+			wantFedauth: "ActiveDirectoryServicePrincipal",
+			wantEncrypt: "strict",
+		},
+		{
+			name:        "uppercase Database is honoured",
+			urlstr:      "azuresql://cid@tid:sec@myhost.example.com?Database=mydb",
+			wantScheme:  "sqlserver",
+			wantDB:      "mydb",
+			wantFedauth: "ActiveDirectoryServicePrincipal",
+			wantEncrypt: "true",
+		},
+		{
+			name:        "uppercase FedAuth is not overwritten",
+			urlstr:      "azuresql://myhost.example.com/mydb?FedAuth=ActiveDirectoryMSI",
+			wantScheme:  "sqlserver",
+			wantDB:      "mydb",
+			wantFedauth: "ActiveDirectoryMSI",
+			wantEncrypt: "true",
+		},
+		{
+			// Uppercase forms must not slip past the dsn.tls conflict checks.
+			name:    "uppercase Encrypt=disable still conflicts with dsn.tls",
+			urlstr:  "azuresql://cid@tid:sec@myhost.example.com/mydb?Encrypt=disable",
+			tls:     &config.TLS{CA: "/etc/ssl/azure.pem"},
+			wantErr: "dsn.tls conflicts with encrypt=disable",
+		},
+		{
+			name:    "keys colliding only by case are rejected",
+			urlstr:  "azuresql://cid@tid:sec@myhost.example.com/mydb?Encrypt=strict&encrypt=true",
+			wantErr: "provided more than once",
+		},
 	}
 
 	for _, tt := range tests {

--- a/datasource/datasource.go
+++ b/datasource/datasource.go
@@ -81,7 +81,7 @@ func Analyze(dsn config.DSN) (_ *schema.Schema, err error) {
 		return AnalyzeDatabricks(urlstr)
 	}
 	if strings.HasPrefix(urlstr, "azuresql://") {
-		return AnalyzeAzureSQL(urlstr, dsn.TLS)
+		return AnalyzeAzureSQL(dsn)
 	}
 	s := &schema.Schema{}
 	u, err := dburl.Parse(urlstr)

--- a/datasource/datasource.go
+++ b/datasource/datasource.go
@@ -81,7 +81,7 @@ func Analyze(dsn config.DSN) (_ *schema.Schema, err error) {
 		return AnalyzeDatabricks(urlstr)
 	}
 	if strings.HasPrefix(urlstr, "azuresql://") {
-		return AnalyzeAzureSQL(urlstr)
+		return AnalyzeAzureSQL(urlstr, dsn.TLS)
 	}
 	s := &schema.Schema{}
 	u, err := dburl.Parse(urlstr)

--- a/datasource/ssl.go
+++ b/datasource/ssl.go
@@ -153,11 +153,38 @@ func applyPostgresTLS(t config.TLS, values url.Values) error {
 	return nil
 }
 
+// canonicalizeSQLServerKeys lowercases every query key, because go-mssqldb's
+// msdsn does the same before looking parameters up and then rejects two keys
+// that collide once lowercased. Without this a DSN written `?Encrypt=strict` is
+// invisible to Get("encrypt"), so the conflict checks below miss it and the
+// lowercase key this package adds turns into a duplicate the driver refuses.
+func canonicalizeSQLServerKeys(values url.Values) error {
+	keys := make([]string, 0, len(values))
+	for k := range values {
+		keys = append(keys, k)
+	}
+	for _, k := range keys {
+		lk := strings.ToLower(k)
+		if lk == k {
+			continue
+		}
+		if _, exists := values[lk]; exists {
+			return fmt.Errorf("connection string key %q provided more than once (keys are case-insensitive)", k)
+		}
+		values[lk] = values[k]
+		delete(values, k)
+	}
+	return nil
+}
+
 // applySQLServerTLS maps dsn.tls.ca to go-mssqldb's certificate parameter (the
 // file must have a .pem or .der extension). go-mssqldb performs full
 // verification (chain + hostname) when encryption is on and
 // trustservercertificate is false, so verify: identity needs no extra mapping.
 func applySQLServerTLS(t config.TLS, values url.Values) error {
+	if err := canonicalizeSQLServerKeys(values); err != nil {
+		return err
+	}
 	if t.Cert != "" {
 		return fmt.Errorf("dsn.tls.cert/dsn.tls.key are not supported for driver 'sqlserver'")
 	}

--- a/datasource/ssl.go
+++ b/datasource/ssl.go
@@ -23,17 +23,26 @@ var tlsSupportedDrivers = []string{"mysql", "postgres", "sqlserver"}
 
 const tlsVerifyIdentity = "identity"
 
+// validateTLSOptions checks the dsn.tls fields that every driver shares, so
+// that the driver-specific appliers only deal with their own parameters.
+func validateTLSOptions(t config.TLS) error {
+	if t.Verify != "" && t.Verify != tlsVerifyIdentity {
+		return fmt.Errorf("invalid dsn.tls.verify value: %s", t.Verify)
+	}
+	if (t.Cert == "") != (t.Key == "") {
+		return fmt.Errorf("dsn.tls.cert and dsn.tls.key must be set together")
+	}
+	return nil
+}
+
 // applyTLSConfig applies the dsn.tls configuration to the connection using
 // each driver's own TLS mechanism, rewriting the DSN query accordingly.
 // Empty values are treated as absent. Native TLS DSN parameters that
 // contradict the configuration (e.g. sslmode=disable, encrypt=disable,
 // trustservercertificate=true) are rejected instead of silently overridden.
 func applyTLSConfig(u *dburl.URL, t config.TLS) error {
-	if t.Verify != "" && t.Verify != tlsVerifyIdentity {
-		return fmt.Errorf("invalid dsn.tls.verify value: %s", t.Verify)
-	}
-	if (t.Cert == "") != (t.Key == "") {
-		return fmt.Errorf("dsn.tls.cert and dsn.tls.key must be set together")
+	if err := validateTLSOptions(t); err != nil {
+		return err
 	}
 
 	values := u.Query()

--- a/drivers/mssql/normalize_test.go
+++ b/drivers/mssql/normalize_test.go
@@ -1,0 +1,55 @@
+package mssql
+
+import "testing"
+
+func TestNormalizeViewDefinition(t *testing.T) {
+	tests := []struct {
+		name string
+		def  string
+		want string
+	}{
+		{
+			name: "definition without a trailing semicolon gains one",
+			def:  "CREATE VIEW v AS (\n  SELECT 1 AS a\n)",
+			want: "CREATE VIEW v AS (\n  SELECT 1 AS a\n);",
+		},
+		{
+			name: "definition already ending in a semicolon is unchanged",
+			def:  "CREATE VIEW v AS (\n  SELECT 1 AS a\n);",
+			want: "CREATE VIEW v AS (\n  SELECT 1 AS a\n);",
+		},
+		{
+			name: "trailing whitespace is trimmed before the semicolon is added",
+			def:  "CREATE VIEW v AS (SELECT 1 AS a)  \n\t\r\n",
+			want: "CREATE VIEW v AS (SELECT 1 AS a);",
+		},
+		{
+			name: "trailing whitespace after an existing semicolon is trimmed",
+			def:  "CREATE VIEW v AS (SELECT 1 AS a); \n",
+			want: "CREATE VIEW v AS (SELECT 1 AS a);",
+		},
+		{
+			name: "empty definition stays empty",
+			def:  "",
+			want: "",
+		},
+		{
+			name: "whitespace-only definition collapses to empty",
+			def:  " \n\t",
+			want: "",
+		},
+		{
+			name: "inner semicolons do not suppress the trailing one",
+			def:  "CREATE VIEW v AS (SELECT 1 AS a); -- note\nSELECT 2",
+			want: "CREATE VIEW v AS (SELECT 1 AS a); -- note\nSELECT 2;",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeViewDefinition(tt.def); got != tt.want {
+				t.Errorf("normalizeViewDefinition(%q) = %q, want %q", tt.def, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

Follow-ups to #838, collected into one PR because each is small. Every item is an independent commit, so any of them can be dropped without touching the others.

**`dsn.tls` is accepted for `azuresql://` and then ignored.** The support gate in `Analyze` resolves the scheme with `dburl.Parse`, which maps `azuresql` onto the `sqlserver` driver, and `sqlserver` is in `tlsSupportedDrivers` — so the gate passes. The `azuresql://` branch then returns before reaching `applyTLSConfig`, and a user-supplied CA is neither applied nor rejected. This is the only scheme where that happens: every other datasource with its own branch fails the gate and gets the explicit `dsn.tls is not supported` error that #847 added precisely so these parameters are never silently ignored.

**Two behaviours from #838 have no test.** `MaskedDSN` is the reason the DSN carries credentials in the userinfo at all, since that is what masks the client secret in the `tbls doc <dsn>` header printed by `tbls diff`. Nothing pins it down, and `MaskedDSN` returns the DSN untouched whenever the userinfo password is unset, so a change to the documented DSN shape could reintroduce the leak silently. `normalizeViewDefinition` is an unconditional output change for every existing SQL Server user, and neither `sample/mssql` nor `sample/azuresql` exercises either of its branches — the view definitions in both already end in `;`, so the goldens would not move if the function stopped working.

**The README renders two sections as one.** The Azure SQL block was inserted directly above the pre-existing `dsn.tls.ca` paragraph with no blank line between them.

**One assertion cannot fail.** In the semicolon test, `q.Encode()` always turns `;` into `%3B`, so `strings.Contains(gotURL, ";")` is never true and the ADO-injection case asserts nothing.

## What

| Commit | Change |
| --- | --- |
| `docs:` | blank line so the SQL Server TLS paragraph leaves the Azure SQL section |
| `fix:` | thread `dsn.TLS` into `AnalyzeAzureSQL`, apply it, and replace the dead assertion |
| `test:` | `MaskedDSN` case for the azuresql DSN, unit tests for `normalizeViewDefinition` |

`dsn.tls` is applied rather than rejected because azuread shares the sqlserver TLS parameters, so `applySQLServerTLS` already does the right thing and works on `url.Values`, which the azuresql path has. The shared field validation moves out of `applyTLSConfig` into `validateTLSOptions` so both callers run it and cannot drift apart. The applier runs before the `encrypt=true` default so its conflict checks see the value the user actually wrote, which is what lets `encrypt=strict` survive and `encrypt=disable` be rejected.

`normalizeViewDefinition`'s test goes in an untagged file so it runs in the ordinary `go test ./...`, unlike the rest of `drivers/mssql`, which needs the SQL Server container behind the `mssql` tag.

## Notes for reviewers

**Two items from the same review are deliberately not here.**

`sample/azuresql` is generated from the local SQL Server container by `doc:` (Makefile:56) and from a real Azure endpoint by `doc_azuresql` (Makefile:140), so the two targets overwrite each other and the committed golden records the container (`"name": "azuresqldb"`, `Microsoft Azure SQL Edge ... (ARM64)`). That fix lands in #858 instead, because it edits the same two recipe lines and would otherwise conflict.

`testdata/ddl/azuresql.sql` uses `IDENTITY`, `DEFAULT`, `CHECK`, enforced `PRIMARY KEY`/`UNIQUE`, `CREATE INDEX` and `sp_addextendedproperty`, none of which Fabric Warehouse implements, so the fixture cannot be applied to the platform it is named after. Confirming that needs a real endpoint, so it is left out rather than guessed at.

**`normalizeViewDefinition` still mishandles a definition ending in a `--` comment** — the appended `;` is swallowed by the comment. The tests document current behaviour and do not assert that case, since changing it is a behaviour change rather than added coverage.

`TestAnalyzeSchema` in `./datasource` fails on `main` as well (it needs a live database), so it is unrelated to this branch.