### PR TITLE
fix: exit non-zero when the root command rejects a flag or command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -100,8 +100,8 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 
 var subCmds = []string{}
 
-// errReported carries the exit status for a failure whose message has already been
-// written, so that Execute does not print it a second time.
+// errReported marks a failure whose message has already been written, so that Execute
+// exits non-zero without printing it a second time.
 var errReported = errors.New("reported")
 
 // rootCmd represents the base command when called without any subcommands.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -128,6 +128,12 @@ var rootCmd = &cobra.Command{
 
 		envs := os.Environ()
 		subCmd := args[0]
+		// The usage text advertises -h and --help, but DisableFlagParsing keeps cobra from
+		// handling them here, so they would otherwise be reported as unknown flags.
+		if subCmd == "-h" || subCmd == "--help" {
+			cmd.HelpFunc()(cmd, args)
+			return nil
+		}
 		bin, err := safeexec.LookPath(version.Name + "-" + subCmd)
 		if err != nil {
 			if strings.HasPrefix(subCmd, "-") {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -100,6 +100,10 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.{{e
 
 var subCmds = []string{}
 
+// errReported carries the exit status for a failure whose message has already been
+// written, so that Execute does not print it a second time.
+var errReported = errors.New("reported")
+
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
 	Use:                "tbls",
@@ -139,11 +143,11 @@ var rootCmd = &cobra.Command{
 			if strings.HasPrefix(subCmd, "-") {
 				cmd.PrintErrf("Error: unknown flag: '%s'\n", subCmd)
 				cmd.HelpFunc()(cmd, args)
-				return nil
+				return errReported
 			}
 			cmd.PrintErrf("Error: unknown command \"%s\" for \"%s\"\n", subCmd, version.Name)
 			cmd.PrintErrf("Run '%s --help' for usage.\n", version.Name)
-			return nil
+			return errReported
 		}
 		args = args[1:]
 
@@ -196,7 +200,9 @@ func Execute() {
 	}
 
 	if err := rootCmd.Execute(); err != nil {
-		printError(err)
+		if !errors.Is(err, errReported) {
+			printError(err)
+		}
 		os.Exit(1)
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -6,6 +6,32 @@ import (
 	"testing"
 )
 
+// An unrecognized flag or command has to be reported as an error, so that tbls exits
+// non-zero like it does for every other failure.
+func TestRootRunEReportsUnknownFlagAndCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"unknown flag", []string{"--nosuchflag"}},
+		{"unknown command", []string{"nosuchcommand"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			rootCmd.SetOut(buf)
+			rootCmd.SetErr(buf)
+			t.Cleanup(func() {
+				rootCmd.SetOut(nil)
+				rootCmd.SetErr(nil)
+			})
+			if err := rootCmd.RunE(rootCmd, tt.args); err == nil {
+				t.Error("got nil, want an error so that the exit status is not zero")
+			}
+		})
+	}
+}
+
 // -h and --help are advertised in the usage text, so they have to print help and
 // succeed rather than be reported as unknown flags.
 func TestRootRunEHandlesHelpFlags(t *testing.T) {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// -h and --help are advertised in the usage text, so they have to print help and
+// succeed rather than be reported as unknown flags.
+func TestRootRunEHandlesHelpFlags(t *testing.T) {
+	for _, flag := range []string{"-h", "--help"} {
+		t.Run(flag, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			rootCmd.SetOut(buf)
+			rootCmd.SetErr(buf)
+			t.Cleanup(func() {
+				rootCmd.SetOut(nil)
+				rootCmd.SetErr(nil)
+			})
+			if err := rootCmd.RunE(rootCmd, []string{flag}); err != nil {
+				t.Errorf("got %v, want nil", err)
+			}
+			if !strings.Contains(buf.String(), "Usage:") {
+				t.Errorf("help was not printed, got %q", buf.String())
+			}
+		})
+	}
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -18,6 +18,9 @@ func TestRootRunEReportsUnknownFlagAndCommand(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// RunE looks for a tbls-<subcmd> plugin on PATH and runs it when one exists, so
+			// pin PATH to an empty directory to keep the lookup off the host.
+			t.Setenv("PATH", t.TempDir())
 			buf := &bytes.Buffer{}
 			rootCmd.SetOut(buf)
 			rootCmd.SetErr(buf)

--- a/cmdutil/option.go
+++ b/cmdutil/option.go
@@ -16,11 +16,9 @@ L:
 	for i, a := range args {
 		for _, opt := range opts {
 			switch {
-			case a == opt:
-				if i+1 >= len(args) {
-					// The option has no value. Keep it in remains so that the caller can report it.
-					break
-				}
+			// A trailing option has no value. Leave it in remains so that the caller can
+			// report it, rather than reading past the end of args.
+			case a == opt && i+1 < len(args):
 				v = args[i+1]
 				skipNext = true
 				continue L


### PR DESCRIPTION
## Why

Follow-ups to #854, collected into one PR because they all live in the root command's hand-rolled argument handling. Each is an independent commit, so any of them can be dropped without touching the others.

**The root command reports a failure and then exits 0.**

```
$ tbls --nosuchflag; echo $?
Error: unknown flag: '--nosuchflag'
...
0
$ tbls nosuchcommand; echo $?
Error: unknown command "nosuchcommand" for "tbls"
Run 'tbls --help' for usage.
0
```

Everywhere else tbls exits 1. `Execute` calls `os.Exit(1)` for any error returned by `rootCmd.Execute()`, and `tbls doc --nosuchflag`, `tbls lint --nosuchflag` and `tbls doc nosucharg` all take that path. `cmd/root.go` is the only place that prints an error and then returns nil, so a CI step or a `&&` chain that mistypes a top-level flag or command carries on as if nothing had gone wrong.

#854 made this reachable one more way. `tbls --config` used to panic, which at least exited 2. It now lands on the unknown-flag branch, so the same typo went from a loud crash to a silent success.

**`-h` and `--help` are rejected as unknown flags.**

```
$ tbls -h
Error: unknown flag: '-h'
tbls is a CI-Friendly tool for document a database, written in Go.
...
Flags:
  -h, --help            help for tbls
```

The usage text lists `-h, --help` two screens below the line saying it is not a flag. `DisableFlagParsing: true` is set so that `-c`, `--when` and `--dsn` can be picked off before dispatching to a `tbls-<subcmd>` plugin, and cobra's built-in help flag goes with it. `tbls doc -h` is unaffected, since cobra parses subcommand flags normally.

This one has to land before the exit status change, otherwise `tbls --help` starts exiting 1.

**The trailing-option guard from #854 uses `break` inside a `switch`.**

That exits the switch rather than the `for _, opt := range opts` loop around it, which is what the fix needs, since the argument has to fall through to `remains`. It is correct and it reads as if it is not. Folding the bounds check into the case expression removes the question without changing behaviour.

## Note on output and exit codes

`errReported` carries only the exit status. The two branches already write their message and, for the flag case, the full usage text, so returning the error itself would print it a second time through `printError`. Output is byte-identical to today; only `$?` changes.

One exit code changes that is not a typo. `tbls --version` goes from 0 to 1. It has never been a supported flag (`tbls version` is the subcommand, and `--version` is not in the usage text), so this is the unknown-flag path doing its job, but it is the kind of thing someone has in a script. Adding `--version` as a real flag would be a separate change.