### PR TITLE
fix: tbls coverage misaligns table names containing East Asian characters

### DIFF
--- a/cmd/coverage.go
+++ b/cmd/coverage.go
@@ -92,11 +92,10 @@ var coverageCmd = &cobra.Command{
 				return errors.WithStack(err)
 			}
 		default:
-			fmtName := fmt.Sprintf("%%-%ds", maxWidth)
-			fmt.Printf("%s  %s\n", color.White(fmt.Sprintf(fmtName, "Table"), color.B), color.White("Coverage", color.B))
-			fmt.Printf("%s  %g%%\n", fmt.Sprintf(fmtName, "All tables"), cover.Coverage)
+			fmt.Printf("%s  %s\n", color.White(runewidth.FillRight("Table", maxWidth), color.B), color.White("Coverage", color.B))
+			fmt.Printf("%s  %g%%\n", runewidth.FillRight("All tables", maxWidth), cover.Coverage)
 			for _, t := range cover.Tables {
-				fmt.Printf(" %s %g%%\n", fmt.Sprintf(fmtName, t.Name), t.Coverage)
+				fmt.Printf(" %s %g%%\n", runewidth.FillRight(t.Name, maxWidth), t.Coverage)
 			}
 		}
 		return nil


### PR DESCRIPTION
## Why

`tbls coverage` misaligns the coverage column for any table whose name contains East Asian characters.

`maxWidth` is measured with `runewidth.StringWidth` (`cmd/coverage.go:78-83`), which counts display cells, and then applied with `fmt.Sprintf("%%-%ds", maxWidth)`, which counts runes. The two disagree for every rune wider than one cell, so a name like `ユーザー` is padded to `maxWidth` runes and rendered `maxWidth + 4` cells wide, pushing its figure out of the column:

```
$ tbls coverage json://schema.json
Table       Coverage
All tables  50%
 users      100%
 ユーザー       66.7%
 注文明細       0%
```

This is the same defect, in the same shape, that #856 fixed in `output/md.adjustTable`. It survived that PR because `coverage` reaches its padding through `fmt` directly rather than through the markdown table builder, so it is not on any code path the `--adjust-table` goldens cover. Grepping the repository for the measure-with-`StringWidth`/pad-with-`%-Ns` pair, this was the only other site.

## What

Pad with `runewidth.FillRight`, from the package already imported here to do the measuring, so measurement and padding share one notion of width. `fmtName` has no remaining caller and goes with it, which is why the diff moves three lines rather than one.

## Notes for reviewers

**ASCII output is byte-identical, and that was verified rather than reasoned.** `tbls coverage json://sample/mysql/schema.json` diffs empty across the change. `FillRight` and `%-Ns` agree whenever every rune occupies one cell, and `FillRight` matches `%-Ns` in returning the string untouched when it is already wider than the target, so nothing is newly truncated either.

**The padding stays outside `color.White` on purpose.** The header is still padded before the escape sequences are wrapped around it; padding the coloured string instead would count the escape bytes toward the width and break the alignment it is meant to produce.

**No test, deliberately.** The padding is inline in the cobra `RunE` closure, so there is nothing a test can call without first extracting a helper. #856 could add `TestAdjustTableEastAsianWidth` only because `adjustTable` was already a function. Extracting one here is a reasonable follow-up, but it is a refactor rather than the fix, so it is left for a separate decision — hence draft.

**Reproduction used a hand-written schema**, since no fixture under `testdata/` or `sample/` has a non-ASCII table *name* (the Japanese in `sample/dict` is dictionary headers and comments, not identifiers). That is also why no golden moves here.