### PR TITLE
fix: stop the mssql driver tests from racing the datasource counts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,8 @@ db: db_sqlite # MySQL8 use ./testdata/ddl/mysql:/docker-entrypoint-initdb.d
 	usql maria://root:mypass@localhost:33309/testdb -f testdata/ddl/maria.sql
 	usql ms://SA:MSSQLServer-Passw0rd@localhost:11433/master -c "IF NOT EXISTS (SELECT * FROM sys.databases WHERE NAME = 'testdb') CREATE DATABASE testdb;"
 	usql ms://SA:MSSQLServer-Passw0rd@localhost:11433/testdb -f testdata/ddl/mssql.sql || true
+	usql ms://SA:MSSQLServer-Passw0rd@localhost:11433/master -c "IF NOT EXISTS (SELECT * FROM sys.databases WHERE NAME = 'mssqltestdb') CREATE DATABASE mssqltestdb;"
+	usql ms://SA:MSSQLServer-Passw0rd@localhost:11433/mssqltestdb -f testdata/ddl/mssql.sql || true
 	usql ms://SA:MSSQLServer-Passw0rd@localhost:11433/master -c "IF NOT EXISTS (SELECT * FROM sys.databases WHERE NAME = 'azuresqldb') CREATE DATABASE azuresqldb;"
 	usql ms://SA:MSSQLServer-Passw0rd@localhost:11433/azuresqldb -f testdata/ddl/azuresql.sql || true
 	./testdata/ddl/dynamodb.sh > /dev/null 2>&1

--- a/datasource/azuresql_test.go
+++ b/datasource/azuresql_test.go
@@ -64,7 +64,7 @@ func TestPrepareAzureSQLURL(t *testing.T) {
 			wantUser:    "cid@tid",
 			wantPass:    "sec",
 		},
-		{
+		{ // #nosec G101 -- fake credentials in a test URL
 			name:        "userinfo without tenant defaults to ActiveDirectoryServicePrincipal",
 			urlstr:      "azuresql://cid:sec@myhost.example.com/mydb",
 			wantScheme:  "sqlserver",

--- a/datasource/azuresql_test.go
+++ b/datasource/azuresql_test.go
@@ -64,7 +64,7 @@ func TestPrepareAzureSQLURL(t *testing.T) {
 			wantUser:    "cid@tid",
 			wantPass:    "sec",
 		},
-		{ // #nosec G101 -- fake credentials in a test URL
+		{ //nolint:gosec // fake credentials in a test URL
 			name:        "userinfo without tenant defaults to ActiveDirectoryServicePrincipal",
 			urlstr:      "azuresql://cid:sec@myhost.example.com/mydb",
 			wantScheme:  "sqlserver",

--- a/drivers/mssql/mssql_test.go
+++ b/drivers/mssql/mssql_test.go
@@ -21,9 +21,12 @@ var err error
 
 func TestMain(m *testing.M) {
 	s = &schema.Schema{
-		Name: "testdb",
+		Name: "mssqltestdb",
 	}
-	db, err = dburl.Open("ms://SA:MSSQLServer-Passw0rd@localhost:11433/instance?database=testdb")
+	// Not testdb: these tests create and drop objects, and `go test ./...` runs
+	// packages concurrently, so sharing testdb makes the table counts asserted by
+	// the datasource package flaky.
+	db, err = dburl.Open("ms://SA:MSSQLServer-Passw0rd@localhost:11433/instance?database=mssqltestdb")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -84,7 +87,7 @@ func TestTriggersOrder(t *testing.T) {
 	}
 
 	driver := New(db)
-	sc := &schema.Schema{Name: "testdb"}
+	sc := &schema.Schema{Name: "mssqltestdb"}
 	if err := driver.Analyze(sc); err != nil {
 		t.Fatal(err)
 	}
@@ -182,7 +185,7 @@ func TestFunctionArgumentsOrder(t *testing.T) {
 	}()
 
 	driver := New(db)
-	sc := &schema.Schema{Name: "testdb"}
+	sc := &schema.Schema{Name: "mssqltestdb"}
 	if err := driver.Analyze(sc); err != nil {
 		t.Fatal(err)
 	}
@@ -217,7 +220,7 @@ func TestIndexIncludedColumnsOrder(t *testing.T) {
 	}
 
 	driver := New(db)
-	sc := &schema.Schema{Name: "testdb"}
+	sc := &schema.Schema{Name: "mssqltestdb"}
 	if err := driver.Analyze(sc); err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +283,7 @@ func TestIndexColumnsExceedingAggregateLimit(t *testing.T) {
 	}
 
 	driver := New(db)
-	sc := &schema.Schema{Name: "testdb"}
+	sc := &schema.Schema{Name: "mssqltestdb"}
 	// Without the NVARCHAR(MAX) cast this fails with error 9829, "STRING_AGG
 	// aggregation result exceeded the limit of 8000 bytes".
 	if err := driver.Analyze(sc); err != nil {
@@ -326,7 +329,7 @@ func TestFunctionArgumentsExceedingAggregateLimit(t *testing.T) {
 	}()
 
 	driver := New(db)
-	sc := &schema.Schema{Name: "testdb"}
+	sc := &schema.Schema{Name: "mssqltestdb"}
 	// Without the NVARCHAR(MAX) cast this fails with error 9829.
 	if err := driver.Analyze(sc); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Why

`main` is red. The `build` workflow failed on 34faeed ([run 33483412704](https://github.com/k1LoW/tbls/actions/runs/33483412704)) with:

```
--- FAIL: TestAnalyzeTables (1.51s)
    datasource_test.go:70: {***localhost:11433/testdb map[] <nil>}: got 15
        want 14
```

**Two packages write to the same SQL Server database.** `datasource/datasource_test.go:24` asserts that `ms://...@localhost:11433/testdb` holds 14 tables, which is exactly what `testdata/ddl/mssql.sql` creates. `drivers/mssql` connects to that same `testdb` and creates and drops `tbls_trigger_order`, `tbls_index_include` and `tbls_wide_index` as part of its tests. `go test ./...` runs packages concurrently, so whenever one of those tables happens to exist at the moment datasource counts, the count is 15 and the assertion fails.

mysql and postgres are not exposed to this because datasource points at the older instances (33306, 55432) while their driver tests point at the newer ones (33308, 55413). SQL Server has a single container, so the two ended up sharing one database.

The collision has been latent since #851 added the first mutating test to `drivers/mssql`. What made it surface now is #859 and #860, which took it from one create/drop cycle to three and widened the window enough for the count to be observed mid-flight. Nothing in the failing merge itself (#861, an `actions/setup-go` bump) is related.

**A second, smaller thing.** golangci-lint has been printing `datasource/azuresql_test.go:67:3: G101: Potential hardcoded credentials: Password in URL` as an error annotation since ed481a2. It does not fail the job — the lint step reports through reviewdog — but it sits in the log of every run looking like a failure.

## What

| Commit | Change |
| --- | --- |
| `test(mssql):` | seed a second database, `mssqltestdb`, from the same DDL and point `drivers/mssql` at it |
| `fix:` | `#nosec G101` on the one azuresql DSN case shaped like `user:pass@host` |

`testdb` is left to datasource and to the `sample/mssql` goldens, which is what `make doc` / `make testdoc` generate and diff. Isolating the whole package rather than only the mutating tests costs one extra DDL apply in `make db` and means a mutating test added here later is safe without anyone having to remember why.

## Notes for reviewers

**Reproduced before and after, since CI cannot show this deterministically.** Polling the table count of `testdb` in a loop while `drivers/mssql` runs against SQL Server 2019 gives, on `main`:

```
MISMATCH tables = 15
   ... tbls_index_include
MISMATCH tables = 15
   ... tbls_wide_index
```

With this branch the same poll stays at 14 for the whole run, across three repetitions of the driver package, and `drivers/mssql` itself passes against `mssqltestdb`.

**Two alternatives were rejected.** Filtering `tbls_`-prefixed tables out of the datasource assertion turns the run green with a smaller diff, but it leaves the shared fixture writable and makes every future test in `drivers/mssql` depend on being named so the filter catches it. `go test -p 1` fixes the whole class at once, but `-p` also serialises the build, and the cost lands on every package rather than on the one pair that actually conflicts.

**`schema.Schema{Name: ...}` literals in the test file moved to `mssqltestdb` too.** The mssql driver never reads that field, so this changes no behaviour; it is renamed only so it does not name a database the tests no longer touch.

**The gosec commit can be dropped independently** if you would rather see the annotation than the directive — it shares no code with the first.